### PR TITLE
Remove noexcept from line_sender::protocol_version() and line_sender::new_buffer()

### DIFF
--- a/include/questdb/ingress/line_sender.hpp
+++ b/include/questdb/ingress/line_sender.hpp
@@ -1110,14 +1110,14 @@ public:
     /**
      * Get the current protocol version used by the sender.
      */
-    questdb::ingress::protocol_version protocol_version() const noexcept
+    questdb::ingress::protocol_version protocol_version() const
     {
         ensure_impl();
         return static_cast<enum protocol_version>(
             static_cast<int>(::line_sender_get_protocol_version(_impl)));
     }
 
-    line_sender_buffer new_buffer(size_t init_buf_size = 64 * 1024) noexcept
+    line_sender_buffer new_buffer(size_t init_buf_size = 64 * 1024)
     {
         ensure_impl();
         return line_sender_buffer{


### PR DESCRIPTION
These methods can both throw due to ensure_impl() throwing.

Fixes #131 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Exception-safety guarantees have been removed from two core API methods. These methods may now throw exceptions in scenarios where exceptions were previously guaranteed not to occur. Applications relying on the previous no-throw behavior should be reviewed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->