### PR TITLE
feat: Support for using OS certs in Rust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,9 @@ if(APPLE)
     target_link_libraries(
         questdb_client
         INTERFACE "-framework Security")
+    target_link_libraries(
+        questdb_client
+        INTERFACE "-framework CoreFoundation")
 endif()
 
 function(set_compile_flags TARGET_NAME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,10 @@ if(WIN32)
         DEFINE_SYMBOL "LINESENDER_DYN_LIB")
     target_link_libraries(
         questdb_client-shared
-        INTERFACE wsock32 ws2_32 ntdll crypt32)
+        INTERFACE wsock32 ws2_32 ntdll crypt32 Secur32)
     target_link_libraries(
         questdb_client-static
-        INTERFACE wsock32 ws2_32 ntdll crypt32)
+        INTERFACE wsock32 ws2_32 ntdll crypt32 Secur32)
 endif(WIN32)
 if(APPLE)
     target_link_libraries(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,10 @@ if(WIN32)
         DEFINE_SYMBOL "LINESENDER_DYN_LIB")
     target_link_libraries(
         questdb_client-shared
-        INTERFACE wsock32 ws2_32 ntdll crypt32 Secur32)
+        INTERFACE wsock32 ws2_32 ntdll crypt32 Secur32 Ncrypt)
     target_link_libraries(
         questdb_client-static
-        INTERFACE wsock32 ws2_32 ntdll crypt32 Secur32)
+        INTERFACE wsock32 ws2_32 ntdll crypt32 Secur32 Ncrypt)
 endif(WIN32)
 if(APPLE)
     target_link_libraries(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,10 @@ if(WIN32)
         DEFINE_SYMBOL "LINESENDER_DYN_LIB")
     target_link_libraries(
         questdb_client-shared
-        INTERFACE wsock32 ws2_32 ntdll)
+        INTERFACE wsock32 ws2_32 ntdll crypt32)
     target_link_libraries(
         questdb_client-static
-        INTERFACE wsock32 ws2_32 ntdll)
+        INTERFACE wsock32 ws2_32 ntdll crypt32)
 endif(WIN32)
 if(APPLE)
     target_link_libraries(

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[workspace]
+resolver = "2"
+
+members = [
+    "questdb-rs",
+    "questdb-rs-ffi",
+    "system_test/tls_proxy"
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,0 @@
-[workspace]
-resolver = "2"
-
-members = [
-    "questdb-rs",
-    "questdb-rs-ffi",
-    "system_test/tls_proxy"
-]

--- a/cpp_test/test_line_sender.cpp
+++ b/cpp_test/test_line_sender.cpp
@@ -548,6 +548,15 @@ TEST_CASE("Bad CA path")
     }
 }
 
