### PR TITLE
feat: nanosecond timestamp support

### DIFF
--- a/cpp_test/test_line_sender.cpp
+++ b/cpp_test/test_line_sender.cpp
@@ -943,8 +943,8 @@ TEST_CASE("Test timestamp column.")
         .at(now_nanos_ts);
 
     std::stringstream ss;
-    ss << "test ts1=12345t,ts2=" << now_micros << "t,ts3=" << now_micros << "t "
-       << now_nanos << "\n";
+    ss << "test ts1=12345000n,ts2=" << now_micros * 1000L
+       << "n,ts3=" << now_nanos << "n " << now_nanos << "\n";
     const auto exp = ss.str();
     CHECK(buffer.peek() == exp);
 

--- a/cpp_test/test_line_sender.cpp
+++ b/cpp_test/test_line_sender.cpp
@@ -943,8 +943,8 @@ TEST_CASE("Test timestamp column.")
         .at(now_nanos_ts);
 
     std::stringstream ss;
-    ss << "test ts1=12345000n,ts2=" << now_micros * 1000L
-       << "n,ts3=" << now_nanos << "n " << now_nanos << "\n";
+    ss << "test ts1=12345t,ts2=" << now_micros << "t,ts3=" << now_nanos << "n "
+       << now_nanos << "\n";
     const auto exp = ss.str();
     CHECK(buffer.peek() == exp);
 

--- a/questdb-rs/src/ingress/buffer.rs
+++ b/questdb-rs/src/ingress/buffer.rs
@@ -23,9 +23,8 @@
  ******************************************************************************/
 use crate::ingress::ndarr::{check_and_get_array_bytes_size, ArrayElementSealed};
 use crate::ingress::{
-    ndarr, ArrayElement, DebugBytes, NdArrayView, ProtocolVersion, Timestamp, TimestampMicros,
-    TimestampNanos, ARRAY_BINARY_FORMAT_TYPE, DOUBLE_BINARY_FORMAT_TYPE, MAX_ARRAY_DIMS,
-    MAX_NAME_LEN_DEFAULT,
+    ndarr, ArrayElement, DebugBytes, NdArrayView, ProtocolVersion, Timestamp, TimestampNanos,
+    ARRAY_BINARY_FORMAT_TYPE, DOUBLE_BINARY_FORMAT_TYPE, MAX_ARRAY_DIMS, MAX_NAME_LEN_DEFAULT,
 };
 use crate::{error, Error};
 use std::fmt::{Debug, Formatter};
@@ -281,7 +280,7 @@ impl<'a> TryFrom<&'a str> for TableName<'a> {
     }
 }
 
-impl<'a> AsRef<str> for TableName<'a> {
+impl AsRef<str> for TableName<'_> {
     fn as_ref(&self) -> &str {
         self.name
     }
@@ -368,7 +367,7 @@ impl<'a> TryFrom<&'a str> for ColumnName<'a> {
     }
 }
 
