### PR TITLE
chore(ci): drop vi_egress from hourly fuzz schedule

### DIFF
--- a/ci/run_fuzz_pipeline.yaml
+++ b/ci/run_fuzz_pipeline.yaml
@@ -2,10 +2,10 @@ trigger: none
 
 pr: none
 
-# Hourly cron against the default branch (and active egress feature
-# branches), always run even if there were no changes since the previous
-# run. The Linux leg of the QWP/WS fuzz runs on the self-hosted
-# hetzner-incus pool (matching questdb/questdb's ci/test-fuzz.yml) — the
+# Hourly cron against the default branch, always run even if there were
+# no changes since the previous run. The Linux leg of the QWP/WS fuzz
+# runs on the self-hosted hetzner-incus pool (matching
+# questdb/questdb's ci/test-fuzz.yml) — the
 # Microsoft-hosted ubuntu-latest agents were hitting "Free disk space on /
 # is lower than 5%" and OOM-killing the test with SIGBUS mid-run. The
 # mac/windows legs stay on Microsoft-hosted images. The pure-Rust QWP
@@ -19,7 +19,6 @@ schedules:
     branches:
       include:
         - main
-        - vi_egress
     always: true
 
 stages:


### PR DESCRIPTION
## Summary
- The `vi_egress` egress feature branch has merged into `main` (#140), so the hourly scheduled fuzz pipeline (`ci/run_fuzz_pipeline.yaml`) no longer needs to watch it.
- Drops `vi_egress` from `schedules[].branches.include` and updates the file header comment so it no longer references "active egress feature branches".
- No change to the PR-time jobs in `ci/run_tests_pipeline.yaml` (those are policy-driven).

## Test plan
- [ ] Confirm the hourly cron next fires only against `main` (the schedule pane in Azure DevOps should no longer list a `vi_egress` run).
- [ ] Verify `#builds` Slack alerts still come through from the `main` run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the scheduled fuzzing pipeline configuration to run exclusively against the main branch, removing development branch filters. This streamlines automated testing efforts and improves pipeline efficiency by consolidating scheduled test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/questdb/c-questdb-client/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->