### PR TITLE
chore: center QWP/WS reconnect backoff jitter

### DIFF
--- a/questdb-rs/src/egress/reader.rs
+++ b/questdb-rs/src/egress/reader.rs
@@ -2892,13 +2892,13 @@ mod tests {
     }
 
     /// Every draw lies in `[0, base)` — the full-jitter contract from
-    /// failover.md §3.1. This is the discriminator against the
-    /// equal-jitter variant `[base, 2*base)` used by SF ingress: a
-    /// regression that swapped the implementation would produce draws
-    /// of `base` or higher on the first iteration. 10k samples per base across
-    /// several bases (powers of two, near-`u32::MAX`, and primes that
-    /// exercise the `% base` reduction) catches both off-by-one and
-    /// signed/unsigned mix-ups.
+    /// failover.md §3.1. SF ingress uses a different scheme (centered
+    /// jitter, `[base/2, 3*base/2)`, in `qwp_ws_driver.rs`); this test
+    /// pins the egress full-jitter contract, which — unlike that — may
+    /// wait near zero. 10k samples per base across several bases
+    /// (powers of two, near-`u32::MAX`, and primes that exercise the
+    /// `% base` reduction) catches both off-by-one and signed/unsigned
+    /// mix-ups.
     #[test]
     fn full_jitter_ms_draws_are_in_range() {
         let mut rng = FailoverRng::new();

--- a/questdb-rs/src/ingress.rs
+++ b/questdb-rs/src/ingress.rs
@@ -1492,7 +1492,8 @@ impl SenderBuilder {
     }
 
     #[cfg(feature = "_sender-qwp-ws")]
-    /// Cap on the per-attempt reconnect delay. Default 5s.
+    /// Cap on the reconnect backoff the retry loop doubles toward; the actual
+    /// per-attempt delay is this value jittered to ~[half, 1.5x]. Default 5s.
     pub fn reconnect_max_backoff(mut self, value: Duration) -> Result<Self> {
         if value.is_zero() {
             return Err(error::fmt!(

--- a/questdb-rs/src/ingress/conf.rs
+++ b/questdb-rs/src/ingress/conf.rs
@@ -209,7 +209,8 @@ pub(crate) struct QwpWsConfig {
     /// Initial reconnect backoff; the reconnect loop doubles the delay up to
     /// `reconnect_max_backoff`.
     pub(crate) reconnect_initial_backoff: ConfigSetting<std::time::Duration>,
-    /// Cap on the per-attempt reconnect delay.
+    /// Cap on the reconnect backoff the retry loop doubles toward; the actual
+    /// per-attempt delay is this value jittered to ~[half, 1.5x].
     pub(crate) reconnect_max_backoff: ConfigSetting<std::time::Duration>,
     /// Initial-connect retry mode. Default is fail-fast after one endpoint
     /// round, matching Java's startup behavior.

--- a/questdb-rs/src/ingress/sender/qwp_ws_driver.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws_driver.rs
@@ -1860,17 +1860,22 @@ fn double_duration(duration: Duration) -> Duration {
 }
 
 #[cfg(feature = "sync-sender-qwp-ws")]
-fn equal_jitter_duration(base: Duration) -> Duration {
+fn centered_jitter_duration(base: Duration) -> Duration {
     let base_nanos = base.as_nanos().min(u128::from(u64::MAX)) as u64;
     if base_nanos == 0 {
         return base;
     }
+    // Centered jitter: a half-backoff floor plus a uniform draw over a full
+    // backoff -> sleep in [base/2, 3*base/2), centered on `base`. Scatters
+    // retries around the target delay (sometimes sooner, sometimes later) and
+    // decorrelates concurrent reconnects. Egress failover uses full jitter
+    // (failover.md §3.1); the two schemes are intentionally separate.
     let extra = rand::rng().random_range(0..base_nanos);
-    base.saturating_add(Duration::from_nanos(extra))
+    Duration::from_nanos((base_nanos / 2).saturating_add(extra))
 }
 
 #[cfg(not(feature = "sync-sender-qwp-ws"))]
-fn equal_jitter_duration(base: Duration) -> Duration {
+fn centered_jitter_duration(base: Duration) -> Duration {
     base
 }
 
@@ -1882,7 +1887,7 @@ pub(super) fn reconnect_sleep_duration(
     if role_reject {
         initial_backoff
     } else {
-        equal_jitter_duration(backoff)
+        centered_jitter_duration(backoff)
     }
 }
 
@@ -4186,6 +4191,23 @@ mod tests {
             reconnect_sleep_duration(false, initial, Duration::ZERO),
             Duration::ZERO
         );
+    }
+
+    #[test]
+    fn centered_jitter_reconnect_sleep_scatters_around_backoff() {
+        // Non-role-reject reconnects use centered jitter: sleep in
+        // [base/2, 3*base/2), centered on the backoff.
+        let unused_initial = Duration::from_millis(100);
+        for base_ms in [2u64, 80, 100, 1_000, 5_000] {
+            let base = Duration::from_millis(base_ms);
+            for _ in 0..10_000 {
+                let d = reconnect_sleep_duration(false, unused_initial, base);
+                assert!(
+                    d >= base / 2 && d < base + base / 2,
+                    "centered-jitter sleep {d:?} outside [base/2, 3*base/2) for base={base:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/system_test/test.py
+++ b/system_test/test.py
@@ -2577,6 +2577,14 @@ class TestQwpWsFuzz(QwpWsTestSupport, unittest.TestCase):
             # wait through the bounce up to reconnect_max_duration_millis.
             initial_connect_retry='sync',
             reconnect_max_duration_millis=120000,
+            # The bounce tests restart the server faster than the reconnect
+            # backoff cap can track, so the client keeps backing off and
+            # misses the brief windows the server is up between restarts —
+            # close_drain then can't drain and times out. A tighter cap keeps
+            # reconnect attempts landing inside those windows. (Harmless for
+            # the non-bounce tests, which never reconnect, so the backoff
+            # never engages.)
+            reconnect_max_backoff_millis=250,
             # 2 min on close_drain — bounce-test variants need a long
             # enough budget for SFA to replay queued frames into a
             # freshly-restarted server.


### PR DESCRIPTION
The jitter was additive -- `base + rand(0, base)` -> `[base, 2*base)`, so it never retried sooner than the full backoff. Under rapid server restarts the client sampled too coarsely to catch the brief server-up windows and close_drain timed out in the QWP/WS bounce fuzz. Center it instead: `base/2 + rand(0, base)` -> `[base/2, 3*base/2)`, so retries scatter around the backoff and can fire at half it (`reconnect_max_backoff` is now the jitter center, not a hard cap). 

Also cap the bounce-fuzz producers at 250ms to fix flakiness. 