### PR TITLE
Bump version: 6.0.0 → 6.1.0

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "6.0.0"
+current_version = "6.1.0"
 commit = false
 tag = false
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15.0)
-project(c-questdb-client VERSION 6.0.0)
+project(c-questdb-client VERSION 6.1.0)
 
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})

--- a/doc/SECURITY.md
+++ b/doc/SECURITY.md
@@ -35,7 +35,7 @@ A few important technical details on TLS:
     are managed centrally.
 
 For API usage:
-* Rust: `SenderBuilder`'s [`auth`](https://docs.rs/questdb-rs/6.0.0/questdb/ingress/struct.SenderBuilder.html#method.auth)
-  and [`tls`](https://docs.rs/questdb-rs/6.0.0/questdb/ingress/struct.SenderBuilder.html#method.tls) methods.
+* Rust: `SenderBuilder`'s [`auth`](https://docs.rs/questdb-rs/6.1.0/questdb/ingress/struct.SenderBuilder.html#method.auth)
+  and [`tls`](https://docs.rs/questdb-rs/6.1.0/questdb/ingress/struct.SenderBuilder.html#method.tls) methods.
 * C: [examples/line_sender_c_example_auth.c](../examples/line_sender_c_example_auth.c)
 * C++: [examples/line_sender_cpp_example_auth.cpp](../examples/line_sender_cpp_example_auth.cpp)

--- a/include/questdb/ingress/line_sender.hpp
+++ b/include/questdb/ingress/line_sender.hpp
@@ -679,7 +679,7 @@ private:
     static inline ::line_sender_utf8 name()
     {
         // Maintained by .bumpversion.cfg
-        static const char user_agent[] = "questdb/c++/6.0.0";
+        static const char user_agent[] = "questdb/c++/6.1.0";
         ::line_sender_utf8 utf8 =
             ::line_sender_utf8_assert(sizeof(user_agent) - 1, user_agent);
         return utf8;

--- a/questdb-rs-ffi/Cargo.lock
+++ b/questdb-rs-ffi/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "questdb-rs"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "base64ct",
  "dns-lookup",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "questdb-rs-ffi"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "libc",
  "questdb-confstr-ffi",

--- a/questdb-rs-ffi/Cargo.toml
+++ b/questdb-rs-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "questdb-rs-ffi"
-version = "6.0.0"
+version = "6.1.0"
 edition = "2024"
 publish = false
 

--- a/questdb-rs/Cargo.toml
+++ b/questdb-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "questdb-rs"
-version = "6.0.0"
+version = "6.1.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "QuestDB Client Library for Rust"

--- a/questdb-rs/README.md
+++ b/questdb-rs/README.md
@@ -70,21 +70,21 @@ fn main() -> Result<()> {
 ## Docs
 
 Most of the client documentation is on the
-[`ingress`](https://docs.rs/questdb-rs/6.0.0/questdb/ingress/) module page.
+[`ingress`](https://docs.rs/questdb-rs/6.1.0/questdb/ingress/) module page.
 
 ## Examples
 
-A selection of usage examples is available in the [examples directory](https://github.com/questdb/c-questdb-client/tree/6.0.0/questdb-rs/examples):
+A selection of usage examples is available in the [examples directory](https://github.com/questdb/c-questdb-client/tree/6.1.0/questdb-rs/examples):
 
 | Example | Description |
 |---------|-------------|
-| [`basic.rs`](https://github.com/questdb/c-questdb-client/blob/6.0.0/questdb-rs/examples/basic.rs) | Minimal TCP ingestion example; shows basic row and array ingestion. |
-| [`auth.rs`](https://github.com/questdb/c-questdb-client/blob/6.0.0/questdb-rs/examples/auth.rs) | Adds authentication (user/password, token) to basic ingestion. |
-| [`auth_tls.rs`](https://github.com/questdb/c-questdb-client/blob/6.0.0/questdb-rs/examples/auth_tls.rs) | Like `auth.rs`, but uses TLS for encrypted TCP connections. |
-| [`from_conf.rs`](https://github.com/questdb/c-questdb-client/blob/6.0.0/questdb-rs/examples/from_conf.rs) | Configures client via connection string instead of builder pattern. |
-| [`from_env.rs`](https://github.com/questdb/c-questdb-client/blob/6.0.0/questdb-rs/examples/from_env.rs) | Reads config from `QDB_CLIENT_CONF` environment variable. |
-| [`http.rs`](https://github.com/questdb/c-questdb-client/blob/6.0.0/questdb-rs/examples/http.rs) | Uses HTTP transport and demonstrates array ingestion with `ndarray`. |
-| [`protocol_version.rs`](https://github.com/questdb/c-questdb-client/blob/6.0.0/questdb-rs/examples/protocol_version.rs) | Shows protocol version selection and feature differences (e.g. arrays). |
+| [`basic.rs`](https://github.com/questdb/c-questdb-client/blob/6.1.0/questdb-rs/examples/basic.rs) | Minimal TCP ingestion example; shows basic row and array ingestion. |
+| [`auth.rs`](https://github.com/questdb/c-questdb-client/blob/6.1.0/questdb-rs/examples/auth.rs) | Adds authentication (user/password, token) to basic ingestion. |
+| [`auth_tls.rs`](https://github.com/questdb/c-questdb-client/blob/6.1.0/questdb-rs/examples/auth_tls.rs) | Like `auth.rs`, but uses TLS for encrypted TCP connections. |
+| [`from_conf.rs`](https://github.com/questdb/c-questdb-client/blob/6.1.0/questdb-rs/examples/from_conf.rs) | Configures client via connection string instead of builder pattern. |
+| [`from_env.rs`](https://github.com/questdb/c-questdb-client/blob/6.1.0/questdb-rs/examples/from_env.rs) | Reads config from `QDB_CLIENT_CONF` environment variable. |
+| [`http.rs`](https://github.com/questdb/c-questdb-client/blob/6.1.0/questdb-rs/examples/http.rs) | Uses HTTP transport and demonstrates array ingestion with `ndarray`. |
+| [`protocol_version.rs`](https://github.com/questdb/c-questdb-client/blob/6.1.0/questdb-rs/examples/protocol_version.rs) | Shows protocol version selection and feature differences (e.g. arrays). |
 
 ## Crate features
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 6.1.0: Bumped project version across all packages and build configurations for both C++ and Rust implementations.
  * Updated all documentation links, references, and examples to reflect version 6.1.0.
  * Updated client user-agent identification string for the line sender to version 6.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->