### PR TITLE
feat: Faster string serialization by escaping in byte space.

### DIFF
--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -736,6 +736,7 @@ impl Buffer {
         self.state = State::Init;
     }
 
+    #[inline(always)]
     fn check_state(&self, op: Op) -> Result<()> {
         if (self.state as isize & op as isize) > 0 {
             return Ok(());
@@ -748,6 +749,7 @@ impl Buffer {
         Err(error)
     }
 
+    #[inline(always)]
     fn validate_max_name_len(&self, name: &str) -> Result<()> {
         if name.len() > self.max_name_len {
             return Err(error::fmt!(

--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -433,10 +433,15 @@ fn write_escaped_impl<Q, C>(
         unsafe { output_vec.set_len(index + additional) };
         for b in s.bytes() {
             if check_escape_fn(b) {
-                output_vec[index] = b'\\';
+                unsafe {
+                    *output_vec.get_unchecked_mut(index) = b'\\';
+                }
                 index += 1;
             }
-            output_vec[index] = b;
+
+            unsafe {
+                *output_vec.get_unchecked_mut(index) = b;
+            }
             index += 1;
         }
     }

--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -409,44 +409,51 @@ fn write_escaped_impl<Q, C>(
     output: &mut String,
     s: &str)
         where
-            C: Fn(char) -> bool,
-            Q: Fn(&mut String) -> ()
+            C: Fn(u8) -> bool,
+            Q: Fn(&mut Vec<u8>) -> ()
 {
+    let output_vec = unsafe { output.as_mut_vec() };
     let mut to_escape = 0usize;
-    for c in s.chars() {
-        if check_escape_fn(c) {
+    for b in s.bytes() {
+        if check_escape_fn(b) {
             to_escape += 1;
         }
     }
 
-    quoting_fn(output);
+    quoting_fn(output_vec);
 
     if to_escape == 0 {
-        output.push_str(s);
+        // output.push_str(s);
+        output_vec.extend_from_slice(s.as_bytes());
     }
     else {
-        output.reserve(s.len() + to_escape);
-        for c in s.chars() {
-            if check_escape_fn(c) {
-                output.push('\\');
+        let additional = s.len() + to_escape;
+        output_vec.reserve(additional);
+        let mut index = output_vec.len();
+        unsafe { output_vec.set_len(index + additional) };
+        for b in s.bytes() {
+            if check_escape_fn(b) {
+                output_vec[index] = b'\\';
+                index += 1;
             }
-            output.push(c);
+            output_vec[index] = b;
+            index += 1;
         }
     }
 
-    quoting_fn(output);
+    quoting_fn(output_vec);
 }
 
-fn must_escape_unquoted(c: char) -> bool {
+fn must_escape_unquoted(c: u8) -> bool {
     match c {
-        ' ' | ',' | '=' | '\n' | '\r' | '\\' => true,
+        b' ' | b',' | b'=' | b'\n' | b'\r' | b'\\' => true,
         _ => false
     }
 }
 
-fn must_escape_quoted(c: char) -> bool {
+fn must_escape_quoted(c: u8) -> bool {
     match c {
-        '\n' | '\r' | '"' | '\\' => true,
+        b'\n' | b'\r' | b'"' | b'\\' => true,
         _ => false
     }
 }
@@ -462,7 +469,7 @@ fn write_escaped_unquoted(output: &mut String, s: &str) {
 fn write_escaped_quoted(output: &mut String, s: &str) {
     write_escaped_impl(
         must_escape_quoted,
-        |output| output.push('"'),
+        |output| output.push(b'"'),
         output,
         s)
 }


### PR DESCRIPTION
During linux `perf` profiling of the python client, I've noticed that the `write_escaped_unquoted` function was on the hot path.

![profile_graph (1)](https://user-images.githubusercontent.com/1499096/204813453-563552c9-0b1e-4f76-b47d-737e6f36ca03.svg)

This PR improves its performance by around ~31%. 

It does so by using unsafe APIs for manipulating strings as vectors: Character escaping is done as bytes rather than chars.

We also get some extra speed by avoiding a branch in the escaping loop by unsafely setting the vector length and setting its contents rather than calling `.push` repeatedly.

We got an extra bit of performance by inlining two functions that get called repeatedly.

Profiling code:

```python
    def test_string_escaping_10m(self):
        count = 10_000_000
        slist = [f's={i:09}==abc \\' for i in range(count)]
        series = pd.Series(slist, dtype='string[pyarrow]')
        df = pd.DataFrame({
            'col1': series,
            'col2': series,
            'col3': series,
            'col4': series,
            'col5': series,
            'col6': series})
        
        buf = qi.Buffer()

        # Warm up and pre-size buffer
        buf.pandas(df, table_name='tbl1', symbols=True)
        buf.clear()

        # Run
        t0 = time.monotonic()
        buf.pandas(df, table_name='tbl1', symbols=True)
        t1 = time.monotonic()
        print(f'Time: {t1 - t0}, size: {len(buf)}')
```

Perf difference:
* With the old code, three sample runs took: 4.12s, 4.01s, 4.07s (avg: 4.06s).
* With the code in this PR, three sample runs took: 2.74s, 2.79s, 2.83s (avg: 2.78s).


