### PR TITLE
feat(ingress): add `_opt` builder methods to Buffer for Option<T>

### DIFF
--- a/questdb-rs/src/ingress/buffer.rs
+++ b/questdb-rs/src/ingress/buffer.rs
@@ -771,6 +771,45 @@ impl Buffer {
         Ok(self)
     }
 
+    /// Record a symbol for the given column if the value is `Some`.
+    /// If the value is `None`, this is a no-op and the column is skipped.
+    ///
+    /// This is a convenience wrapper around [`Self::symbol`]. Make sure you
+    /// record all symbol columns before any other column type.
+    ///
+    /// **Tip:** If you have an `Option<String>`, use `.as_deref()` to pass it
+    /// without consuming the original string.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use questdb::Result;
+    /// # use questdb::ingress::{Buffer, SenderBuilder};
+    /// # fn main() -> Result<()> {
+    /// # let mut sender = SenderBuilder::from_conf("https::addr=localhost:9000;")?.build()?;
+    /// # let mut buffer = sender.new_buffer();
+    /// # buffer.table("x")?;
+    /// let val: Option<&str> = Some("value");
+    /// buffer.symbol_opt("col_name", val)?;
+    ///
+    /// let no_val: Option<&str> = None;
+    /// buffer.symbol_opt("skipped_col", no_val)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn symbol_opt<'a, N, S>(&mut self, name: N, value: Option<S>) -> crate::Result<&mut Self>
+    where
+        N: TryInto<ColumnName<'a>>,
+        S: AsRef<str>,
+        Error: From<N::Error>,
+    {
+        if let Some(v) = value {
+            self.symbol(name, v)
+        } else {
+            Ok(self)
+        }
+    }
+
     fn write_column_key<'a, N>(&mut self, name: N) -> crate::Result<&mut Self>
     where
         N: TryInto<ColumnName<'a>>,
@@ -831,6 +870,44 @@ impl Buffer {
         Ok(self)
     }
 
+    /// Record a boolean value for the given column if the value is `Some`.
+    /// If the value is `None`, this is a no-op and the column is skipped.
+    ///
+    /// This is a convenience wrapper around [`Self::column_bool`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use questdb::Result;
+    /// # use questdb::ingress::{Buffer, SenderBuilder};
+    /// # fn main() -> Result<()> {
+    /// # let mut sender = SenderBuilder::from_conf("https::addr=localhost:9000;")?.build()?;
+    /// # let mut buffer = sender.new_buffer();
+    /// # buffer.table("x")?;
+    /// let val: Option<bool> = Some(true);
+    /// buffer.column_bool_opt("col_name", val)?;
+    ///
+    /// let no_val: Option<bool> = None;
+    /// buffer.column_bool_opt("skipped_col", no_val)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn column_bool_opt<'a, N>(
+        &mut self,
+        name: N,
+        value: Option<bool>,
+    ) -> crate::Result<&mut Self>
+    where
+        N: TryInto<ColumnName<'a>>,
+        Error: From<N::Error>,
+    {
+        if let Some(v) = value {
+            self.column_bool(name, v)
+        } else {
+            Ok(self)
+        }
+    }
+
     /// Record an integer value for the given column.
     ///
     /// ```no_run
@@ -872,6 +949,40 @@ impl Buffer {
         self.output.extend_from_slice(printed.as_bytes());
         self.output.push(b'i');
         Ok(self)
+    }
+
+    /// Record an integer value for the given column if the value is `Some`.
+    /// If the value is `None`, this is a no-op and the column is skipped.
+    ///
+    /// This is a convenience wrapper around [`Self::column_i64`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use questdb::Result;
+    /// # use questdb::ingress::{Buffer, SenderBuilder};
+    /// # fn main() -> Result<()> {
+    /// # let mut sender = SenderBuilder::from_conf("https::addr=localhost:9000;")?.build()?;
+    /// # let mut buffer = sender.new_buffer();
+    /// # buffer.table("x")?;
+    /// let val: Option<i64> = Some(42);
+    /// buffer.column_i64_opt("col_name", val)?;
+    ///
+    /// let no_val: Option<i64> = None;
+    /// buffer.column_i64_opt("skipped_col", no_val)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn column_i64_opt<'a, N>(&mut self, name: N, value: Option<i64>) -> crate::Result<&mut Self>
+    where
+        N: TryInto<ColumnName<'a>>,
+        Error: From<N::Error>,
+    {
+        if let Some(v) = value {
+            self.column_i64(name, v)
+        } else {
+            Ok(self)
+        }
     }
 
     /// Record a floating point value for the given column.
