### PR TITLE
test(ingress): meta-test that every column-writing Buffer method has an `_opt` twin

### DIFF
--- a/questdb-rs/Cargo.toml
+++ b/questdb-rs/Cargo.toml
@@ -58,6 +58,7 @@ chrono = "0.4.31"
 tempfile = "3"
 webpki-roots = "1.0.1"
 rstest = "0.26.1"
+regex = "1"
 
 [features]
 default = ["sync-sender", "tls-webpki-certs", "ring-crypto"]

--- a/questdb-rs/src/tests/buffer_opt.rs
+++ b/questdb-rs/src/tests/buffer_opt.rs
@@ -152,10 +152,14 @@ fn test_every_column_writing_method_has_opt_variant() {
     // additions are caught too. The `[^{]*` segment in the writer regex
     // matches across newlines (it does not exclude `\n`), so it spans
     // multi-line `where` clauses without needing dotall.
+    //
+    // The `(?m)^\s*` anchor restricts matches to start at the indentation
+    // of an impl item, so a stray `pub fn ...` inside a `///` doc example
+    // can never be picked up.
     let src = include_str!("../ingress/buffer.rs");
 
-    let pub_fn = regex::Regex::new(r"pub fn (\w+)").unwrap();
-    let writer = regex::Regex::new(r"pub fn (\w+)[^{]*TryInto<ColumnName").unwrap();
+    let pub_fn = regex::Regex::new(r"(?m)^\s*pub fn (\w+)").unwrap();
+    let writer = regex::Regex::new(r"(?m)^\s*pub fn (\w+)[^{]*TryInto<ColumnName").unwrap();
 
     let all_pub_fns: std::collections::HashSet<&str> = pub_fn
         .captures_iter(src)

--- a/questdb-rs/src/tests/buffer_opt.rs
+++ b/questdb-rs/src/tests/buffer_opt.rs
@@ -139,3 +139,45 @@ fn test_buffer_opt_array_some_binary_match() -> TestResult {
 
     Ok(())
 }
+
+#[test]
+fn test_every_column_writing_method_has_opt_variant() {
+    // Meta-test: scan buffer.rs and assert every column-writing method has a
+    // matching `_opt` sibling. Catches the case where someone adds a new
+    // method like `uuid` (à la `symbol`) or `column_uuid` without the
+    // `_opt` companion.
+    //
+    // Column writers are identified by the `N: TryInto<ColumnName<'a>>` bound
+    // rather than by name prefix - so `symbol` and any future unprefixed
+    // additions are caught too. The `[^{]*` segment in the writer regex
+    // matches across newlines (it does not exclude `\n`), so it spans
+    // multi-line `where` clauses without needing dotall.
+    let src = include_str!("../ingress/buffer.rs");
+
+    let pub_fn = regex::Regex::new(r"pub fn (\w+)").unwrap();
+    let writer = regex::Regex::new(r"pub fn (\w+)[^{]*TryInto<ColumnName").unwrap();
+
+    let all_pub_fns: std::collections::HashSet<&str> = pub_fn
+        .captures_iter(src)
+        .map(|c| c.get(1).unwrap().as_str())
+        .collect();
+
+    let writers: Vec<&str> = writer
+        .captures_iter(src)
+        .map(|c| c.get(1).unwrap().as_str())
+        .collect();
+
+    // Guard against a wrong include_str! path silently passing the test.
+    assert!(!writers.is_empty(), "no column writers found — wrong path?");
+
+    let missing: Vec<&&str> = writers
+        .iter()
+        .filter(|n| !n.ends_with("_opt"))
+        .filter(|n| !all_pub_fns.contains(format!("{n}_opt").as_str()))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "Buffer column-writing methods missing `_opt` variants: {missing:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #134. Adds a meta-test in `tests/buffer_opt.rs` that scans `buffer.rs` and asserts every column-writing method has a matching `_opt` sibling.

Column writers are detected by the `N: TryInto<ColumnName<'a>>` generic bound rather than by a `column_*` name prefix — so `symbol` and any future unprefixed method (e.g. a hypothetical `uuid`) are also covered. If someone lands `column_uuid` or `uuid` without a `_opt` companion, the test fails with the missing names listed.

Two short regexes do the work; `[^{]*` matches across newlines so it spans multi-line `where` clauses without dotall. Adds `regex` to dev-dependencies (already pulled in transitively by other crates, so no new top-level dep at build time).

## Test plan

- [x] `cargo test --lib buffer_opt` — all 6 tests pass, including the new `test_every_column_writing_method_has_opt_variant`
- [x] Locally remove one `_opt` method from `buffer.rs` and confirm the test fails with that method name in the assertion message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added internal validation test to ensure API consistency across methods.

* **Chores**
  * Updated development dependencies for testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->