### PR TITLE
feat: new http retry logic

### DIFF
--- a/ci/run_all_tests.py
+++ b/ci/run_all_tests.py
@@ -38,7 +38,7 @@ def main():
     test_line_sender_path = next(iter(
         build_dir.glob(f'**/test_line_sender{exe_suffix}')))
     system_test_path = pathlib.Path('system_test') / 'test.py'
-    qdb_v = '7.3.7'  # The version of QuestDB we'll test against.
+    qdb_v = '7.3.9'  # The version of QuestDB we'll test against.
 
     run_cmd('cargo', 'test', '--', '--nocapture', cwd='questdb-rs')
     run_cmd('cargo', 'test', '--all-features', '--', '--nocapture', cwd='questdb-rs')

--- a/cpp_test/test_line_sender.cpp
+++ b/cpp_test/test_line_sender.cpp
@@ -720,8 +720,17 @@ TEST_CASE("Empty Buffer") {
 TEST_CASE("HTTP basics") {
     questdb::ingress::opts opts1{"localhost", 1};
     questdb::ingress::opts opts2{"localhost", 1};
-    opts1.http().transactional().max_retries(5).retry_interval(10).basic_auth("user", "pass");
-    opts2.http().token_auth("token").min_throughput(1000);
+    opts1
+        .http()
+        .transactional()
+        .grace_timeout(5000)
+        .retry_timeout(5)
+        .basic_auth("user", "pass");
+    opts2
+        .http()
+        .token_auth("token")
+        .min_throughput(1000)
+        .retry_timeout(0);
     questdb::ingress::line_sender sender1{opts1};
     questdb::ingress::line_sender sender2{opts2};
 

--- a/include/questdb/ingress/line_sender.h
+++ b/include/questdb/ingress/line_sender.h
@@ -600,25 +600,13 @@ LINESENDER_API
 void line_sender_opts_http(line_sender_opts* opts);
 
 /**
- * Maxmimum number of HTTP request retries.
- * Defaults to 3.
+ * Cumulative duration spent in retries.
+ * Default is 10 seconds.
  */
 LINESENDER_API
-void line_sender_opts_max_retries(
+void line_sender_opts_retry_timeout(
     line_sender_opts* opts,
-    uint32_t max_retries);
-
-/**
- * The initial retry interval (specified in milliseconds).
- * This the default is 100 milliseconds.
- * The retry interval is doubled after each failed attempt,
- * up to the maximum number of retries.
- * Also see `max_retries`.
- */
-LINESENDER_API
-void line_sender_opts_retry_interval(
-    line_sender_opts* opts,
-    uint64_t retry_interval_millis);
+    uint64_t millis);
 
 /**
  * Minimum expected throughput in bytes per second for HTTP requests.
@@ -630,6 +618,15 @@ LINESENDER_API
 void line_sender_opts_min_throughput(
     line_sender_opts* opts,
     uint64_t bytes_per_sec);
+
+/**
+ * Grace request timeout before relying on the minimum throughput logic.
+ * The default is 5 seconds.
+ */
+LINESENDER_API
+void line_sender_opts_grace_timeout(
+    line_sender_opts* opts,
+    uint64_t millis);
 
 /**
  * Enable transactional flushes.

--- a/include/questdb/ingress/line_sender.hpp
+++ b/include/questdb/ingress/line_sender.hpp
@@ -824,27 +824,12 @@ namespace questdb::ingress
             }
 
             /**
-             * Maxmimum number of HTTP request retries.
-             * Defaults to 3.
+             * Cumulative duration spent in retries.
+             * Default is 10 seconds.
              */
-            opts& max_retries(uint32_t max_retries) noexcept
+            opts& retry_timeout(uint64_t millis) noexcept
             {
-                ::line_sender_opts_max_retries(_impl, max_retries);
-                return *this;
-            }
-
-            /**
-             * The initial retry interval (specified in milliseconds).
-             * This the default is 100 milliseconds.
-             * The retry interval is doubled after each failed attempt,
-             * up to the maximum number of retries.
-             * Also see `max_retries`.
-             */
-            opts& retry_interval(uint64_t retry_interval_millis) noexcept
-            {
-                ::line_sender_opts_retry_interval(
-                    _impl,
-                    retry_interval_millis);
+                ::line_sender_opts_retry_timeout(_impl, millis);
                 return *this;
             }
 
@@ -857,6 +842,16 @@ namespace questdb::ingress
             opts& min_throughput(uint64_t bytes_per_sec) noexcept
             {
                 ::line_sender_opts_min_throughput(_impl, bytes_per_sec);
+                return *this;
+            }
+
+            /**
+             * Grace request timeout before relying on the minimum throughput logic.
+             * The default is 5 seconds.
+             */
+            opts& grace_timeout(uint64_t millis) noexcept
+            {
+                ::line_sender_opts_grace_timeout(_impl, millis);
                 return *this;
             }
 

--- a/questdb-rs-ffi/Cargo.lock
+++ b/questdb-rs-ffi/Cargo.lock
@@ -273,6 +273,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +296,7 @@ dependencies = [
  "indoc",
  "itoa",
  "libc",
+ "rand",
  "ring",
  "rustls",
  "rustls-native-certs",
@@ -321,6 +328,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/questdb-rs-ffi/src/lib.rs
+++ b/questdb-rs-ffi/src/lib.rs
@@ -514,28 +514,12 @@ pub unsafe extern "C" fn line_sender_opts_http(opts: *mut line_sender_opts) {
     upd_opts!(opts, http);
 }
 
-/// Maxmimum number of HTTP request retries.
-/// Defaults to 3.
+/// Cumulative duration spent in retries.
+/// Default is 10 seconds.
 #[no_mangle]
-pub unsafe extern "C" fn line_sender_opts_max_retries(
-    opts: *mut line_sender_opts,
-    max_retries: u32,
-) {
-    upd_opts!(opts, max_retries, max_retries);
-}
-
-/// The initial retry interval (specified in milliseconds).
-/// This the default is 100 milliseconds.
-/// The retry interval is doubled after each failed attempt,
-/// up to the maximum number of retries.
-/// Also see `max_retries`.
-#[no_mangle]
-pub unsafe extern "C" fn line_sender_opts_retry_interval(
-    opts: *mut line_sender_opts,
-    retry_interval_millis: u64,
-) {
-    let retry_interval = std::time::Duration::from_millis(retry_interval_millis);
-    upd_opts!(opts, retry_interval, retry_interval);
+pub unsafe extern "C" fn line_sender_opts_retry_timeout(opts: *mut line_sender_opts, millis: u64) {
+    let retry_timeout = std::time::Duration::from_millis(millis);
+    upd_opts!(opts, retry_timeout, retry_timeout);
 }
 
 /// Minimum expected throughput in bytes per second for HTTP requests.
@@ -548,6 +532,14 @@ pub unsafe extern "C" fn line_sender_opts_min_throughput(
     bytes_per_sec: u64,
 ) {
     upd_opts!(opts, min_throughput, bytes_per_sec);
+}
+
+/// Grace request timeout before relying on the minimum throughput logic.
+/// The default is 5 seconds.
+#[no_mangle]
+pub unsafe extern "C" fn line_sender_opts_grace_timeout(opts: *mut line_sender_opts, millis: u64) {
+    let grace_timeout = std::time::Duration::from_millis(millis);
+    upd_opts!(opts, grace_timeout, grace_timeout);
 }
 
 /// Enable transactional flushes.

--- a/questdb-rs/Cargo.toml
+++ b/questdb-rs/Cargo.toml
@@ -30,6 +30,7 @@ webpki-roots = { version = "0.26.0", optional = true }
 chrono = { version = "0.4.30", optional = true }
 ureq = { version = "2.9.4", optional = true }
 serde_json = { version = "1.0.108", optional = true }
+rand = "0.8.5"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["ws2def"] }

--- a/questdb-rs/Cargo.toml
+++ b/questdb-rs/Cargo.toml
@@ -30,7 +30,7 @@ webpki-roots = { version = "0.26.0", optional = true }
 chrono = { version = "0.4.30", optional = true }
 ureq = { version = "2.9.4", optional = true }
 serde_json = { version = "1.0.108", optional = true }
-rand = "0.8.5"
+rand = { version = "0.8.5", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["ws2def"] }
@@ -49,7 +49,7 @@ chrono = "0.4.31"
 default = ["tls-webpki-certs"]
 
 # Include support for ILP over HTTP.
-ilp-over-http = ["dep:ureq", "dep:serde_json"]
+ilp-over-http = ["dep:ureq", "dep:serde_json", "dep:rand"]
 
 # Allow use OS-provided root TLS certificates
 tls-native-certs = ["dep:rustls-native-certs"]

--- a/questdb-rs/src/tests/http.rs
+++ b/questdb-rs/src/tests/http.rs
@@ -561,7 +561,6 @@ fn test_two_retries() -> TestResult {
         assert_eq!(req.body_str().unwrap(), buffer2.as_str());
         let elapsed = std::time::Instant::now().duration_since(start_time);
         assert!(elapsed > Duration::from_millis(5));
-        assert!(elapsed < Duration::from_millis(25)); // theoretically 15ms, but we allow some slack.
 
         server.send_http_response_q(
             HttpResponse::empty()
@@ -575,7 +574,6 @@ fn test_two_retries() -> TestResult {
         assert_eq!(req.body_str().unwrap(), buffer2.as_str());
         let elapsed = std::time::Instant::now().duration_since(start_time);
         assert!(elapsed > Duration::from_millis(15));
-        assert!(elapsed < Duration::from_millis(35)); // theoretically 25ms, but we allow some slack.
 
         server.send_http_response_q(HttpResponse::empty())?;
 


### PR DESCRIPTION
This tweaks the HTTP retry logic and parameters to line them up with the latest Java ILP/HTTP logic. The new parameters match those documented in the new configuration string format.

See linked issue for pseudo-code description of the intended retry logic behaviour.

* Closes: https://github.com/questdb/c-questdb-client/issues/51
* See: https://docs.google.com/document/d/1EQZjYrJO_Ll8RrSIZpbr15Ul3N-xAtTxvrunI-TpOR8