@@ -919,6 +1030,40 @@ impl Buffer {
             self.output.extend_from_slice(ser.as_str().as_bytes())
         }
         Ok(self)
+    }
+
+    /// Record a floating point value for the given column if the value is `Some`.
+    /// If the value is `None`, this is a no-op and the column is skipped.
+    ///
+    /// This is a convenience wrapper around [`Self::column_f64`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use questdb::Result;
+    /// # use questdb::ingress::{Buffer, SenderBuilder};
+    /// # fn main() -> Result<()> {
+    /// # let mut sender = SenderBuilder::from_conf("https::addr=localhost:9000;")?.build()?;
+    /// # let mut buffer = sender.new_buffer();
+    /// # buffer.table("x")?;
+    /// let val: Option<f64> = Some(3.14);
+    /// buffer.column_f64_opt("col_name", val)?;
+    ///
+    /// let no_val: Option<f64> = None;
+    /// buffer.column_f64_opt("skipped_col", no_val)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn column_f64_opt<'a, N>(&mut self, name: N, value: Option<f64>) -> crate::Result<&mut Self>
+    where
+        N: TryInto<ColumnName<'a>>,
+        Error: From<N::Error>,
+    {
+        if let Some(v) = value {
+            self.column_f64(name, v)
+        } else {
+            Ok(self)
+        }
     }
 
     /// Record a string value for the given column.
@@ -975,6 +1120,48 @@ impl Buffer {
         self.write_column_key(name)?;
         write_escaped_quoted(&mut self.output, value.as_ref());
         Ok(self)
+    }
+
+    /// Record a string value for the given column if the value is `Some`.
+    /// If the value is `None`, this is a no-op and the column is skipped.
+    ///
+    /// This is a convenience wrapper around [`Self::column_str`].
+    ///
+    /// **Tip:** If you have an `Option<String>`, use `.as_deref()` to pass it
+    /// without consuming the original string.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use questdb::Result;
+    /// # use questdb::ingress::{Buffer, SenderBuilder};
+    /// # fn main() -> Result<()> {
+    /// # let mut sender = SenderBuilder::from_conf("https::addr=localhost:9000;")?.build()?;
+    /// # let mut buffer = sender.new_buffer();
+    /// # buffer.table("x")?;
+    /// let val: Option<&str> = Some("value");
+    /// buffer.column_str_opt("col_name", val)?;
+    ///
+    /// let no_val: Option<&str> = None;
+    /// buffer.column_str_opt("skipped_col", no_val)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn column_str_opt<'a, N, S>(
+        &mut self,
+        name: N,
+        value: Option<S>,
+    ) -> crate::Result<&mut Self>
+    where
+        N: TryInto<ColumnName<'a>>,
+        S: AsRef<str>,
+        Error: From<N::Error>,
+    {
+        if let Some(v) = value {
+            self.column_str(name, v)
+        } else {
+            Ok(self)
+        }
     }
 
     /// Record a decimal value for the given column.
