### PR TITLE
bug: Apply request_timeout to timeout_connect

### DIFF
--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -2275,7 +2275,8 @@ impl SenderBuilder {
                     ));
                 }
 
-                let user_agent = self.http.as_ref().unwrap().user_agent.as_str();
+                let http_config = self.http.as_ref().unwrap();
+                let user_agent = http_config.user_agent.as_str();
                 let agent_builder = ureq::AgentBuilder::new()
                     .user_agent(user_agent)
                     .no_delay(true);
@@ -2307,6 +2308,8 @@ impl SenderBuilder {
                     }
                     None => None,
                 };
+                let agent_builder =
+                    agent_builder.timeout_connect(*http_config.request_timeout.deref());
                 let agent = agent_builder.build();
                 let proto = self.protocol.schema();
                 let url = format!(

--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -1919,7 +1919,7 @@ impl SenderBuilder {
     }
 
     /// Configure how long to wait for messages from the QuestDB server during
-    /// the TLS handshake and authentication process.
+    /// the TLS handshake and authentication process. This only applies to TCP.
     /// The default is 15 seconds.
     pub fn auth_timeout(mut self, value: Duration) -> Result<Self> {
         self.auth_timeout.set_specified("auth_timeout", value)?;
@@ -2016,6 +2016,8 @@ impl SenderBuilder {
     /// The timeout calculated from minimum throughput is adedd to the value of
     /// [`request_timeout`](SenderBuilder::request_timeout) to get the total timeout
     /// value.
+    /// A value of 0 disables this feature, so it's similar to setting "infinite"
+    /// minimum throughput. The total timeout will then be equal to `request_timeout`.
     pub fn request_min_throughput(mut self, value: u64) -> Result<Self> {
         if let Some(http) = &mut self.http {
             http.request_min_throughput


### PR DESCRIPTION
`ureq` has a potential bug in its configuration:

- `agent_builder.timeout_connect()` setting takes precedence over `agent_builder.timeout()`
- `timeout_connect()` has a default of 15 seconds
- therefore, setting `timeout()` is ignored as it's impossible to revert `timeout_connect()` to unconfigured state

This PR applies a workaround and sets `timeout_connect` to QuestDB's parameter `request_timeout`.

This partially addresses https://github.com/questdb/py-questdb-client/issues/75.