-impl<'a> AsRef<str> for ColumnName<'a> {
+impl AsRef<str> for ColumnName<'_> {
     fn as_ref(&self) -> &str {
         self.name
     }
@@ -1148,11 +1147,11 @@ impl Buffer {
     {
         self.write_column_key(name)?;
         let timestamp: Timestamp = value.try_into()?;
-        let timestamp: TimestampMicros = timestamp.try_into()?;
+        let timestamp: TimestampNanos = timestamp.try_into()?;
         let mut buf = itoa::Buffer::new();
         let printed = buf.format(timestamp.as_i64());
         self.output.extend_from_slice(printed.as_bytes());
-        self.output.push(b't');
+        self.output.push(b'n');
         Ok(self)
     }
 

--- a/questdb-rs/src/ingress/buffer.rs
+++ b/questdb-rs/src/ingress/buffer.rs
@@ -1147,11 +1147,19 @@ impl Buffer {
     {
         self.write_column_key(name)?;
         let timestamp: Timestamp = value.try_into()?;
-        let timestamp: TimestampNanos = timestamp.try_into()?;
         let mut buf = itoa::Buffer::new();
-        let printed = buf.format(timestamp.as_i64());
-        self.output.extend_from_slice(printed.as_bytes());
-        self.output.push(b'n');
+        match timestamp {
+            Timestamp::Micros(ts) => {
+                let printed = buf.format(ts.as_i64());
+                self.output.extend_from_slice(printed.as_bytes());
+                self.output.push(b't');
+            }
+            Timestamp::Nanos(ts) => {
+                let printed = buf.format(ts.as_i64());
+                self.output.extend_from_slice(printed.as_bytes());
+                self.output.push(b'n');
+            }
+        }
         Ok(self)
     }
 

--- a/questdb-rs/src/ingress/mod.rs
+++ b/questdb-rs/src/ingress/mod.rs
@@ -1287,7 +1287,7 @@ fn parse_key_pair(auth: &conf::EcdsaAuthParams) -> Result<EcdsaKeyPair> {
 
 struct DebugBytes<'a>(pub &'a [u8]);
 
-impl<'a> Debug for DebugBytes<'a> {
+impl Debug for DebugBytes<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "b\"")?;
 

--- a/questdb-rs/src/tests/sender.rs
+++ b/questdb-rs/src/tests/sender.rs
@@ -90,8 +90,8 @@ fn test_basics(
         "test,t1=v1 ".as_bytes(),
         f64_to_bytes("f1", 0.5, version).as_slice(),
         format!(
-            ",ts1=12345000n,ts2={}n,ts3={ts_nanos_num}n {ts_nanos_num}\n",
-            ts_micros_num * 1000
+            ",ts1=12345t,ts2={}t,ts3={ts_nanos_num}n {ts_nanos_num}\n",
+            ts_micros_num
         )
         .as_bytes(),
     ]
@@ -538,8 +538,8 @@ fn test_timestamp_overloads() -> TestResult {
         )?)?;
 
     let exp = concat!(
-        "tbl_name a=12345000n,b=-100000000000n,c=12345678n,d=-12345678n,e=-1000n,f=-10000n 1000\n",
-        "tbl_name a=1000000000n 5000000000\n"
+        "tbl_name a=12345t,b=-100000000t,c=12345678n,d=-12345678n,e=-1t,f=-10000n 1000\n",
+        "tbl_name a=1000000t 5000000000\n"
     )
     .as_bytes();
     assert_eq!(buffer.as_bytes(), exp);

--- a/questdb-rs/src/tests/sender.rs
+++ b/questdb-rs/src/tests/sender.rs
@@ -89,8 +89,11 @@ fn test_basics(
     let exp = &[
         "test,t1=v1 ".as_bytes(),
         f64_to_bytes("f1", 0.5, version).as_slice(),
-        format!(",ts1=12345000n,ts2={}n,ts3={ts_nanos_num}n {ts_nanos_num}\n", ts_micros_num * 1000)
-            .as_bytes(),
+        format!(
+            ",ts1=12345000n,ts2={}n,ts3={ts_nanos_num}n {ts_nanos_num}\n",
+            ts_micros_num * 1000
+        )
+        .as_bytes(),
     ]
     .concat();
     assert_eq!(buffer.as_bytes(), exp);

--- a/questdb-rs/src/tests/sender.rs
+++ b/questdb-rs/src/tests/sender.rs
@@ -89,13 +89,8 @@ fn test_basics(
     let exp = &[
         "test,t1=v1 ".as_bytes(),
         f64_to_bytes("f1", 0.5, version).as_slice(),
-        format!(
-            ",ts1=12345t,ts2={}t,ts3={}t {}\n",
-            ts_micros_num,
-            ts_nanos_num / 1000i64,
-            ts_nanos_num
-        )
-        .as_bytes(),
+        format!(",ts1=12345000n,ts2={ts_nanos_num}n,ts3={ts_nanos_num}n {ts_nanos_num}\n",)
+            .as_bytes(),
     ]
     .concat();
     assert_eq!(buffer.as_bytes(), exp);
@@ -540,8 +535,8 @@ fn test_timestamp_overloads() -> TestResult {
         )?)?;
 
     let exp = concat!(
-        "tbl_name a=12345t,b=-100000000t,c=12345t,d=-12345t,e=-1t,f=-10t 1000\n",
-        "tbl_name a=1000000t 5000000000\n"
+        "tbl_name a=12345000n,b=-100000000000n,c=12345678n,d=-12345678n,e=-1000n,f=-10000n 1000\n",
+        "tbl_name a=1000000000n 5000000000\n"
     )
     .as_bytes();
     assert_eq!(buffer.as_bytes(), exp);
@@ -561,7 +556,7 @@ fn test_chrono_timestamp() -> TestResult {
     let mut buffer = Buffer::new(ProtocolVersion::V2);
     buffer.table(tbl_name)?.column_ts("a", ts)?.at(ts)?;
 
-    let exp = b"tbl_name a=1000000t 1000000000\n";
+    let exp = b"tbl_name a=1000000000n 1000000000\n";
     assert_eq!(buffer.as_bytes(), exp);
 
     Ok(())

--- a/questdb-rs/src/tests/sender.rs
+++ b/questdb-rs/src/tests/sender.rs
@@ -89,7 +89,7 @@ fn test_basics(
     let exp = &[
         "test,t1=v1 ".as_bytes(),
         f64_to_bytes("f1", 0.5, version).as_slice(),
-        format!(",ts1=12345000n,ts2={ts_nanos_num}n,ts3={ts_nanos_num}n {ts_nanos_num}\n",)
+        format!(",ts1=12345000n,ts2={}n,ts3={ts_nanos_num}n {ts_nanos_num}\n", ts_micros_num * 1000)
             .as_bytes(),
     ]
     .concat();


### PR DESCRIPTION
This PR adds nanosecond support.

The client already exposed APIs that accepted both microseconds and nanosecond.
Before this change, the nanosecond APIs would convert to microseconds for the non-designated timestamp column. Now the nanosecond APIs pass the data through as-is.

This change is being introduced in conjunction with https://github.com/questdb/questdb/pull/5685 which adds native nanosecond precision timestamps to the database.