@@ -1072,6 +1259,58 @@ impl Buffer {
         self.write_column_key(name)?;
         value.serialize(&mut self.output);
         Ok(self)
+    }
+
+    /// Record a decimal value for the given column if the value is `Some`.
+    /// If the value is `None`, this is a no-op and the column is skipped.
+    ///
+    /// This is a convenience wrapper around [`Self::column_dec`]. It has the
+    /// exact same requirements and error conditions as the underlying method
+    /// (e.g., it requires Protocol Version 3 or higher).
+    ///
+    /// **Tip:** If you have an `Option<Decimal>`, use `.as_ref()` to pass it
+    /// without consuming the original string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] if the provided value is `Some` and violates any of the
+    /// constraints detailed in [`Self::column_dec`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use questdb::Result;
+    /// # use questdb::ingress::{Buffer, SenderBuilder};
+    /// use bigdecimal::BigDecimal;
+    /// use std::str::FromStr;
+    /// # fn main() -> Result<()> {
+    /// # let mut sender = SenderBuilder::from_conf("https::addr=localhost:9000;")?.build()?;
+    /// # let mut buffer = sender.new_buffer();
+    /// # buffer.table("x")?;
+    /// let val: Option<BigDecimal> = Some(BigDecimal::from_str("0.123456789012345678901234567890").unwrap());
+    /// buffer.column_dec_opt("col_name", val)?;
+    ///
+    /// let no_val: Option<BigDecimal> = None;
+    /// buffer.column_dec_opt("skipped_col", no_val)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn column_dec_opt<'a, N, S>(
+        &mut self,
+        name: N,
+        value: Option<S>,
+    ) -> crate::Result<&mut Self>
+    where
+        N: TryInto<ColumnName<'a>>,
+        S: TryInto<DecimalView<'a>>,
+        Error: From<N::Error>,
+        Error: From<S::Error>,
+    {
+        if let Some(v) = value {
+            self.column_dec(name, v)
+        } else {
+            Ok(self)
+        }
     }
 
     /// Record a multidimensional array value for the given column.
@@ -1184,6 +1423,59 @@ impl Buffer {
         Ok(self)
     }
 
+    /// Record a multidimensional array value for the given column if the value is `Some`.
+    /// If the value is `None`, this is a no-op and the column is skipped.
+    ///
+    /// This is a convenience wrapper around [`Self::column_arr`]. When the value is `Some`,
+    /// it has the exact same requirements and error conditions as the underlying method.
+    /// Specifically, it requires QuestDB server version 9.0.0+ and supports up to
+    /// [`MAX_ARRAY_DIMS`] dimensions of `f64` elements.
+    ///
+    /// **Tip:** If you have an `Option<Vec<Vec<f64>>>`, use `.as_ref()` to pass it
+    /// without consuming the original vector.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] if the provided value is `Some` and violates any of the
+    /// constraints detailed in [`Self::column_arr`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use questdb::Result;
+    /// # use questdb::ingress::{Buffer, SenderBuilder};
+    /// # fn main() -> Result<()> {
+    /// # let mut sender = SenderBuilder::from_conf("https::addr=localhost:9000;")?.build()?;
+    /// # let mut buffer = sender.new_buffer();
+    /// # buffer.table("x")?;
+    /// let array_2d = vec![vec![1.1, 2.2], vec![3.3, 4.4]];
+    /// let val = Some(&array_2d);
+    /// buffer.column_arr_opt("array_col", val)?;
+    ///
+    /// let no_val: Option<&Vec<Vec<f64>>> = None;
+    /// buffer.column_arr_opt("skipped_col", no_val)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[allow(private_bounds)]
+    pub fn column_arr_opt<'a, N, T, D>(
+        &mut self,
+        name: N,
+        value: Option<&T>,
+    ) -> crate::Result<&mut Self>
+    where
+        N: TryInto<ColumnName<'a>>,
+        T: NdArrayView<D>,
+        D: ArrayElement + ArrayElementSealed,
+        Error: From<N::Error>,
+    {
+        if let Some(v) = value {
+            self.column_arr(name, v)
+        } else {
+            Ok(self)
+        }
+    }
+
     /// Record a timestamp value for the given column.
     ///
     /// ```no_run