+TEST_CASE("os certs")
+{
+    // We're just checking these APIs don't throw.
+    questdb::ingress::test::mock_server server;
+    questdb::ingress::opts opts{"localhost", server.port()};
+    opts.tls_os_roots();
+    opts.tls_webpki_and_os_roots();
+}
+
 TEST_CASE("Opts copy ctor, assignment and move testing.")
 {
     {

--- a/doc/SECURITY.md
+++ b/doc/SECURITY.md
@@ -15,14 +15,24 @@ Authentication can be used independently of TLS encryption.
 
 ## TLS Encryption
 
-As of writing, whilst QuestDB itself can't be configured to support TLS natively
-it is recommended that you use [HAProxy](http://www.haproxy.org/) or other
+As of writing, only QuestDB Enterprise can be configured to support TLS natively.
+If you're using the open source edition, you can still use TLS encryption by setting
+up [HAProxy](http://www.haproxy.org/) or other proxy
 to secure the connection for any public-facing servers.
 
 TLS can be used independently and provides no authentication itself.
 
 The `tls_certs` directory of this project contains tests certificates, its
-[README](../tls_certs/README.md) page describes generating your own certs.
+[README](../tls_certs/README.md) page describes generating your own test certs.
+
+A few important technical details on TLS:
+  * The libraries use the `rustls` Rust crate for TLS support.
+  * They also, by default, use the `webpki_roots` Rust crate for root certificate verification
+    which require no OS-specific configuration.
+  * Alternatively, If you want to use your operating system's root certificates,
+    you can do so calling the `tls_os_roots` method when building the "sender" object.
+    The latter is especially desireable in corporate environments where the certificates
+    are managed centrally.
 
 For API usage:
 * Rust: `SenderBuilder`'s [`auth`](https://docs.rs/questdb-rs/3.0.0/questdb/ingress/struct.SenderBuilder.html#method.auth)

--- a/examples/line_sender_c_example_auth_tls.c
+++ b/examples/line_sender_c_example_auth_tls.c
@@ -24,6 +24,9 @@ static bool example(const char* host, const char* port)
     // Enable TLS to accept connections using common trusted CAs.
     line_sender_opts_tls(opts);
 
+    //// Alternatively, to use the OS-provided root certificates:
+    // line_sender_opts_tls_os_roots(opts);
+
     // Use `QDB_UTF_8_FROM_STR_OR` to init from `const char*`.
     line_sender_utf8 key_id = QDB_UTF8_LITERAL("testUser1");
     line_sender_utf8 priv_key = QDB_UTF8_LITERAL(

--- a/examples/line_sender_cpp_example_auth_tls.cpp
+++ b/examples/line_sender_cpp_example_auth_tls.cpp
@@ -15,6 +15,9 @@ static bool example(
         // Enable TLS to accept connections using common trusted CAs.
         opts.tls();
 
+        //// Alternatively, to use the OS-provided root certificates:
+        // opts.tls_os_roots(opts);
+
         // Follow our authentication documentation to generate your own keys:
         // https://questdb.io/docs/reference/api/ilp/authenticate
         opts.auth(

--- a/include/questdb/ingress/line_sender.h
+++ b/include/questdb/ingress/line_sender.h
@@ -563,7 +563,7 @@ void line_sender_opts_tls(line_sender_opts* opts);
  * Enable full connection encryption via TLS, using OS-provided certificate roots.
  */
 LINESENDER_API
-void line_sender_opts_tls_os_certs(line_sender_opts* opts);
+void line_sender_opts_tls_os_roots(line_sender_opts* opts);
 
 /*
  * Enable full connection encryption via TLS, accepting certificates signed by either
@@ -571,7 +571,7 @@ void line_sender_opts_tls_os_certs(line_sender_opts* opts);
  * the "webpki-roots" Rust crate.
  */
 LINESENDER_API
-void line_sender_opts_tls_webpki_and_os_certs(line_sender_opts* opts);
+void line_sender_opts_tls_webpki_and_os_roots(line_sender_opts* opts);
 
 /**
  * Enable full connection encryption via TLS.

--- a/include/questdb/ingress/line_sender.h
+++ b/include/questdb/ingress/line_sender.h
@@ -560,6 +560,20 @@ LINESENDER_API
 void line_sender_opts_tls(line_sender_opts* opts);
 
 /**
+ * Enable full connection encryption via TLS, using OS-provided certificate roots.
+ */
+LINESENDER_API
+void line_sender_opts_tls_os_certs(line_sender_opts* opts);
+
+/*
+ * Enable full connection encryption via TLS, accepting certificates signed by either
+ * the OS-provided certificate roots or well-known certificate authorities as per
+ * the "webpki-roots" Rust crate.
+ */
+LINESENDER_API
+void line_sender_opts_tls_webpki_and_os_certs(line_sender_opts* opts);
+
+/**
  * Enable full connection encryption via TLS.
  * The connection will accept certificates by the specified certificate
  * authority file.

--- a/include/questdb/ingress/line_sender.hpp
+++ b/include/questdb/ingress/line_sender.hpp
@@ -743,6 +743,26 @@ namespace questdb::ingress
                 return *this;
             }
 
+            /*
+             * Enable full connection encryption via TLS, using OS-provided certificate roots.
+             */
+            opts& tls_os_certs() noexcept
+            {
+                ::line_sender_opts_tls_os_certs(_impl);
+                return *this;
+            }
+
+            /*
+             * Enable full connection encryption via TLS, accepting certificates signed by either
+             * the OS-provided certificate roots or well-known certificate authorities as per
+             * the "webpki-roots" Rust crate.
+             */
+            opts& tls_webpki_and_os_certs() noexcept
+            {
+                ::line_sender_opts_tls_webpki_and_os_certs(_impl);
+                return *this;
+            }
+
             /**
              * Enable full connection encryption via TLS.
              * The connection will accept certificates by the specified certificate

--- a/include/questdb/ingress/line_sender.hpp
+++ b/include/questdb/ingress/line_sender.hpp
@@ -746,9 +746,9 @@ namespace questdb::ingress
             /*
              * Enable full connection encryption via TLS, using OS-provided certificate roots.
              */
-            opts& tls_os_certs() noexcept
+            opts& tls_os_roots() noexcept
             {
-                ::line_sender_opts_tls_os_certs(_impl);
+                ::line_sender_opts_tls_os_roots(_impl);
                 return *this;
             }
 
@@ -757,9 +757,9 @@ namespace questdb::ingress
              * the OS-provided certificate roots or well-known certificate authorities as per
              * the "webpki-roots" Rust crate.
              */
-            opts& tls_webpki_and_os_certs() noexcept
+            opts& tls_webpki_and_os_roots() noexcept
             {
-                ::line_sender_opts_tls_webpki_and_os_certs(_impl);
+                ::line_sender_opts_tls_webpki_and_os_roots(_impl);
                 return *this;
             }
 

--- a/questdb-rs-ffi/Cargo.lock
+++ b/questdb-rs-ffi/Cargo.lock
@@ -72,6 +72,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
 name = "dns-lookup"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +125,17 @@ name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "getrandom"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "hashbrown"
@@ -155,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "linux-raw-sys"
@@ -178,6 +205,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,8 +228,9 @@ dependencies = [
  "indoc",
  "itoa",
  "libc",
- "ring",
+ "ring 0.17.5",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "ryu",
  "serde",
@@ -243,10 +277,24 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -269,9 +317,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
- "ring",
+ "ring 0.16.20",
  "rustls-webpki",
  "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -289,8 +349,8 @@ version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -300,13 +360,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "schannel"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -364,6 +456,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "syn"
@@ -426,6 +524,18 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/questdb-rs-ffi/Cargo.toml
+++ b/questdb-rs-ffi/Cargo.toml
@@ -9,7 +9,7 @@ name = "questdb_client"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-questdb-rs = { path = "../questdb-rs", features = ["insecure-skip-verify"] }
+questdb-rs = { path = "../questdb-rs", features = ["insecure-skip-verify", "tls-native-certs"] }
 libc = "0.2"
 
 [build-dependencies]

--- a/questdb-rs-ffi/src/lib.rs
+++ b/questdb-rs-ffi/src/lib.rs
@@ -478,7 +478,7 @@ pub unsafe extern "C" fn line_sender_opts_tls(opts: *mut line_sender_opts) {
 
 /// Enable full connection encryption via TLS, using OS-provided certificate roots.
 #[no_mangle]
-pub unsafe extern "C" fn line_sender_opts_tls_os_certs(opts: *mut line_sender_opts) {
+pub unsafe extern "C" fn line_sender_opts_tls_os_roots(opts: *mut line_sender_opts) {
     upd_opts!(opts, tls, Tls::Enabled(CertificateAuthority::OsRoots));
 }
 
@@ -486,7 +486,7 @@ pub unsafe extern "C" fn line_sender_opts_tls_os_certs(opts: *mut line_sender_op
 /// the OS-provided certificate roots or well-known certificate authorities as per
 /// the "webpki-roots" Rust crate.
 #[no_mangle]
-pub unsafe extern "C" fn line_sender_opts_tls_webpki_and_os_certs(opts: *mut line_sender_opts) {
+pub unsafe extern "C" fn line_sender_opts_tls_webpki_and_os_roots(opts: *mut line_sender_opts) {
     upd_opts!(
         opts,
         tls,

--- a/questdb-rs-ffi/src/lib.rs
+++ b/questdb-rs-ffi/src/lib.rs
@@ -487,7 +487,11 @@ pub unsafe extern "C" fn line_sender_opts_tls_os_certs(opts: *mut line_sender_op
 /// the "webpki-roots" Rust crate.
 #[no_mangle]
 pub unsafe extern "C" fn line_sender_opts_tls_webpki_and_os_certs(opts: *mut line_sender_opts) {
-    upd_opts!(opts, tls, Tls::Enabled(CertificateAuthority::WebpkiAndOsRoots));
+    upd_opts!(
+        opts,
+        tls,
+        Tls::Enabled(CertificateAuthority::WebpkiAndOsRoots)
+    );
 }
 
 /// Enable full connection encryption via TLS.

--- a/questdb-rs-ffi/src/lib.rs
+++ b/questdb-rs-ffi/src/lib.rs
@@ -476,6 +476,20 @@ pub unsafe extern "C" fn line_sender_opts_tls(opts: *mut line_sender_opts) {
     upd_opts!(opts, tls, Tls::Enabled(CertificateAuthority::WebpkiRoots));
 }
 
+/// Enable full connection encryption via TLS, using OS-provided certificate roots.
+#[no_mangle]
+pub unsafe extern "C" fn line_sender_opts_tls_os_certs(opts: *mut line_sender_opts) {
+    upd_opts!(opts, tls, Tls::Enabled(CertificateAuthority::OsRoots));
+}
+
+/// Enable full connection encryption via TLS, accepting certificates signed by either
+/// the OS-provided certificate roots or well-known certificate authorities as per
+/// the "webpki-roots" Rust crate.
+#[no_mangle]
+pub unsafe extern "C" fn line_sender_opts_tls_webpki_and_os_certs(opts: *mut line_sender_opts) {
+    upd_opts!(opts, tls, Tls::Enabled(CertificateAuthority::WebpkiAndOsRoots));
+}
+
 /// Enable full connection encryption via TLS.
 /// The connection will accept certificates by the specified certificate
 /// authority file.

--- a/questdb-rs/Cargo.toml
+++ b/questdb-rs/Cargo.toml
@@ -22,7 +22,7 @@ base64ct = { version = "1.6.0", features = ["alloc"] }
 ring = "0.17.5"
 rustls = "0.21.7"
 rustls-pemfile = "1.0.3"
-webpki-roots = "0.25.2"
+webpki-roots = { version = "0.25.2", optional = true }
 ryu = "1.0.15"
 itoa = "1.0.9"
 chrono = { version = "0.4.30", optional = true }
@@ -42,10 +42,13 @@ mio = { version = "0.8.8", features = ["os-poll", "net"] }
 chrono = "0.4.30"
 
 [features]
-default = ["tls-native-certs"]
+default = ["tls-webpki-certs"]
 
-# Use OS-provided root TLS certificates
+# Allow use OS-provided root TLS certificates
 tls-native-certs = ["dep:rustls-native-certs"]
+
+# Allow use of the `webpki-roots` crate to validate TLS certificates.
+tls-webpki-certs = ["dep:webpki-roots"]
 
 # Allow skipping verification of insecure certificates.
 insecure-skip-verify = ["rustls/dangerous_configuration"]

--- a/questdb-rs/Cargo.toml
+++ b/questdb-rs/Cargo.toml
@@ -19,13 +19,14 @@ libc = "0.2"
 socket2 = "0.5.4"
 dns-lookup = "2.0.2"
 base64ct = { version = "1.6.0", features = ["alloc"] }
-ring = "0.16.20"
+ring = "0.17.5"
 rustls = "0.21.7"
 rustls-pemfile = "1.0.3"
 webpki-roots = "0.25.2"
 ryu = "1.0.15"
 itoa = "1.0.9"
 chrono = { version = "0.4.30", optional = true }
+rustls-native-certs = { version = "0.6.3", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["ws2def"] }
@@ -41,6 +42,11 @@ mio = { version = "0.8.8", features = ["os-poll", "net"] }
 chrono = "0.4.30"
 
 [features]
+default = ["tls-native-certs"]
+
+# Use OS-provided root TLS certificates
+tls-native-certs = ["dep:rustls-native-certs"]
+
 # Allow skipping verification of insecure certificates.
 insecure-skip-verify = ["rustls/dangerous_configuration"]
 

--- a/questdb-rs/README.md
+++ b/questdb-rs/README.md
@@ -23,7 +23,8 @@ use questdb::{
     ingress::{
         Sender,
         Buffer,
-        SenderBuilder}};
+        SenderBuilder,
+        TimestampNanos}};
 
 fn main() -> Result<()> {
    let mut sender = SenderBuilder::new("localhost", 9009).connect()?;
@@ -33,7 +34,7 @@ fn main() -> Result<()> {
        .symbol("id", "toronto1")?
        .column_f64("temperature", 20.0)?
        .column_i64("humidity", 50)?
-       .at_now()?;
+       .at(TimestampNanos::now())?;
    sender.flush(&mut buffer)?;
    Ok(())
 }

--- a/questdb-rs/examples/auth.rs
+++ b/questdb-rs/examples/auth.rs
@@ -16,8 +16,8 @@ fn main() -> Result<()> {
             "testUser1",                                   // kid
             "5UjEMuA0Pj5pjK8a-fa24dyIf-Es5mYny3oE_Wmus48", // d
             "fLKYEaoEb9lrn3nkwLDA-M_xnuFOdSt9y0Z7_vWSHLU", // x
-            "Dt5tbS1dEDMSYfym3fgMv0B99szno-dFc1rYF9t0aac",
-        ) // y
+            "Dt5tbS1dEDMSYfym3fgMv0B99szno-dFc1rYF9t0aac", // y
+        )
         .connect()?;
     let mut buffer = Buffer::new();
     let designated_timestamp =

--- a/questdb-rs/examples/auth_tls.rs
+++ b/questdb-rs/examples/auth_tls.rs
@@ -16,9 +16,10 @@ fn main() -> Result<()> {
             "testUser1",                                   // kid
             "5UjEMuA0Pj5pjK8a-fa24dyIf-Es5mYny3oE_Wmus48", // d
             "fLKYEaoEb9lrn3nkwLDA-M_xnuFOdSt9y0Z7_vWSHLU", // x
-            "Dt5tbS1dEDMSYfym3fgMv0B99szno-dFc1rYF9t0aac",
-        ) // y
+            "Dt5tbS1dEDMSYfym3fgMv0B99szno-dFc1rYF9t0aac", // y
+        )
         .tls(Tls::Enabled(CertificateAuthority::WebpkiRoots))
+        // Alternatively: .tls(Tls::Enabled(CertificateAuthority::OsRoots))
         .connect()?;
     let mut buffer = Buffer::new();
     let designated_timestamp =

--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -1380,7 +1380,7 @@ fn configure_tls(tls: &Tls) -> Result<Option<Arc<rustls::ClientConfig>>> {
             CertificateAuthority::OsRoots => {
                 add_os_roots(&mut root_store)?;
             }
-            #[cfg(feature = "tls-native-certs")]
+            #[cfg(all(feature = "tls-webpki-certs", feature = "tls-native-certs"))]
             CertificateAuthority::WebpkiAndOsRoots => {
                 add_webpki_roots(&mut root_store);
                 add_os_roots(&mut root_store)?;

--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -197,9 +197,7 @@ use std::sync::Arc;
 use base64ct::{Base64, Base64UrlUnpadded, Encoding};
 use ring::rand::SystemRandom;
 use ring::signature::{EcdsaKeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
-use rustls::{
-    Certificate, ClientConnection, OwnedTrustAnchor, RootCertStore, ServerName, StreamOwned,
-};
+use rustls::{ClientConnection, OwnedTrustAnchor, RootCertStore, ServerName, StreamOwned};
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 
 #[derive(Debug, Copy, Clone)]
@@ -1356,9 +1354,11 @@ fn add_os_roots(root_store: &mut RootCertStore) -> Result<()> {
         error::fmt!(TlsError, "Could not OS native TLS certificates: {}", io_err)
     })?;
     for cert in os_certs {
-        root_store.add(&Certificate(cert.0)).map_err(|rustls_err| {
-            error::fmt!(TlsError, "Could not load OS certificate: {}", rustls_err)
-        })?;
+        root_store
+            .add(&rustls::Certificate(cert.0))
+            .map_err(|rustls_err| {
+                error::fmt!(TlsError, "Could not load OS certificate: {}", rustls_err)
+            })?;
     }
     Ok(())
 }

--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -1351,7 +1351,11 @@ fn add_webpki_roots(root_store: &mut RootCertStore) {
 #[cfg(feature = "tls-native-certs")]
 fn add_os_roots(root_store: &mut RootCertStore) -> Result<()> {
     let os_certs = rustls_native_certs::load_native_certs().map_err(|io_err| {
-        error::fmt!(TlsError, "Could not OS native TLS certificates: {}", io_err)
+        error::fmt!(
+            TlsError,
+            "Could not load OS native TLS certificates: {}",
+            io_err
+        )
     })?;
     for cert in os_certs {
         root_store

--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -1363,7 +1363,7 @@ fn add_os_roots(root_store: &mut RootCertStore) -> Result<()> {
     if valid_count == 0 && invalid_count > 0 {
         return Err(error::fmt!(
             TlsError,
-            "zero valid certificates found in native root store ({} found but were invalid)",
+            "No valid certificates found in native root store ({} found but were invalid)",
             invalid_count
         ));
     }

--- a/questdb-rs/src/ingress/timestamp.rs
+++ b/questdb-rs/src/ingress/timestamp.rs
@@ -82,6 +82,7 @@ fn extract_current_timestamp(extract_fn: impl FnOnce(Duration) -> u128) -> crate
 /// use questdb::ingress::TimestampMicros;
 ///
 /// # fn main() -> Result<()> {
+/// #[cfg(feature = "chrono_timestamp")]
 /// let ts = TimestampMicros::from_datetime(chrono::Utc::now());
 /// # Ok(())
 /// # }
@@ -161,6 +162,7 @@ impl TimestampMicros {
 /// use questdb::ingress::TimestampNanos;
 ///
 /// # fn main() -> Result<()> {
+/// # #[cfg(feature = "chrono_timestamp")]
 /// let ts = TimestampNanos::from_datetime(chrono::Utc::now());
 /// # Ok(())
 /// # }

--- a/system_test/questdb_line_sender.py
+++ b/system_test/questdb_line_sender.py
@@ -275,6 +275,14 @@ def _setup_cdll():
         None,
         c_line_sender_opts_p)
     set_sig(
+        dll.line_sender_opts_tls_os_roots,
+        None,
+        c_line_sender_opts_p)
+    set_sig(
+        dll.line_sender_opts_tls_webpki_and_os_roots,
+        None,
+        c_line_sender_opts_p)
+    set_sig(
         dll.line_sender_opts_tls_ca,
         None,
         c_line_sender_opts_p,
@@ -571,6 +579,10 @@ class Sender:
         if tls:
             if tls is True:
                 opts.tls()
+            elif tls == 'os_roots':
+                opts.tls_os_roots()
+            elif tls == 'webpki_and_os_roots':
+                opts.tls_webpki_and_os_roots()
             elif tls == 'insecure_skip_verify':
                 opts.tls_insecure_skip_verify()
             else:


### PR DESCRIPTION
Allow chosing between using bundled `webpki-roots` TLS certificate roots, or use the ones provided by the OS.