### PR TITLE
perf: optimised marker operations removing heap allocations [backport]

### DIFF
--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -431,7 +431,9 @@ impl OpCase {
     }
 }
 
-#[derive(Debug, Clone)]
+// IMPORTANT: This struct MUST remain `Copy` to ensure that
+// there are no heap allocations when performing marker operations.
+#[derive(Debug, Clone, Copy)]
 struct BufferState {
     op_case: OpCase,
     row_count: usize,
@@ -447,13 +449,6 @@ impl BufferState {
             first_table_len: None,
             transactional: true,
         }
-    }
-
-    fn clear(&mut self) {
-        self.op_case = OpCase::Init;
-        self.row_count = 0;
-        self.first_table_len = None;
-        self.transactional = true;
     }
 }
 
@@ -631,7 +626,7 @@ impl Buffer {
                 )
             ));
         }
-        self.marker = Some((self.output.len(), self.state.clone()));
+        self.marker = Some((self.output.len(), self.state));
         Ok(())
     }
 
@@ -664,7 +659,7 @@ impl Buffer {
     /// [`capacity`](Buffer::capacity).
     pub fn clear(&mut self) {
         self.output.clear();
-        self.state.clear();
+        self.state = BufferState::new();
         self.marker = None;
     }
 

--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -490,11 +490,11 @@ impl BufferState {
 ///   * A row always starts with [`table`](Buffer::table).
 ///   * A row must contain at least one [`symbol`](Buffer::symbol) or
 ///     column (
-///       [`column_bool`](Buffer::column_bool),
-///       [`column_i64`](Buffer::column_i64),
-///       [`column_f64`](Buffer::column_f64),
-///       [`column_str`](Buffer::column_str),
-///       [`column_ts`](Buffer::column_ts)).
+///     [`column_bool`](Buffer::column_bool),
+///     [`column_i64`](Buffer::column_i64),
+///     [`column_f64`](Buffer::column_f64),
+///     [`column_str`](Buffer::column_str),
+///     [`column_ts`](Buffer::column_ts)).
 ///   * Symbols must appear before columns.
 ///   * A row must be terminated with either [`at`](Buffer::at) or
 ///     [`at_now`](Buffer::at_now).

--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -34,6 +34,7 @@ use std::collections::HashMap;
 use std::convert::Infallible;
 use std::fmt::{Debug, Display, Formatter, Write};
 use std::io::{self, BufRead, BufReader, ErrorKind, Write as IoWrite};
+use std::num::NonZeroUsize;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -434,7 +435,7 @@ impl OpCase {
 struct BufferState {
     op_case: OpCase,
     row_count: usize,
-    first_table: Option<String>,
+    first_table_len: Option<NonZeroUsize>,
     transactional: bool,
 }
 
@@ -443,7 +444,7 @@ impl BufferState {
         Self {
             op_case: OpCase::Init,
             row_count: 0,
-            first_table: None,
+            first_table_len: None,
             transactional: true,
         }
     }
@@ -451,7 +452,7 @@ impl BufferState {
     fn clear(&mut self) {
         self.op_case = OpCase::Init;
         self.row_count = 0;
-        self.first_table = None;
+        self.first_table_len = None;
         self.transactional = true;
     }
 }
@@ -729,16 +730,31 @@ impl Buffer {
         let name: TableName<'a> = name.try_into()?;
         self.validate_max_name_len(name.name)?;
         self.check_op(Op::Table)?;
+        let table_begin = self.output.len();
         write_escaped_unquoted(&mut self.output, name.name);
+        let table_end = self.output.len();
         self.state.op_case = OpCase::TableWritten;
 
         // A buffer stops being transactional if it targets multiple tables.
-        if let Some(first_table) = &self.state.first_table {
-            if first_table != name.name {
+        if let Some(first_table_len) = &self.state.first_table_len {
+            let first_table = &self.output[0..(first_table_len.get())];
+            let this_table = &self.output[table_begin..table_end];
+            if first_table != this_table {
                 self.state.transactional = false;
             }
         } else {
-            self.state.first_table = Some(name.name.to_owned());
+            debug_assert!(table_begin == 0);
+
+            // This is a bit confusing, so worth explaining:
+            // `NonZeroU16::new(table_end as u16)` will return `None` if `table_end` is 0,
+            // but we know that `table_end` is never 0 here, we just need an option type
+            // anyway, so we don't bother unwrapping it to then wrap it again.
+            let first_table_len = NonZeroUsize::new(table_end);
+
+            // Instead we just assert that it's `Some`.
+            debug_assert!(first_table_len.is_some());
+
+            self.state.first_table_len = first_table_len;
         }
         Ok(self)
     }

--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -741,7 +741,7 @@ impl Buffer {
             debug_assert!(table_begin == 0);
 
             // This is a bit confusing, so worth explaining:
-            // `NonZeroU16::new(table_end as u16)` will return `None` if `table_end` is 0,
+            // `NonZeroUsize::new(table_end)` will return `None` if `table_end` is 0,
             // but we know that `table_end` is never 0 here, we just need an option type
             // anyway, so we don't bother unwrapping it to then wrap it again.
             let first_table_len = NonZeroUsize::new(table_end);

--- a/questdb-rs/src/tests/sender.rs
+++ b/questdb-rs/src/tests/sender.rs
@@ -153,7 +153,7 @@ fn test_row_count() -> TestResult {
 
 #[test]
 fn test_transactional() -> TestResult {
-    let mut buffer = Buffer::new(ProtocolVersion::V2);
+    let mut buffer = Buffer::new();
 
     // transactional since there are no recorded tables yet
     assert_eq!(buffer.row_count(), 0);


### PR DESCRIPTION
Backporting https://github.com/questdb/c-questdb-client/pull/107 to v4.x.x