### PR TITLE
Update example indentation

### DIFF
--- a/examples.manifest.yaml
+++ b/examples.manifest.yaml
@@ -103,23 +103,23 @@
     host: localhost
     port: 9009
 
- - name: ilp-from-conf
-   lang: c
-   path: examples/line_sender_c_example_from_conf.c
-   header: |-
-     [C client library docs](https://github.com/questdb/c-questdb-client/blob/main/doc/C.md)
-   conf: tcp::addr=localhost:9009;
+- name: ilp-from-conf
+  lang: c
+  path: examples/line_sender_c_example_from_conf.c
+  header: |-
+    [C client library docs](https://github.com/questdb/c-questdb-client/blob/main/doc/C.md)
+  conf: tcp::addr=localhost:9009;
 
- - name: ilp-from-conf
-   lang: cpp
-   path: examples/line_sender_cpp_example_from_conf.cpp
-   header: |-
-     [C client library docs](https://github.com/questdb/c-questdb-client/blob/main/doc/CPP.md)
-   conf: tcp::addr=localhost:9009;
+- name: ilp-from-conf
+  lang: cpp
+  path: examples/line_sender_cpp_example_from_conf.cpp
+  header: |-
+    [C client library docs](https://github.com/questdb/c-questdb-client/blob/main/doc/CPP.md)
+  conf: tcp::addr=localhost:9009;
 
-  - name: ilp-from-conf
-    lang: rust
-    path: questdb-rs/examples/from_conf.rs
-    header: |-
-      [Rust client library docs](https://docs.rs/crate/questdb-rs/latest)
-    conf: tcp::addr=localhost:9009;
+- name: ilp-from-conf
+  lang: rust
+  path: questdb-rs/examples/from_conf.rs
+  header: |-
+    [Rust client library docs](https://docs.rs/crate/questdb-rs/latest)
+  conf: tcp::addr=localhost:9009;


### PR DESCRIPTION
Docs blew up!

```shell
❯ yarn start
yarn run v1.22.21
$ cross-env NO_UPDATE_NOTIFIER=true docusaurus start
Starting the development server...
YAMLException: bad indentation of a sequence entry at line 106, column 2:
     - name: ilp-from-conf
     ^
    at generateError (/Users/goodroot/Code/questdb.io/node_modules/js-yaml/lib/js-yaml/loader.js:167:10)
    at throwError (/Users/goodroot/Code/questdb.io/node_modules/js-yaml/lib/js-yaml/loader.js:173:9)
    at readBlockSequence (/Users/goodroot/Code/questdb.io/node_modules/js-yaml/lib/js-yaml/loader.js:962:7)
    at composeNode (/Users/goodroot/Code/questdb.io/node_modules/js-yaml/lib/js-yaml/loader.js:1358:12)
    at readDocument (/Users/goodroot/Code/questdb.io/node_modules/js-yaml/lib/js-yaml/loader.js:1525:3)
    at loadDocuments (/Users/goodroot/Code/questdb.io/node_modules/js-yaml/lib/js-yaml/loader.js:1588:5)
    at Object.load (/Users/goodroot/Code/questdb.io/node_modules/js-yaml/lib/js-yaml/loader.js:1614:19)
    at Object.loadContent (/Users/goodroot/Code/questdb.io/plugins/remote-repo-example/index.js:52:29)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /Users/goodroot/Code/questdb.io/node_modules/@docusaurus/core/lib/server/plugins/index.js:53:46
    at async Promise.all (index 6)
    at async Object.loadPlugins (/Users/goodroot/Code/questdb.io/node_modules/@docusaurus/core/lib/server/plugins/index.js:52:34)
    at async Object.load (/Users/goodroot/Code/questdb.io/node_modules/@docusaurus/core/lib/server/index.js:94:82)
    at async start (/Users/goodroot/Code/questdb.io/node_modules/@docusaurus/core/lib/commands/start.js:44:19)
```

Appears to be indentation issue.