### PR TITLE
docs: fix rust client tcp ECDSA example

### DIFF
--- a/questdb-rs/src/ingress/mod.md
+++ b/questdb-rs/src/ingress/mod.md
@@ -162,7 +162,7 @@ let mut sender = Sender::from_conf(
 # use questdb::{Result, ingress::Sender};
 # fn main() -> Result<()> {
 let mut sender = Sender::from_conf(
-    "tcps::addr=localhost:9009;username=testUser1;token=5UjEA0;token_x=fLKYa9;token_y=bS1dEfy"
+    "tcps::addr=localhost:9009;username=testUser1;token=5UjEA0;token_x=fLKYa9;token_y=bS1dEfy;"
 )?;
 # Ok(())
 # }


### PR DESCRIPTION
Fix for a missing ";" in the rust crate documentation regarding the TCP [ECDSA example](https://docs.rs/questdb-rs/4.0.3/questdb/ingress/index.html#tcp-elliptic-curve-digital-signature-algorithm-ecdsa).

Original PR by @DownD: https://github.com/questdb/c-questdb-client/pull/81