### PR TITLE
feat(rust): add support to u64 and u256

### DIFF
--- a/questdb-rs/Cargo.toml
+++ b/questdb-rs/Cargo.toml
@@ -32,6 +32,7 @@ rustls = { version = "0.23.25", default-features = false, features = ["logging",
 rustls-native-certs = { version = "0.8.1", optional = true }
 webpki-roots = { version = "0.26.8", default-features = false, optional = true }
 chrono = { version = "0.4.40", optional = true }
+hex	= "0.4.3"
 
 # We need to limit the `ureq` version to 3.0.x since we use
 # the `ureq::unversioned` module which does not respect semantic versioning.

--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -909,6 +909,57 @@ impl Buffer {
         self.output.push(b'i');
         Ok(self)
     }
+    /// Record an integer value for the given column.
+    ///
+    /// ```
+    /// # use questdb::Result;
+    /// # use questdb::ingress::Buffer;
+    /// # fn main() -> Result<()> {
+    /// # let mut buffer = Buffer::new();
+    /// # buffer.table("x")?;
+    /// buffer.column_u64("col_name", 42)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// or
+    ///
+    /// ```
+    /// # use questdb::Result;
+    /// # use questdb::ingress::Buffer;
+    /// use questdb::ingress::ColumnName;
+    ///
+    /// # fn main() -> Result<()> {
+    /// # let mut buffer = Buffer::new();
+    /// # buffer.table("x")?;
+    /// let col_name = ColumnName::new("col_name")?;
+    /// buffer.column_u64(col_name, 42);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn column_u64<'a, N>(&mut self, name: N, value: u64) -> Result<&mut Self>
+    where
+        N: TryInto<ColumnName<'a>>,
+        Error: From<N::Error>,
+    {
+        self.write_column_key(name)?;
+        let mut buf = itoa::Buffer::new();
+        let printed = buf.format(value);
+        self.output.extend_from_slice(printed.as_bytes());
+        self.output.push(b'i');
+        Ok(self)
+    }
+
+    pub fn column_long256<'a, N>(&mut self, name: N, value: [u8; 32]) -> Result<&mut Self>
+    where
+        N: TryInto<ColumnName<'a>>,
+        Error: From<N::Error>,
+    {
+        self.write_column_key(name)?;
+        let ser = format!("0x{}i", hex::encode(value));
+        self.output.extend_from_slice(ser.as_bytes());
+        Ok(self)
+    }
 
     /// Record a floating point value for the given column.
     ///


### PR DESCRIPTION
Adds support for these types on the client. However, you'd still need to create the table first.

It's a simple change that makes life easier.

There's also an open issue regarding this:

https://github.com/questdb/c-questdb-client/issues/75