@@ -1262,6 +1554,43 @@ impl Buffer {
         self.output.extend_from_slice(printed.as_bytes());
         self.output.push(suffix);
         Ok(self)
+    }
+
+    /// Record a timestamp value for the given column if the value is `Some`.
+    /// If the value is `None`, this is a no-op and the column is skipped.
+    ///
+    /// This is a convenience wrapper around [`Self::column_ts`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use questdb::Result;
+    /// # use questdb::ingress::{Buffer, SenderBuilder};
+    /// use questdb::ingress::TimestampMicros;
+    /// # fn main() -> Result<()> {
+    /// # let mut sender = SenderBuilder::from_conf("https::addr=localhost:9000;")?.build()?;
+    /// # let mut buffer = sender.new_buffer();
+    /// # buffer.table("x")?;
+    /// let val = Some(TimestampMicros::now());
+    /// buffer.column_ts_opt("col_name", val)?;
+    ///
+    /// let no_val: Option<TimestampMicros> = None;
+    /// buffer.column_ts_opt("skipped_col", no_val)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn column_ts_opt<'a, N, T>(&mut self, name: N, value: Option<T>) -> crate::Result<&mut Self>
+    where
+        N: TryInto<ColumnName<'a>>,
+        T: TryInto<Timestamp>,
+        Error: From<N::Error>,
+        Error: From<T::Error>,
+    {
+        if let Some(v) = value {
+            self.column_ts(name, v)
+        } else {
+            Ok(self)
+        }
     }
 
     /// Complete the current row with the designated timestamp. After this call, you can

--- a/questdb-rs/src/ingress/buffer.rs
+++ b/questdb-rs/src/ingress/buffer.rs
@@ -871,7 +871,9 @@ impl Buffer {
     }
 
     /// Record a boolean value for the given column if the value is `Some`.
-    /// If the value is `None`, this is a no-op and the column is skipped.
+    /// If the value is `None`, this is a no-op and the column is skipped
+    /// entirely — it is **not** written as `false`. If you need an explicit
+    /// `false`, call [`Self::column_bool`] directly.
     ///
     /// This is a convenience wrapper around [`Self::column_bool`].
     ///

