### PR TITLE
chore: minor fixes to examples manifest file and reduced python test flakyness

### DIFF
--- a/examples.manifest.yaml
+++ b/examples.manifest.yaml
@@ -103,23 +103,23 @@
     host: localhost
     port: 9009
 
- - name: ilp-from-conf
-   lang: c
-   path: examples/line_sender_c_example_from_conf.c
-   header: |-
-     [C client library docs](https://github.com/questdb/c-questdb-client/blob/main/doc/C.md)
-   conf: tcp::addr=localhost:9009;
+- name: ilp-from-conf
+  lang: c
+  path: examples/line_sender_c_example_from_conf.c
+  header: |-
+    [C client library docs](https://github.com/questdb/c-questdb-client/blob/main/doc/C.md)
+  conf: tcp::addr=localhost:9009;
 
- - name: ilp-from-conf
-   lang: cpp
-   path: examples/line_sender_cpp_example_from_conf.cpp
-   header: |-
-     [C client library docs](https://github.com/questdb/c-questdb-client/blob/main/doc/CPP.md)
-   conf: tcp::addr=localhost:9009;
+- name: ilp-from-conf
+  lang: cpp
+  path: examples/line_sender_cpp_example_from_conf.cpp
+  header: |-
+    [C client library docs](https://github.com/questdb/c-questdb-client/blob/main/doc/CPP.md)
+  conf: tcp::addr=localhost:9009;
 
-  - name: ilp-from-conf
-    lang: rust
-    path: questdb-rs/examples/from_conf.rs
-    header: |-
-      [Rust client library docs](https://docs.rs/crate/questdb-rs/latest)
-    conf: tcp::addr=localhost:9009;
+- name: ilp-from-conf
+  lang: rust
+  path: questdb-rs/examples/from_conf.rs
+  header: |-
+    [Rust client library docs](https://docs.rs/crate/questdb-rs/latest)
+  conf: tcp::addr=localhost:9009;

--- a/system_test/fixture.py
+++ b/system_test/fixture.py
@@ -459,6 +459,19 @@ class TlsProxyFixture:
         env = dict(os.environ)
         env['CARGO_TARGET_DIR'] = str(self._target_dir)
         self._log_file = open(self._log_path, 'wb')
+
+        # Compile before running `cargo run`.
+        # Note that errors and output are purpously suppressed.
+        # This is just to exclude the build time from the start-up time.
+        # If there are build errors, they'll be reported later in the `run`
+        # call below.
+        subprocess.call(
+            ['cargo', 'build'],
+            cwd=self._code_dir,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL)
+
         self._proc = subprocess.Popen(
             ['cargo', 'run', str(self.qdb_ilp_port)],
             cwd=self._code_dir,

--- a/system_test/test.py
+++ b/system_test/test.py
@@ -754,7 +754,10 @@ class TestSender(unittest.TestCase):
 
     def test_manifest_yaml(self):
         # Check the manifest file can be read as yaml.
-        import yaml
+        try:
+            import yaml
+        except ImportError:
+            self.skipTest('Python version does not support yaml')
         proj = Project()
         manifest_path = proj.root_dir / 'examples.manifest.yaml'
         with open(manifest_path, 'r') as f:

--- a/system_test/test.py
+++ b/system_test/test.py
@@ -752,6 +752,14 @@ class TestSender(unittest.TestCase):
         with self.assertRaisesRegex(qls.SenderError, r'.*Environment variable QDB_CLIENT_CONF not set.*'):
             qls._error_wrapped_call(qls._DLL.line_sender_from_env)
 
+    def test_manifest_yaml(self):
+        # Check the manifest file can be read as yaml.
+        import yaml
+        proj = Project()
+        manifest_path = proj.root_dir / 'examples.manifest.yaml'
+        with open(manifest_path, 'r') as f:
+            yaml.safe_load(f)
+
 
 def parse_args():
     parser = argparse.ArgumentParser('Run system tests.')


### PR DESCRIPTION
Minor cleanup and fixes, not related to core functionality.

Test improvements:
* Split out building the TLS proxy into own command so it does not contribute to the start-up time, reducing flakyness on slow CI.
* Testing that the `examples.manifest.yaml` file can be parsed as YAML.

Fixes:
* Fixed the `examples.manifest.yaml` file.