### PR TITLE
docs: tweaks for the documentation

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 current_version = 4.0.0
-commit = True
+commit = False
 tag = False
 
 [bumpversion:file:CMakeLists.txt]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -15,10 +15,6 @@ replace = questdb-rs/{new_version}/
 search = version = "{current_version}"
 replace = version = "{new_version}"
 
-[bumpversion:file:questdb-rs/README.md]
-search = questdb-rs = "{current_version}"
-replace = questdb-rs = "{new_version}"
-
 [bumpversion:file:./questdb-rs/README.md]
 search = questdb-rs/{current_version}/
 replace = questdb-rs/{new_version}/

--- a/questdb-rs/README.md
+++ b/questdb-rs/README.md
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
 ## Docs
 
 Most of the client documentation is on the
-[`ingress`](https://docs.rs/questdb-rs/latest/questdb/ingress/) module page.
+[`ingress`](https://docs.rs/questdb-rs/4.0.0/questdb/ingress/) module page.
 
 ## Crate features
 

--- a/questdb-rs/README.md
+++ b/questdb-rs/README.md
@@ -9,25 +9,16 @@ InfluxDB Line Protocol (ILP).
 * [QuestDB Database docs](https://questdb.io/docs/)
 * [Docs on InfluxDB Line Protocol](https://questdb.io/docs/reference/api/ilp/overview/)
 
-## Getting Started
+## Quick Start
 
-To start using `questdb-rs`, add it to your `Cargo.toml`:
+To start using `questdb-rs`, add it as a dependency of your project:
 
-```toml
-[dependencies]
-questdb-rs = "4.0.0"
+```bash
+cargo add questdb-rs
 ```
 
-## Docs
-
-See documentation for the
-[`ingress`](https://docs.rs/questdb-rs/4.0.0/questdb/ingress/) module to insert
-data into QuestDB via the ILP protocol.
-
-* Latest API docs:
-  [https://docs.rs/questdb-rs/latest/](https://docs.rs/questdb-rs/latest/)
-
-## Example
+Then you can try out this quick example, which connects to a QuestDB server
+running on your local machine:
 
 ```rust no_run
 use questdb::{
@@ -50,6 +41,11 @@ fn main() -> Result<()> {
    Ok(())
 }
 ```
+
+## Docs
+
+Most of the client documentation is on the
+[`ingress`](https://docs.rs/questdb-rs/latest/questdb/ingress/) module page.
 
 ## Crate features
 

--- a/questdb-rs/src/ingress/mod.md
+++ b/questdb-rs/src/ingress/mod.md
@@ -65,6 +65,27 @@ QuestDB instances), call
 The two supported transport modes, HTTP and TCP, handle errors very differently.
 In a nutshell, HTTP is much better at error handling.
 
+# Health Check
+
+The QuestDB server has a "ping" endpoint you can access to see if it's alive,
+and confirm the version of InfluxDB Line Protocol with which you are
+interacting:
+
+```shell
+curl -I http://localhost:9000/ping
+```
+
+Example of the expected response:
+
+```shell
+HTTP/1.1 204 OK
+Server: questDB/1.0
+Date: Fri, 2 Feb 2024 17:09:38 GMT
+Transfer-Encoding: chunked
+Content-Type: text/plain; charset=utf-8
+X-Influxdb-Version: v2.7.4
+```
+
 ## TCP
 
 TCP doesn't report errors at all to the sender; instead, the server quietly
@@ -231,6 +252,21 @@ transactional flushing.
 However, TCP has a lower overhead than HTTP and it's worthwhile to try out as an
 alternative in a scenario where you have a constantly high data rate and/or deal
 with a high-latency network connection.
+
+### Timestamp Column Name
+
+InfluxDB Line Protocol (ILP) does not give a name to the designated timestamp,
+so if you let this client auto-create the table, it will have the default name.
+To use a custom name, create the table using a DDL statement:
+
+```sql
+CREATE TABLE sensors (
+    my_ts timestamp,
+    id symbol,
+    temperature double,
+    humidity double,
+) timestamp(my_ts);
+```
 
 ## Sequential Coupling in the Buffer API
 


### PR DESCRIPTION
This improves the main page with a simpler Quick Start section.

It adds two more sections to the main ingress page, copied from the QuestDB webpage content.