### PR TITLE
chore(ci): replace windows-2019 image with windows-2025

### DIFF
--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -37,8 +37,8 @@ stages:
             windows-msvc-2022:
               imageName: "windows-2022"
               poolName: "Azure Pipelines"
-            windows-msvc-2019:
-              imageName: "windows-2019"
+            windows-msvc-2025:
+              imageName: "windows-2025"
               poolName: "Azure Pipelines"
         pool:
           name: $(poolName)


### PR DESCRIPTION
The windows-2019 image was removed on the 31st of December 2025, see  https://devblogs.microsoft.com/devops/upcoming-updates-for-azure-pipelines-agents-images/

As the result the CI was failing with `##[error]No image label found to route agent pool Azure Pipelines.` 

This PR replaces this image with windows-2025 which was missing. This means Windows test will run on windows-2022 and windows-2025.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows testing environment in the CI pipeline from MSVC 2019 to MSVC 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->