### PR TITLE
feat(ingress): handle X-QWP-Max-Batch-Size to prevent MESSAGE_TOO_BIG

### DIFF
--- a/questdb-rs/src/ingress/sender.rs
+++ b/questdb-rs/src/ingress/sender.rs
@@ -42,6 +42,8 @@ use crate::ingress::SenderBuilder;
 use crate::ingress::{Buffer, Protocol, ProtocolVersion};
 use std::fmt::{Debug, Formatter};
 #[cfg(feature = "sync-sender-qwp-ws")]
+use std::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(feature = "sync-sender-qwp-ws")]
 use std::time::{Duration, Instant};
 
 #[cfg(feature = "sync-sender-qwp-udp")]
@@ -105,6 +107,16 @@ mod http;
 
 #[cfg(feature = "sync-sender-http")]
 pub(crate) use http::*;
+
+#[cfg(feature = "sync-sender-qwp-ws")]
+fn effective_qwp_ws_max_buf_size(configured: usize, server_max: &AtomicUsize) -> usize {
+    let server = server_max.load(Ordering::Relaxed);
+    if server > 0 {
+        configured.min(server)
+    } else {
+        configured
+    }
+}
 
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum SyncProtocolHandler {
@@ -303,9 +315,15 @@ impl Sender {
         }
 
         let result = match &mut self.handler {
-            SyncProtocolHandler::SyncQwpWs(state) => flush_qwp_ws(state, qwp, self.max_buf_size),
+            SyncProtocolHandler::SyncQwpWs(state) => {
+                let max =
+                    effective_qwp_ws_max_buf_size(self.max_buf_size, &state.server_max_batch_size);
+                flush_qwp_ws(state, qwp, max)
+            }
             SyncProtocolHandler::ManualQwpWs(state) => {
-                flush_qwp_ws_manual(state, qwp, self.max_buf_size)
+                let max =
+                    effective_qwp_ws_max_buf_size(self.max_buf_size, &state.server_max_batch_size);
+                flush_qwp_ws_manual(state, qwp, max)
             }
             _ => unreachable!("QWP/WebSocket handler was checked above"),
         };

--- a/questdb-rs/src/ingress/sender/qwp_ws.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws.rs
@@ -29,7 +29,7 @@
 use std::collections::VecDeque;
 use std::io::{ErrorKind, Read, Write};
 use std::net::{SocketAddr, TcpStream};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, TryLockError};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -169,6 +169,7 @@ struct QwpWsConnectedParts {
 pub(crate) struct SyncQwpWsHandlerState {
     encoder: QwpWsReplayEncoder,
     runner: SyncQwpWsRunner,
+    pub(crate) server_max_batch_size: Arc<AtomicUsize>,
     orphan_pool: Option<OrphanDrainerPool>,
     close_drain_timeout: Duration,
 }
@@ -177,6 +178,7 @@ pub(crate) struct ManualQwpWsHandlerState {
     encoder: QwpWsReplayEncoder,
     store: QwpWsPublicationStore<SfaSlotQueue>,
     send_core: QwpWsSendCore<BlockingQwpWsTransport>,
+    pub(crate) server_max_batch_size: Arc<AtomicUsize>,
     orphan_drainers: Option<ManualOrphanDrainers>,
     append_deadline: Duration,
     close_drain_timeout: Duration,
@@ -208,7 +210,6 @@ struct SyncQwpWsPendingRunnerCore {
     lifecycle: PublicationLifecycle,
 }
 
-#[derive(Clone)]
 struct QwpWsPendingConnect {
     host: String,
     port: String,
@@ -219,6 +220,7 @@ struct QwpWsPendingConnect {
     reconnect_policy: ReconnectPolicy,
     max_in_flight: usize,
     durable_ack: bool,
+    server_max_batch_size: Arc<AtomicUsize>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -595,6 +597,7 @@ impl QwpWsPendingConnect {
         auth_header: Option<String>,
         max_in_flight: usize,
         durable_ack: bool,
+        server_max_batch_size: Arc<AtomicUsize>,
     ) -> Self {
         Self {
             host: host.to_string(),
@@ -610,6 +613,7 @@ impl QwpWsPendingConnect {
             ),
             max_in_flight,
             durable_ack,
+            server_max_batch_size,
         }
     }
 
@@ -647,6 +651,7 @@ impl QwpWsPendingConnect {
                         self.tls_settings.clone(),
                         self.qwp_ws.clone(),
                         self.auth_header.clone(),
+                        Arc::clone(&self.server_max_batch_size),
                         connected,
                     )));
                 }
@@ -2030,12 +2035,12 @@ pub(crate) fn perform_upgrade<S: Read + Write>(
     let extras = codec::qwp_extra_headers(auth_header, max_version, client_id, request_durable_ack);
     let handshake = crate::ws::handshake::upgrade(stream, host_header, codec::WS_PATH, &extras)
         .map_err(codec::handshake_error_to_ingress)?;
-    let version = codec::validate_qwp_handshake_headers(
+    let result = codec::validate_qwp_handshake_headers(
         &handshake.headers,
         max_version,
         request_durable_ack,
     )?;
-    Ok((version, handshake.leftover))
+    Ok((result.version, handshake.leftover))
 }
 
 // ---------- connect ----------
@@ -2257,6 +2262,7 @@ pub(super) struct QwpWsConnectRoundSuccess {
     pub(super) endpoint_idx: usize,
     pub(super) stream: WsStream,
     pub(super) negotiated_version: u8,
+    pub(super) server_max_batch_size: usize,
     pub(super) leftover: Vec<u8>,
 }
 
@@ -2318,7 +2324,7 @@ pub(crate) fn establish_connection(
     tls_settings: Option<TlsSettings>,
     qwp_ws: &QwpWsConfig,
     auth_header: Option<&str>,
-) -> crate::Result<(WsStream, u8, Vec<u8>)> {
+) -> crate::Result<(WsStream, codec::QwpWsHandshakeResult, Vec<u8>)> {
     let auth_timeout = *qwp_ws.auth_timeout;
     let request_timeout = *qwp_ws.request_timeout;
 
@@ -2334,7 +2340,7 @@ pub(crate) fn establish_connection(
     let client_id = qwp_ws.client_id.as_deref();
     let request_durable_ack = *qwp_ws.request_durable_ack;
 
-    let (stream, negotiated_version, leftover) = if use_tls {
+    let (stream, handshake_result, leftover) = if use_tls {
         let tls = tls_settings.ok_or_else(|| {
             error::fmt!(ConfigError, "TLS settings missing for QWP/WebSocket Secure")
         })?;
@@ -2372,7 +2378,7 @@ pub(crate) fn establish_connection(
         let handshake =
             crate::ws::handshake::upgrade(&mut tls_stream, &host_header, codec::WS_PATH, &extras)
                 .map_err(codec::handshake_error_to_ingress)?;
-        let negotiated_version = codec::validate_qwp_handshake_headers(
+        let handshake_result = codec::validate_qwp_handshake_headers(
             &handshake.headers,
             max_version,
             request_durable_ack,
@@ -2380,7 +2386,7 @@ pub(crate) fn establish_connection(
         let leftover = handshake.leftover;
         (
             WsStream::Tls(Box::new(tls_stream)),
-            negotiated_version,
+            handshake_result,
             leftover,
         )
     } else {
@@ -2391,20 +2397,20 @@ pub(crate) fn establish_connection(
         let handshake =
             crate::ws::handshake::upgrade(&mut plain_stream, &host_header, codec::WS_PATH, &extras)
                 .map_err(codec::handshake_error_to_ingress)?;
-        let negotiated_version = codec::validate_qwp_handshake_headers(
+        let handshake_result = codec::validate_qwp_handshake_headers(
             &handshake.headers,
             max_version,
             request_durable_ack,
         )?;
         let leftover = handshake.leftover;
-        (WsStream::Plain(plain_stream), negotiated_version, leftover)
+        (WsStream::Plain(plain_stream), handshake_result, leftover)
     };
 
     stream
         .set_timeouts(Some(request_timeout), Some(request_timeout))
         .ok();
 
-    Ok((stream, negotiated_version, leftover))
+    Ok((stream, handshake_result, leftover))
 }
 
 pub(super) fn connect_qwp_ws_endpoint_round(
@@ -2439,13 +2445,14 @@ pub(super) fn connect_qwp_ws_endpoint_round(
             qwp_ws,
             auth_header,
         ) {
-            Ok((stream, negotiated_version, leftover)) => {
+            Ok((stream, handshake_result, leftover)) => {
                 tracker.record_success(idx);
                 *previous_idx = Some(idx);
                 return Ok(QwpWsConnectRoundSuccess {
                     endpoint_idx: idx,
                     stream,
-                    negotiated_version,
+                    negotiated_version: handshake_result.version,
+                    server_max_batch_size: handshake_result.server_max_batch_size,
                     leftover,
                 });
             }
@@ -2527,6 +2534,7 @@ pub(crate) fn connect_qwp_ws(
         qwp_ws,
         auth_header.clone(),
     );
+    let server_max_batch_size = Arc::new(AtomicUsize::new(0));
     let (runner, encoder) = if *qwp_ws.initial_connect_retry == QwpWsInitialConnectMode::Async {
         let queue = open_configured_qwp_ws_queue(qwp_ws)?;
         let pending_connect = QwpWsPendingConnect::new(
@@ -2538,6 +2546,7 @@ pub(crate) fn connect_qwp_ws(
             auth_header,
             queue.max_in_flight(),
             *qwp_ws.request_durable_ack,
+            Arc::clone(&server_max_batch_size),
         );
         (
             SyncQwpWsRunner::start_pending_connect(
@@ -2549,7 +2558,15 @@ pub(crate) fn connect_qwp_ws(
             QwpWsReplayEncoder::new(1),
         )
     } else {
-        let parts = open_qwp_ws_parts(host, port, use_tls, tls_settings, qwp_ws, auth_header)?;
+        let parts = open_qwp_ws_parts(
+            host,
+            port,
+            use_tls,
+            tls_settings,
+            qwp_ws,
+            auth_header,
+            Arc::clone(&server_max_batch_size),
+        )?;
         (
             SyncQwpWsRunner::start_with_append_deadline(
                 parts.store,
@@ -2570,6 +2587,7 @@ pub(crate) fn connect_qwp_ws(
         SyncQwpWsHandlerState {
             encoder,
             runner,
+            server_max_batch_size,
             orphan_pool,
             close_drain_timeout: *qwp_ws.close_flush_timeout,
         },
@@ -2603,7 +2621,16 @@ pub(crate) fn open_manual_qwp_ws(
         qwp_ws,
         auth_header.clone(),
     );
-    let parts = open_qwp_ws_parts(host, port, use_tls, tls_settings, qwp_ws, auth_header)?;
+    let server_max_batch_size = Arc::new(AtomicUsize::new(0));
+    let parts = open_qwp_ws_parts(
+        host,
+        port,
+        use_tls,
+        tls_settings,
+        qwp_ws,
+        auth_header,
+        Arc::clone(&server_max_batch_size),
+    )?;
     let orphan_drainers = ManualOrphanDrainers::new(
         orphan_candidates(qwp_ws),
         *qwp_ws.max_background_drainers,
@@ -2613,6 +2640,7 @@ pub(crate) fn open_manual_qwp_ws(
         encoder: parts.encoder,
         store: parts.store,
         send_core: parts.send_core,
+        server_max_batch_size,
         orphan_drainers,
         append_deadline: *qwp_ws.sf_append_deadline,
         close_drain_timeout: *qwp_ws.close_flush_timeout,
@@ -2627,10 +2655,18 @@ fn open_qwp_ws_parts(
     tls_settings: Option<TlsSettings>,
     qwp_ws: &QwpWsConfig,
     auth_header: Option<String>,
+    server_max_batch_size: Arc<AtomicUsize>,
 ) -> crate::Result<QwpWsConnectedParts> {
     let queue = open_configured_qwp_ws_queue(qwp_ws)?;
-    let transport =
-        connect_blocking_transport(host, port, use_tls, tls_settings, qwp_ws, auth_header)?;
+    let transport = connect_blocking_transport(
+        host,
+        port,
+        use_tls,
+        tls_settings,
+        qwp_ws,
+        auth_header,
+        Arc::clone(&server_max_batch_size),
+    )?;
     let negotiated_version = transport.negotiated_version();
     let max_in_flight = queue.max_in_flight();
     let store = QwpWsPublicationStore::new(queue, *qwp_ws.error_inbox_capacity);
@@ -2659,6 +2695,7 @@ fn connect_blocking_transport(
     tls_settings: Option<TlsSettings>,
     qwp_ws: &QwpWsConfig,
     auth_header: Option<String>,
+    server_max_batch_size: Arc<AtomicUsize>,
 ) -> crate::Result<BlockingQwpWsTransport> {
     match *qwp_ws.initial_connect_retry {
         QwpWsInitialConnectMode::Off => BlockingQwpWsTransport::connect(
@@ -2668,6 +2705,7 @@ fn connect_blocking_transport(
             tls_settings,
             qwp_ws.clone(),
             auth_header,
+            server_max_batch_size,
         ),
         QwpWsInitialConnectMode::Sync | QwpWsInitialConnectMode::Async => {
             connect_blocking_transport_with_retry(
@@ -2677,6 +2715,7 @@ fn connect_blocking_transport(
                 tls_settings,
                 qwp_ws,
                 auth_header,
+                server_max_batch_size,
             )
         }
     }
@@ -2689,6 +2728,7 @@ fn connect_blocking_transport_with_retry(
     tls_settings: Option<TlsSettings>,
     qwp_ws: &QwpWsConfig,
     auth_header: Option<String>,
+    server_max_batch_size: Arc<AtomicUsize>,
 ) -> crate::Result<BlockingQwpWsTransport> {
     let started = Instant::now();
     let deadline = started.checked_add(*qwp_ws.reconnect_max_duration);
@@ -2718,6 +2758,7 @@ fn connect_blocking_transport_with_retry(
                     tls_settings,
                     qwp_ws.clone(),
                     auth_header,
+                    server_max_batch_size,
                     connected,
                 ));
             }
@@ -3505,10 +3546,10 @@ mod tests {
         let handshake =
             crate::ws::handshake::upgrade(&mut stream, "localhost:9000", codec::WS_PATH, &extras)
                 .unwrap();
-        let version = codec::validate_qwp_handshake_headers(&handshake.headers, 1, false).unwrap();
+        let result = codec::validate_qwp_handshake_headers(&handshake.headers, 1, false).unwrap();
         let leftover = handshake.leftover;
 
-        assert_eq!(version, 1);
+        assert_eq!(result.version, 1);
         let mut reader = WsFrameReader::with_initial_input(leftover);
         let mut written = Vec::new();
         let mut scratch = Vec::new();

--- a/questdb-rs/src/ingress/sender/qwp_ws_codec.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws_codec.rs
@@ -112,16 +112,28 @@ pub(super) fn qwp_extra_headers(
 
 // ---------- HTTP response validation (post-shared-handshake) ----------
 
+/// Validated QWP handshake result extracted from the server's 101 response.
+#[derive(Debug)]
+pub(crate) struct QwpWsHandshakeResult {
+    /// Negotiated protocol version.
+    pub(super) version: u8,
+    /// Server's effective per-message payload cap in bytes, from
+    /// `X-QWP-Max-Batch-Size`. `0` when the server did not advertise the
+    /// header (older builds); callers fall back to their locally configured
+    /// byte budget.
+    pub(super) server_max_batch_size: usize,
+}
+
 /// QWP-specific post-validation on a successful 101 response. Returns the
 /// negotiated protocol version (defaults to 1 when the server omits
-/// X-QWP-Version, matching the spec). Errors when the server returns an
-/// out-of-range version or fails to echo `X-QWP-Durable-Ack: enabled`
-/// after the client requested it.
+/// X-QWP-Version, matching the spec) and the server-advertised max batch
+/// size. Errors when the server returns an out-of-range version or fails
+/// to echo `X-QWP-Durable-Ack: enabled` after the client requested it.
 pub(super) fn validate_qwp_handshake_headers(
     headers: &crate::ws::handshake::Headers,
     max_version: u32,
     request_durable_ack: bool,
-) -> crate::Result<u8> {
+) -> crate::Result<QwpWsHandshakeResult> {
     let version: u8 = match headers.find_ci("x-qwp-version") {
         Some(v) => v.parse().map_err(|_| {
             error::fmt!(
@@ -157,7 +169,24 @@ pub(super) fn validate_qwp_handshake_headers(
             ));
         }
     }
-    Ok(version)
+
+    let server_max_batch_size = extract_server_max_batch_size(headers);
+
+    Ok(QwpWsHandshakeResult {
+        version,
+        server_max_batch_size,
+    })
+}
+
+/// Parse `X-QWP-Max-Batch-Size` from the 101 upgrade response. Returns 0
+/// when the header is absent, malformed, or negative (older servers, or a
+/// server bug). Mirrors the Java reference implementation's
+/// `extractMaxBatchSize`.
+fn extract_server_max_batch_size(headers: &crate::ws::handshake::Headers) -> usize {
+    headers
+        .find_ci("x-qwp-max-batch-size")
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(0)
 }
 
 /// Map a non-101 HTTP response (from
@@ -537,7 +566,9 @@ mod tests {
     fn validate_qwp_handshake_headers_negotiates_version() {
         let headers = Headers::from_pairs([("X-QWP-Version", "1")]);
         assert_eq!(
-            validate_qwp_handshake_headers(&headers, 1, false).unwrap(),
+            validate_qwp_handshake_headers(&headers, 1, false)
+                .unwrap()
+                .version,
             1
         );
     }
@@ -582,7 +613,9 @@ mod tests {
     fn validate_qwp_handshake_headers_defaults_to_v1_when_missing() {
         let headers = Headers::default();
         assert_eq!(
-            validate_qwp_handshake_headers(&headers, 1, false).unwrap(),
+            validate_qwp_handshake_headers(&headers, 1, false)
+                .unwrap()
+                .version,
             1
         );
     }
@@ -601,7 +634,9 @@ mod tests {
         let headers =
             Headers::from_pairs([("X-QWP-Version", "1"), ("X-QWP-Durable-Ack", "enabled")]);
         assert_eq!(
-            validate_qwp_handshake_headers(&headers, 1, true).unwrap(),
+            validate_qwp_handshake_headers(&headers, 1, true)
+                .unwrap()
+                .version,
             1
         );
     }
@@ -610,9 +645,54 @@ mod tests {
     fn validate_qwp_handshake_headers_allows_missing_durable_ack_by_default() {
         let headers = Headers::from_pairs([("X-QWP-Version", "1")]);
         assert_eq!(
-            validate_qwp_handshake_headers(&headers, 1, false).unwrap(),
+            validate_qwp_handshake_headers(&headers, 1, false)
+                .unwrap()
+                .version,
             1
         );
+    }
+
+    #[test]
+    fn extract_server_max_batch_size_absent_returns_zero() {
+        let headers = Headers::from_pairs([("X-QWP-Version", "1")]);
+        let result = validate_qwp_handshake_headers(&headers, 1, false).unwrap();
+        assert_eq!(result.server_max_batch_size, 0);
+    }
+
+    #[test]
+    fn extract_server_max_batch_size_parses_valid_value() {
+        let headers =
+            Headers::from_pairs([("X-QWP-Version", "1"), ("X-QWP-Max-Batch-Size", "16777202")]);
+        let result = validate_qwp_handshake_headers(&headers, 1, false).unwrap();
+        assert_eq!(result.server_max_batch_size, 16_777_202);
+    }
+
+    #[test]
+    fn extract_server_max_batch_size_malformed_returns_zero() {
+        let headers = Headers::from_pairs([
+            ("X-QWP-Version", "1"),
+            ("X-QWP-Max-Batch-Size", "not-a-number"),
+        ]);
+        let result = validate_qwp_handshake_headers(&headers, 1, false).unwrap();
+        assert_eq!(result.server_max_batch_size, 0);
+    }
+
+    #[test]
+    fn extract_server_max_batch_size_negative_returns_zero() {
+        let headers =
+            Headers::from_pairs([("X-QWP-Version", "1"), ("X-QWP-Max-Batch-Size", "-100")]);
+        let result = validate_qwp_handshake_headers(&headers, 1, false).unwrap();
+        assert_eq!(result.server_max_batch_size, 0);
+    }
+
+    #[test]
+    fn extract_server_max_batch_size_trims_whitespace() {
+        let headers = Headers::from_pairs([
+            ("X-QWP-Version", "1"),
+            ("X-QWP-Max-Batch-Size", " 2097138 "),
+        ]);
+        let result = validate_qwp_handshake_headers(&headers, 1, false).unwrap();
+        assert_eq!(result.server_max_batch_size, 2_097_138);
     }
 
     #[test]

--- a/questdb-rs/src/ingress/sender/qwp_ws_driver.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws_driver.rs
@@ -34,7 +34,7 @@ use std::collections::{HashMap, VecDeque};
 #[cfg(feature = "sync-sender-qwp-ws")]
 use std::io::Write;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 #[cfg(feature = "sync-sender-qwp-ws")]
@@ -2123,6 +2123,7 @@ pub(crate) struct BlockingQwpWsTransport {
     qwp_ws: QwpWsConfig,
     auth_header: Option<String>,
     negotiated_version: u8,
+    server_max_batch_size: Arc<AtomicUsize>,
     stream: WsStream,
     reader: WsFrameReader,
     send_buf: Vec<u8>,
@@ -2139,6 +2140,7 @@ impl BlockingQwpWsTransport {
         tls_settings: Option<TlsSettings>,
         qwp_ws: QwpWsConfig,
         auth_header: Option<String>,
+        server_max_batch_size: Arc<AtomicUsize>,
     ) -> crate::Result<Self> {
         let host = host.into();
         let port = port.into();
@@ -2161,10 +2163,12 @@ impl BlockingQwpWsTransport {
             tls_settings,
             qwp_ws,
             auth_header,
+            server_max_batch_size,
             connected,
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn from_connected(
         endpoints: Arc<[QwpWsEndpoint]>,
         tracker: QwpWsHostHealthTracker,
@@ -2172,8 +2176,10 @@ impl BlockingQwpWsTransport {
         tls_settings: Option<TlsSettings>,
         qwp_ws: QwpWsConfig,
         auth_header: Option<String>,
+        server_max_batch_size: Arc<AtomicUsize>,
         connected: QwpWsConnectRoundSuccess,
     ) -> Self {
+        server_max_batch_size.store(connected.server_max_batch_size, Ordering::Relaxed);
         Self {
             endpoints,
             previous_idx: Some(connected.endpoint_idx),
@@ -2183,6 +2189,7 @@ impl BlockingQwpWsTransport {
             qwp_ws,
             auth_header,
             negotiated_version: connected.negotiated_version,
+            server_max_batch_size,
             stream: connected.stream,
             reader: WsFrameReader::with_initial_input(connected.leftover),
             send_buf: Vec::with_capacity(16 * 1024),
@@ -2209,6 +2216,8 @@ impl BlockingQwpWsTransport {
         self.previous_idx = Some(connected.endpoint_idx);
         self.stream = connected.stream;
         self.negotiated_version = connected.negotiated_version;
+        self.server_max_batch_size
+            .store(connected.server_max_batch_size, Ordering::Relaxed);
         self.reader = WsFrameReader::with_initial_input(connected.leftover);
         self.send_buf.clear();
         self.pending_wire_sequences.clear();

--- a/questdb-rs/src/ingress/sender/qwp_ws_orphan.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws_orphan.rs
@@ -30,7 +30,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 #[cfg(feature = "sync-sender-qwp-ws")]
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 #[cfg(feature = "sync-sender-qwp-ws")]
 use std::sync::{Arc, Mutex};
 #[cfg(feature = "sync-sender-qwp-ws")]
@@ -413,6 +413,7 @@ impl OrphanDrainer {
             config.tls_settings.clone(),
             config.qwp_ws.clone(),
             config.auth_header.clone(),
+            Arc::new(AtomicUsize::new(0)),
         ) {
             Ok(transport) => transport,
             Err(err) => {

--- a/questdb-rs/src/tests/qwp_ws.rs
+++ b/questdb-rs/src/tests/qwp_ws.rs
@@ -4182,3 +4182,337 @@ fn qwp_ws_from_conf_parses_java_reconnect_keys() {
         err.msg()
     );
 }
+
+// ---------- X-QWP-Max-Batch-Size handling ----------
+
+fn upgrade_mock_stream_with_max_batch_size(
+    stream: &mut TcpStream,
+    max_batch_size: Option<usize>,
+) -> Vec<String> {
+    let req_bytes = read_request_until_blank(stream).unwrap();
+    let req = String::from_utf8_lossy(&req_bytes).to_string();
+    let request_lines: Vec<String> = req
+        .split("\r\n")
+        .take_while(|l| !l.is_empty())
+        .map(String::from)
+        .collect();
+    let key = parse_header(&req, "Sec-WebSocket-Key").expect("missing Sec-WebSocket-Key");
+    let accept = compute_accept(&key);
+    let batch_size_header = match max_batch_size {
+        Some(n) => format!("X-QWP-Max-Batch-Size: {n}\r\n"),
+        None => String::new(),
+    };
+    let response = format!(
+        "HTTP/1.1 101 Switching Protocols\r\n\
+         Upgrade: websocket\r\n\
+         Connection: Upgrade\r\n\
+         Sec-WebSocket-Accept: {accept}\r\n\
+         X-QWP-Version: 1\r\n\
+         {batch_size_header}\
+         \r\n"
+    );
+    stream.write_all(response.as_bytes()).unwrap();
+    request_lines
+}
+
+fn spawn_max_batch_size_server(max_batch_size: Option<usize>) -> (u16, mpsc::Receiver<MockResult>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let request_lines = upgrade_mock_stream_with_max_batch_size(&mut stream, max_batch_size);
+        let mut received_frames = Vec::new();
+        let (_fin, _opcode, payload) = read_frame(&mut stream).unwrap();
+        received_frames.push(payload);
+        write_qwp_ok_response(&mut stream, FIRST_WIRE_SEQUENCE).unwrap();
+        let _ = tx.send(MockResult {
+            request_lines,
+            received_frames,
+        });
+        thread::sleep(Duration::from_millis(50));
+    });
+    (port, rx)
+}
+
+fn spawn_max_batch_size_upgrade_only_server(max_batch_size: Option<usize>) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        upgrade_mock_stream_with_max_batch_size(&mut stream, max_batch_size);
+        thread::sleep(Duration::from_millis(200));
+    });
+    port
+}
+
+fn build_buffer_with_payload_bytes(target_encoded_len: usize) -> Buffer {
+    let mut buf = Buffer::qwp_ws_with_max_name_len(127);
+    buf.table("t").unwrap();
+    let col_name = "v";
+    let value_len = target_encoded_len;
+    let big_value: String = "x".repeat(value_len);
+    buf.column_str(col_name, big_value.as_str())
+        .unwrap()
+        .at_now()
+        .unwrap();
+    buf
+}
+
+#[test]
+fn server_max_batch_size_clamps_flush_below_configured_max_in_all_progress_modes() {
+    for progress in [ProgressCase::Background, ProgressCase::Manual] {
+        let server_cap: usize = 512;
+        let port = spawn_max_batch_size_upgrade_only_server(Some(server_cap));
+        let builder = SenderBuilder::new(Protocol::QwpWs, "127.0.0.1", port)
+            .max_buf_size(100 * 1024 * 1024)
+            .unwrap();
+        let mut sender = build_qwp_ws_sender_from_builder(progress, builder);
+
+        let mut buf = build_buffer_with_payload_bytes(server_cap + 200);
+        let encoded_len = qwp_ws_replay_encoded_len(&buf);
+        assert!(
+            encoded_len > server_cap,
+            "mode={}: encoded_len={encoded_len} must exceed server_cap={server_cap}",
+            progress.name()
+        );
+
+        let err = sender.flush(&mut buf).unwrap_err();
+        assert_eq!(
+            err.code(),
+            crate::ErrorCode::InvalidApiCall,
+            "mode={}",
+            progress.name()
+        );
+        assert!(
+            err.msg()
+                .contains("exceeds maximum configured allowed size"),
+            "mode={}: got: {}",
+            progress.name(),
+            err.msg()
+        );
+        assert!(
+            err.msg().contains(&server_cap.to_string()),
+            "mode={}: error should reference server cap {server_cap}, got: {}",
+            progress.name(),
+            err.msg()
+        );
+    }
+}
+
+#[test]
+fn server_max_batch_size_allows_flush_when_encoded_fits_in_all_progress_modes() {
+    for progress in [ProgressCase::Background, ProgressCase::Manual] {
+        let server_cap: usize = 100 * 1024;
+        let (port, rx) = spawn_max_batch_size_server(Some(server_cap));
+        let builder = SenderBuilder::new(Protocol::QwpWs, "127.0.0.1", port)
+            .max_buf_size(100 * 1024 * 1024)
+            .unwrap();
+        let mut sender = build_qwp_ws_sender_from_builder(progress, builder);
+
+        let mut buf = Buffer::qwp_ws_with_max_name_len(127);
+        buf.table("t")
+            .unwrap()
+            .column_i64("v", 42)
+            .unwrap()
+            .at_now()
+            .unwrap();
+        let encoded_len = qwp_ws_replay_encoded_len(&buf);
+        assert!(
+            encoded_len < server_cap,
+            "mode={}: encoded_len={encoded_len} must be under server_cap={server_cap}",
+            progress.name()
+        );
+
+        sender.flush(&mut buf).unwrap();
+        if progress == ProgressCase::Manual {
+            assert!(sender.drive_once().unwrap());
+        }
+        let result = rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(result.received_frames.len(), 1, "mode={}", progress.name());
+    }
+}
+
+#[test]
+fn absent_server_max_batch_size_falls_back_to_configured_max_in_all_progress_modes() {
+    for progress in [ProgressCase::Background, ProgressCase::Manual] {
+        let configured_max: usize = 1024;
+        let port = spawn_max_batch_size_upgrade_only_server(None);
+        let builder = SenderBuilder::new(Protocol::QwpWs, "127.0.0.1", port)
+            .max_buf_size(configured_max)
+            .unwrap();
+        let mut sender = build_qwp_ws_sender_from_builder(progress, builder);
+
+        let mut buf = build_buffer_with_payload_bytes(configured_max + 200);
+        let encoded_len = qwp_ws_replay_encoded_len(&buf);
+        assert!(
+            encoded_len > configured_max,
+            "mode={}: encoded_len={encoded_len} must exceed configured_max={configured_max}",
+            progress.name()
+        );
+
+        let err = sender.flush(&mut buf).unwrap_err();
+        assert_eq!(
+            err.code(),
+            crate::ErrorCode::InvalidApiCall,
+            "mode={}",
+            progress.name()
+        );
+        assert!(
+            err.msg().contains(&configured_max.to_string()),
+            "mode={}: error should reference configured max {configured_max}, got: {}",
+            progress.name(),
+            err.msg()
+        );
+    }
+}
+
+#[test]
+fn configured_max_wins_when_smaller_than_server_cap_in_all_progress_modes() {
+    for progress in [ProgressCase::Background, ProgressCase::Manual] {
+        let configured_max: usize = 1024;
+        let server_cap: usize = 16 * 1024 * 1024;
+        let port = spawn_max_batch_size_upgrade_only_server(Some(server_cap));
+        let builder = SenderBuilder::new(Protocol::QwpWs, "127.0.0.1", port)
+            .max_buf_size(configured_max)
+            .unwrap();
+        let mut sender = build_qwp_ws_sender_from_builder(progress, builder);
+
+        let mut buf = build_buffer_with_payload_bytes(configured_max + 200);
+        let encoded_len = qwp_ws_replay_encoded_len(&buf);
+        assert!(
+            encoded_len > configured_max,
+            "mode={}: encoded_len={encoded_len} must exceed configured_max={configured_max}",
+            progress.name()
+        );
+        assert!(
+            encoded_len < server_cap,
+            "mode={}: encoded_len={encoded_len} must be under server_cap={server_cap}",
+            progress.name()
+        );
+
+        let err = sender.flush(&mut buf).unwrap_err();
+        assert_eq!(
+            err.code(),
+            crate::ErrorCode::InvalidApiCall,
+            "mode={}",
+            progress.name()
+        );
+        assert!(
+            err.msg().contains(&configured_max.to_string()),
+            "mode={}: error should reference configured max {configured_max}, got: {}",
+            progress.name(),
+            err.msg()
+        );
+    }
+}
+
+#[test]
+fn server_cap_prevents_message_too_big_by_rejecting_locally_in_all_progress_modes() {
+    for progress in [ProgressCase::Background, ProgressCase::Manual] {
+        let server_cap: usize = 2048;
+        let (port, _rx) = spawn_max_batch_size_server(Some(server_cap));
+        let builder = SenderBuilder::new(Protocol::QwpWs, "127.0.0.1", port)
+            .max_buf_size(100 * 1024 * 1024)
+            .unwrap();
+        let mut sender = build_qwp_ws_sender_from_builder(progress, builder);
+
+        let mut small_buf = Buffer::qwp_ws_with_max_name_len(127);
+        small_buf
+            .table("t")
+            .unwrap()
+            .column_i64("v", 1)
+            .unwrap()
+            .at_now()
+            .unwrap();
+        sender.flush(&mut small_buf).unwrap();
+        if progress == ProgressCase::Manual {
+            assert!(sender.drive_once().unwrap());
+        }
+
+        let mut big_buf = build_buffer_with_payload_bytes(server_cap + 500);
+        let encoded_len = qwp_ws_replay_encoded_len(&big_buf);
+        assert!(
+            encoded_len > server_cap,
+            "mode={}: encoded_len={encoded_len} must exceed server_cap={server_cap}",
+            progress.name()
+        );
+
+        let err = sender.flush(&mut big_buf).unwrap_err();
+        assert_eq!(
+            err.code(),
+            crate::ErrorCode::InvalidApiCall,
+            "mode={}: must get local InvalidApiCall, not a server error",
+            progress.name()
+        );
+    }
+}
+
+#[test]
+fn server_cap_at_exact_boundary_allows_flush_in_all_progress_modes() {
+    for progress in [ProgressCase::Background, ProgressCase::Manual] {
+        let mut buf = Buffer::qwp_ws_with_max_name_len(127);
+        buf.table("t")
+            .unwrap()
+            .column_i64("v", 42)
+            .unwrap()
+            .at_now()
+            .unwrap();
+        let encoded_len = qwp_ws_replay_encoded_len(&buf);
+
+        let server_cap = encoded_len;
+        let (port, rx) = spawn_max_batch_size_server(Some(server_cap));
+        let builder = SenderBuilder::new(Protocol::QwpWs, "127.0.0.1", port)
+            .max_buf_size(100 * 1024 * 1024)
+            .unwrap();
+        let mut sender = build_qwp_ws_sender_from_builder(progress, builder);
+
+        sender.flush(&mut buf).unwrap();
+        if progress == ProgressCase::Manual {
+            assert!(sender.drive_once().unwrap());
+        }
+        let result = rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(result.received_frames.len(), 1, "mode={}", progress.name());
+        assert_eq!(
+            result.received_frames[0].len(),
+            encoded_len,
+            "mode={}",
+            progress.name()
+        );
+    }
+}
+
+#[test]
+fn server_cap_one_byte_below_encoded_len_rejects_flush_in_all_progress_modes() {
+    for progress in [ProgressCase::Background, ProgressCase::Manual] {
+        let mut buf = Buffer::qwp_ws_with_max_name_len(127);
+        buf.table("t")
+            .unwrap()
+            .column_i64("v", 42)
+            .unwrap()
+            .at_now()
+            .unwrap();
+        let encoded_len = qwp_ws_replay_encoded_len(&buf);
+
+        let server_cap = encoded_len - 1;
+        let port = spawn_max_batch_size_upgrade_only_server(Some(server_cap));
+        let builder = SenderBuilder::new(Protocol::QwpWs, "127.0.0.1", port)
+            .max_buf_size(100 * 1024 * 1024)
+            .unwrap();
+        let mut sender = build_qwp_ws_sender_from_builder(progress, builder);
+
+        let err = sender.flush(&mut buf).unwrap_err();
+        assert_eq!(
+            err.code(),
+            crate::ErrorCode::InvalidApiCall,
+            "mode={}",
+            progress.name()
+        );
+        assert!(
+            err.msg().contains(&server_cap.to_string()),
+            "mode={}: error should reference server cap {server_cap}, got: {}",
+            progress.name(),
+            err.msg()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Parse `X-QWP-Max-Batch-Size` from the server's 101 WebSocket upgrade response and clamp the flush-time encoded-message size limit to `min(configured_max_buf_size, server_cap)`.
- Oversize batches are now caught **locally** with a clear `InvalidApiCall` error instead of being sent to the server and rejected with a connection-killing `ws-close[1009 MESSAGE_TOO_BIG]`.
- The server cap is stored in a shared `Arc<AtomicUsize>` so reconnects (including failover) refresh it automatically.
- When the header is absent (older servers), the client falls back to its configured `max_buf_size` unchanged.

## Changes

| File | What |
|------|------|
| `qwp_ws_codec.rs` | New `QwpWsHandshakeResult` struct; `extract_server_max_batch_size()` parser; 5 unit tests |
| `qwp_ws.rs` | Thread `server_max_batch_size` through `establish_connection` → `QwpWsConnectRoundSuccess` → handler states via `Arc<AtomicUsize>` |
| `qwp_ws_driver.rs` | `BlockingQwpWsTransport` stores + updates the shared atomic on connect and reconnect |
| `qwp_ws_orphan.rs` | Updated orphan drainer call site (standalone atomic) |
| `sender.rs` | `effective_qwp_ws_max_buf_size()` helper; flush path clamps against server cap |
| `tests/qwp_ws.rs` | 7 e2e tests (each in Background + Manual modes = 14 cases) |

## Test plan

All 7 new e2e tests cover both `Background` and `Manual` progress modes:

- [x] Server advertises small cap → flush rejects locally (not server error)
- [x] Server advertises cap, small buffer fits → flush succeeds end-to-end
- [x] Header absent → falls back to configured `max_buf_size`
- [x] Configured max < server cap → configured max wins (`min` semantics)
- [x] First small flush succeeds, second oversized flush rejected locally
- [x] Exact boundary: encoded_len == server_cap → flush succeeds
- [x] Off-by-one: server_cap = encoded_len - 1 → flush fails

```
cargo test -- "tests::qwp_ws::server" absent_server configured_max
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QWP/WebSocket synchronous sender now negotiates batch size constraints with the server during handshake and automatically enforces them on flush operations, capping to the minimum of configured and server-advertised limits. Falls back to configured maximum when server doesn't advertise.

* **Tests**
  * Comprehensive test coverage for batch size negotiation and enforcement across various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/questdb/c-questdb-client/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->