--- a/questdb-rs/src/ingress/buffer.rs
+++ b/questdb-rs/src/ingress/buffer.rs
@@ -214,15 +214,13 @@ impl<'a> TableName<'a> {
         let mut prev = '\0';
         for (index, c) in name.chars().enumerate() {
             match c {
-                '.' => {
-                    if index == 0 || index == name.len() - 1 || prev == '.' {
-                        return Err(error::fmt!(
-                            InvalidName,
-                            concat!("Bad string {:?}: ", "Found invalid dot `.` at position {}."),
-                            name,
-                            index
-                        ));
-                    }
+                '.' if (index == 0 || index == name.len() - 1 || prev == '.') => {
+                    return Err(error::fmt!(
+                        InvalidName,
+                        concat!("Bad string {:?}: ", "Found invalid dot `.` at position {}."),
+                        name,
+                        index
+                    ));
                 }
                 '?' | ',' | '\'' | '\"' | '\\' | '/' | ':' | ')' | '(' | '+' | '*' | '%' | '~'
                 | '\r' | '\n' | '\0' | '\u{0001}' | '\u{0002}' | '\u{0003}' | '\u{0004}'

--- a/questdb-rs/src/ingress/buffer.rs
+++ b/questdb-rs/src/ingress/buffer.rs
@@ -1269,7 +1269,7 @@ impl Buffer {
     /// (e.g., it requires Protocol Version 3 or higher).
     ///
     /// **Tip:** If you have an `Option<Decimal>`, use `.as_ref()` to pass it
-    /// without consuming the original string.
+    /// without consuming the original value.
     ///
     /// # Errors
     ///
@@ -1279,6 +1279,8 @@ impl Buffer {
     /// # Examples
     ///
     /// ```no_run
+    /// # #[cfg(feature = "bigdecimal")]
+    /// # {
     /// # use questdb::Result;
     /// # use questdb::ingress::{Buffer, SenderBuilder};
     /// use bigdecimal::BigDecimal;
@@ -1288,11 +1290,12 @@ impl Buffer {
     /// # let mut buffer = sender.new_buffer();
     /// # buffer.table("x")?;
     /// let val: Option<BigDecimal> = Some(BigDecimal::from_str("0.123456789012345678901234567890").unwrap());
-    /// buffer.column_dec_opt("col_name", val)?;
+    /// buffer.column_dec_opt("col_name", val.as_ref())?;
     ///
     /// let no_val: Option<BigDecimal> = None;
-    /// buffer.column_dec_opt("skipped_col", no_val)?;
+    /// buffer.column_dec_opt("skipped_col", no_val.as_ref())?;
     /// # Ok(())
+    /// # }
     /// # }
     /// ```
     pub fn column_dec_opt<'a, N, S>(
@@ -1448,12 +1451,11 @@ impl Buffer {
     /// # let mut sender = SenderBuilder::from_conf("https::addr=localhost:9000;")?.build()?;
     /// # let mut buffer = sender.new_buffer();
     /// # buffer.table("x")?;
-    /// let array_2d = vec![vec![1.1, 2.2], vec![3.3, 4.4]];
-    /// let val = Some(&array_2d);
-    /// buffer.column_arr_opt("array_col", val)?;
+    /// let val: Option<Vec<Vec<f64>>> = Some(vec![vec![1.1, 2.2], vec![3.3, 4.4]]);
+    /// buffer.column_arr_opt("array_col", val.as_ref())?;
     ///
-    /// let no_val: Option<&Vec<Vec<f64>>> = None;
-    /// buffer.column_arr_opt("skipped_col", no_val)?;
+    /// let no_val: Option<Vec<Vec<f64>>> = None;
+    /// buffer.column_arr_opt("skipped_col", no_val.as_ref())?;
     /// # Ok(())
     /// # }
     /// ```

--- a/questdb-rs/src/ingress/mod.md
+++ b/questdb-rs/src/ingress/mod.md
@@ -326,6 +326,45 @@ buffer.table(table_name)?.column_f64(price_name, 39269.98)?.at(TimestampNanos::n
 # }
 ```
 
+## Handling Optional Data (NULLs)
+
+In QuestDB, `NULL` values are represented by simply omitting the column for that specific row. 
+
+To make working with Rust's `Option<T>` ergonomic and keep the fluent builder chain unbroken, the [`Buffer`] API provides `_opt` variants for all column methods (e.g., [`column_str_opt`](Buffer::column_str_opt), [`column_f64_opt`](Buffer::column_f64_opt)). 
+
+If the provided value is `Some(v)`, the column is written normally. If the value is `None`, the method acts as a no-op and skips the column.
+
+**Note on ownership:** For types that implement `Copy` (like `i64`, `f64`, `bool`), you can pass the `Option` directly. For heap-allocated types like `String` or `Vec`, use `.as_ref()` or `.as_deref()` to pass a reference without consuming the original value.
+
+```rust no_run
+# use questdb::Result;
+use questdb::ingress::{Buffer, SenderBuilder, TimestampNanos};
+
+# fn main() -> Result<()> {
+  let mut sender = SenderBuilder::from_conf("https::addr=localhost:9000;")?.build()?;
+  let mut buffer = sender.new_buffer();
+  struct SensorData {
+      sensor_id: Option<String>,
+      temperature: Option<f64>,
+      humidity: Option<f64>,
+  }
+
+  let data = SensorData { sensor_id: Some("sensor-1".to_string()), temperature: Some(22.5), humidity: None };
+
+  buffer
+      .table("sensors")?
+      .symbol("location", "factory-1")?
+      // Writes the sensor_id column if it's Some, otherwise skips it (stored as NULL in QuestDB)
+      .symbol_opt("sensor_id", data.sensor_id.as_deref())?
+      // Writes the temperature column
+      .column_f64_opt("temperature", data.temperature)? 
+      // Silently skips the humidity column (stored as NULL in QuestDB)
+      .column_f64_opt("humidity", data.humidity)?       
+      .at(TimestampNanos::now())?;
+#   Ok(())
+# }
+```
+
 ## Decimal Datatype
 
 The [`Buffer::column_dec`](Buffer::column_dec) method supports efficient ingestion of decimal values using several convenient types:

--- a/questdb-rs/src/tests/buffer_opt.rs
+++ b/questdb-rs/src/tests/buffer_opt.rs
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2025 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+use std::f64::consts::PI;
+
+use crate::ingress::{Buffer, DecimalView, ProtocolVersion, TimestampMicros};
+use crate::tests::TestResult;
+use rstest::rstest;
+
+// ============================================================================
+// Buffer Option (_opt) integration tests
+// ============================================================================
+
+#[rstest]
+fn test_buffer_opt_some_matches_standard(
+    // We use V3 because it supports all datatypes, including arrays and decimals
+    #[values(ProtocolVersion::V3)] version: ProtocolVersion,
+) -> TestResult {
+    let mut opt_buf = Buffer::new(version);
+
+    // Shared data
+    let arr = vec![1.0f64, 2.0, 3.0];
+    // We MUST use a hardcoded timestamp, otherwise `.now()` might differ
+    // by a microsecond between the two buffer initializations, failing the test!
+    let ts = TimestampMicros::new(1659548204354448);
+
+    // 1. Build a buffer using ONLY our new `_opt` methods
+    opt_buf
+        .table("test")?
+        .symbol_opt("sym", Some("val"))?
+        .column_bool_opt("c_bool", Some(true))?
+        .column_i64_opt("c_i64", Some(42))?
+        .column_f64_opt("c_f64", Some(PI))?
+        .column_str_opt("c_str", Some("text"))?
+        .column_dec_opt("c_dec", Some(DecimalView::try_new_string("123.45")?))?
+        .column_arr_opt("c_arr", Some(&arr))?
+        .column_ts_opt("c_ts", Some(ts))?
+        .at_now()?;
+
+    // 2. Build a buffer using ONLY the standard methods
+    let mut std_buf = Buffer::new(version);
+    std_buf
+        .table("test")?
+        .symbol("sym", "val")?
+        .column_bool("c_bool", true)?
+        .column_i64("c_i64", 42)?
+        .column_f64("c_f64", PI)?
+        .column_str("c_str", "text")?
+        .column_dec("c_dec", DecimalView::try_new_string("123.45")?)?
+        .column_arr("c_arr", &arr)?
+        .column_ts("c_ts", ts)?
+        .at_now()?;
+
+    // 3. The raw binary output should be byte-for-byte identical.
+    // This perfectly tests strings, numbers, AND the complex V3 binary array/decimal formats.
+    assert_eq!(opt_buf.as_bytes(), std_buf.as_bytes());
+
+    Ok(())
+}
+
+#[rstest]
+fn test_buffer_opt_none_skips_columns(
+    #[values(ProtocolVersion::V3)] version: ProtocolVersion,
+) -> TestResult {
+    let mut buffer = Buffer::new(version);
+
+    // Explicitly typed None values to satisfy the compiler
+    let no_sym: Option<&str> = None;
+    let no_bool: Option<bool> = None;
+    let no_i64: Option<i64> = None;
+    let no_f64: Option<f64> = None;
+    let no_str: Option<&str> = None;
+    let no_dec: Option<DecimalView> = None;
+    let no_arr: Option<&Vec<f64>> = None; // Uses Vec to satisfy Sized bounds
+    let no_ts: Option<TimestampMicros> = None;
+
+    buffer
+        .table("test")?
+        .symbol_opt("sym", no_sym)?
+        .column_bool_opt("c_bool", no_bool)?
+        .column_i64_opt("c_i64", no_i64)?
+        .column_f64_opt("c_f64", no_f64)?
+        .column_str_opt("c_str", no_str)?
+        .column_dec_opt("c_dec", no_dec)?
+        .column_arr_opt("c_arr", no_arr)?
+        .column_ts_opt("c_ts", no_ts)?
+        // We MUST include at least one valid column to form a legal ILP row
+        .column_i64("always_there", 100)?
+        .at_now()?;
+
+    let output = std::str::from_utf8(buffer.as_bytes())?;
+
+    // Prove that NONE of the skipped columns appear in the final ILP string.
+    // Note the space after "test": In ILP, if there are no symbols, the separator
+    // between the table name and the first column is a space, not a comma.
+    assert_eq!(output, "test always_there=100i\n");
+
+    Ok(())
+}
+
+#[test]
+fn test_buffer_opt_array_some_binary_match() -> TestResult {
+    let arr = [1.0f64, 2.0, 3.0];
+
+    // Arrays require Protocol V2 or higher
+    let mut opt_buf = Buffer::new(ProtocolVersion::V2);
+    opt_buf.table("my_test")?;
+    opt_buf.column_arr_opt("temperature", Some(&arr))?;
+
+    let mut std_buf = Buffer::new(ProtocolVersion::V2);
+    std_buf.table("my_test")?;
+    std_buf.column_arr("temperature", &arr)?;
+
+    // We do a raw byte comparison here because Protocol V2 encodes arrays as binary
+    assert_eq!(opt_buf.as_bytes(), std_buf.as_bytes());
+
+    Ok(())
+}
+
+#[rstest]
+fn test_buffer_opt_decimal_some_matches_standard(
+    #[values(ProtocolVersion::V3)] version: ProtocolVersion, // Decimals require V3
+) -> TestResult {
+    let mut opt_buf = Buffer::new(version);
+    opt_buf
+        .table("test")?
+        .column_dec_opt("dec", Some("123.45"))?;
+
+    let mut std_buf = Buffer::new(version);
+    std_buf.table("test")?.column_dec("dec", "123.45")?;
+
+    assert_eq!(
+        std::str::from_utf8(opt_buf.as_bytes())?,
+        std::str::from_utf8(std_buf.as_bytes())?
+    );
+
+    Ok(())
+}

--- a/questdb-rs/src/tests/buffer_opt.rs
+++ b/questdb-rs/src/tests/buffer_opt.rs
@@ -139,23 +139,3 @@ fn test_buffer_opt_array_some_binary_match() -> TestResult {
 
     Ok(())
 }
-
-#[test]
-fn test_buffer_opt_decimal_some_matches_standard() -> TestResult {
-    // Decimals require V3.
-    let version = ProtocolVersion::V3;
-    let mut opt_buf = Buffer::new(version);
-    opt_buf
-        .table("test")?
-        .column_dec_opt("dec", Some("123.45"))?;
-
-    let mut std_buf = Buffer::new(version);
-    std_buf.table("test")?.column_dec("dec", "123.45")?;
-
-    assert_eq!(
-        std::str::from_utf8(opt_buf.as_bytes())?,
-        std::str::from_utf8(std_buf.as_bytes())?
-    );
-
-    Ok(())
-}

--- a/questdb-rs/src/tests/buffer_opt.rs
+++ b/questdb-rs/src/tests/buffer_opt.rs
@@ -32,11 +32,10 @@ use rstest::rstest;
 // Buffer Option (_opt) integration tests
 // ============================================================================
 
-#[rstest]
-fn test_buffer_opt_some_matches_standard(
-    // We use V3 because it supports all datatypes, including arrays and decimals
-    #[values(ProtocolVersion::V3)] version: ProtocolVersion,
-) -> TestResult {
+#[test]
+fn test_buffer_opt_some_matches_standard() -> TestResult {
+    // V3 is required to exercise every `_opt` method — decimals and arrays need it.
+    let version = ProtocolVersion::V3;
     let mut opt_buf = Buffer::new(version);
 
     // Shared data
@@ -81,7 +80,10 @@ fn test_buffer_opt_some_matches_standard(
 
 #[rstest]
 fn test_buffer_opt_none_skips_columns(
-    #[values(ProtocolVersion::V3)] version: ProtocolVersion,
+    // `_opt(None)` short-circuits before any version check, so the output
+    // should be identical across every protocol version.
+    #[values(ProtocolVersion::V1, ProtocolVersion::V2, ProtocolVersion::V3)]
+    version: ProtocolVersion,
 ) -> TestResult {
     let mut buffer = Buffer::new(version);
 
@@ -138,10 +140,10 @@ fn test_buffer_opt_array_some_binary_match() -> TestResult {
     Ok(())
 }
 
-#[rstest]
-fn test_buffer_opt_decimal_some_matches_standard(
-    #[values(ProtocolVersion::V3)] version: ProtocolVersion, // Decimals require V3
-) -> TestResult {
+#[test]
+fn test_buffer_opt_decimal_some_matches_standard() -> TestResult {
+    // Decimals require V3.
+    let version = ProtocolVersion::V3;
     let mut opt_buf = Buffer::new(version);
     opt_buf
         .table("test")?

--- a/questdb-rs/src/tests/mod.rs
+++ b/questdb-rs/src/tests/mod.rs
@@ -33,6 +33,8 @@ mod sender;
 mod decimal;
 mod ndarr;
 
+mod buffer_opt;
+
 #[cfg(feature = "json_tests")]
 mod json_tests {
     include!(concat!(env!("OUT_DIR"), "/json_tests.rs"));


### PR DESCRIPTION
Closes #133

This PR introduces native support for `Option<T>` in the `Buffer` builder API to drastically improve the developer experience when ingesting real-world data with nullable fields. 

### The Problem:
Previously, handling optional data forced users to break the ergonomic method chain:
```rust
buffer.table("trades")?.symbol("symbol", "BTC-USD")?;

if let Some(fee) = trade.maker_fee {
    buffer.column_f64("maker_fee", fee)?;
}
if let Some(order_id) = trade.order_id.as_deref() {
    buffer.column_str("order_id", order_id)?;
}

buffer.at_now()?;
```

### The Solution:
This PR adds `_opt` variants for all column types (`column_str_opt`, `column_f64_opt`, `column_arr_opt`, etc.). If the value is Some, it behaves exactly like the standard method. If None, it is a no-op, skipping the column perfectly in line with ILP standards.

```rust
buffer
    .table("trades")?
    .symbol("symbol", "BTC-USD")?
    .column_f64_opt("maker_fee", trade.maker_fee)?
    .column_str_opt("order_id", trade.order_id.as_deref())?
    .at_now()?;
```
    
### Changes made
Added `_opt` methods directly to `impl Buffer` using the exact same zero-cost generic constraints as their standard counterparts.

Added a new section to the module-level documentation (`# Usage Considerations`) explaining how to handle `NULL`s and how to correctly pass ownership of heap-allocated `Option` types (e.g., using `.as_deref()`).

Documented every new method using intra-doc links to avoid duplicating complex API constraints.

### Testing
As requested in the issue, a rigorous integration test suite was added in `tests/buffer_opt.rs`:

`test_buffer_opt_some_matches_standard`: Uses `ProtocolVersion::V3` to construct one buffer with the standard methods, and one buffer with the `_opt` methods wrapped in Some. Validates that the resulting binary byte arrays are 100% identical (covering Strings, Numbers, Decimals, and Arrays).

`test_buffer_opt_none_skips_columns`: Asserts that passing `None` results in valid ILP syntax where the columns are entirely omitted from the UTF-8 output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional-parameter buffer APIs so fields wrapped in Option<T> can be conditionally omitted while preserving fluent chaining.

* **Documentation**
  * Added a guide on representing NULLs and examples showing conditional column writing with optional parameters.

* **Tests**
  * Added tests ensuring optional-parameter behavior matches non-optional behavior for present values and correctly omits columns for None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->