### PR TITLE
fix(system_test): preserve QuestDB server log on failure for CI archival

### DIFF
--- a/system_test/test.py
+++ b/system_test/test.py
@@ -4163,6 +4163,23 @@ def iter_versions(args):
         yield questdb_dir
 
 
+def _stop_and_maybe_wipe(fixture):
+    """Stop ``fixture``, reclaiming its data dir only on a clean run.
+
+    Called from the ``finally`` of each suite block. ``wipe_data_dir()``
+    deletes everything under ``data/`` (including ``data/log/log.txt``) to
+    reclaim disk between runs, but on failure we re-raise via ``sys.exit(1)``
+    and want that server log to survive for the CI "Compress QuestDB server
+    log on failure" archive step. So skip the wipe whenever an exception is
+    propagating — including the ``SystemExit`` from ``sys.exit(1)`` —
+    detected via ``sys.exc_info()`` captured before ``stop()`` runs.
+    """
+    failed = sys.exc_info()[0] is not None
+    fixture.stop()
+    if not failed:
+        fixture.wipe_data_dir()
+
+
 def run_with_fixtures(args):
     global QDB_FIXTURE
     global TLS_PROXY_FIXTURE
@@ -4217,8 +4234,7 @@ def run_with_fixtures(args):
                                 TLS_PROXY_FIXTURE.stop()
                                 TLS_PROXY_FIXTURE = None
                 finally:
-                    QDB_FIXTURE.stop()
-                    QDB_FIXTURE.wipe_data_dir()
+                    _stop_and_maybe_wipe(QDB_FIXTURE)
 
         if run_qwp_ws_smoke_suite:
             for http_auth in (False, True):
@@ -4252,8 +4268,7 @@ def run_with_fixtures(args):
                                 TLS_PROXY_FIXTURE = None
                             QWP_WS_SMOKE_TLS = False
                 finally:
-                    QDB_FIXTURE.stop()
-                    QDB_FIXTURE.wipe_data_dir()
+                    _stop_and_maybe_wipe(QDB_FIXTURE)
 
         if run_qwp_ws_protocol_suite:
             QDB_FIXTURE = QuestDbFixture(
@@ -4271,8 +4286,7 @@ def run_with_fixtures(args):
                 if not _run_selected_tests(SUITE_QWP_WS_PROTOCOL):
                     sys.exit(1)
             finally:
-                QDB_FIXTURE.stop()
-                QDB_FIXTURE.wipe_data_dir()
+                _stop_and_maybe_wipe(QDB_FIXTURE)
 
         if run_qwp_ws_restart_suite:
             QDB_FIXTURE = QuestDbFixture(
@@ -4290,8 +4304,7 @@ def run_with_fixtures(args):
                 if not _run_selected_tests(SUITE_QWP_WS_RESTART):
                     sys.exit(1)
             finally:
-                QDB_FIXTURE.stop()
-                QDB_FIXTURE.wipe_data_dir()
+                _stop_and_maybe_wipe(QDB_FIXTURE)
 
         if run_qwp_ws_fuzz_suite:
             QDB_FIXTURE = QuestDbFixture(
@@ -4309,8 +4322,7 @@ def run_with_fixtures(args):
                 if not _run_selected_tests(SUITE_QWP_WS_FUZZ):
                     sys.exit(1)
             finally:
-                QDB_FIXTURE.stop()
-                QDB_FIXTURE.wipe_data_dir()
+                _stop_and_maybe_wipe(QDB_FIXTURE)
 
 
 def run(args, show_help=False):


### PR DESCRIPTION
## Problem

The scheduled **QWP/WS + QWP egress fuzz** pipeline's `TestQwpWsFuzz` step failed (environment slowness), and the follow-up **Compress QuestDB server log on failure** step then failed too:

```
##[error]Error: Not found ls: ENOENT: no such file or directory,
lstat '/Users/runner/work/1/s/build/questdb/repo/data/log'
```

## Root cause

The path is good, but the log directory was being deleted after the fuzz test completed, with or without failure.

Every suite block in `run_with_fixtures()` (`system_test/test.py`) ended its `finally` with an unconditional `QDB_FIXTURE.wipe_data_dir()`, which removes everything under `data/` (including `data/log/log.txt`) to reclaim disk between runs. On a failure:

1. test fails → `_run_selected_tests()` returns `False` → `sys.exit(1)`
2. the `finally` runs anyway → `wipe_data_dir()` deletes `data/log`
3. `SystemExit` propagates → step marked failed
4. the `failed()`-conditioned archive step finds no `data/log` → `ENOENT`

This affected all five suite blocks and both CI pipelines (`run_fuzz_pipeline.yaml` and `run_tests_pipeline.yaml`).

## Fix

A new `_stop_and_maybe_wipe()` helper that stops the server always but skips the wipe while an exception is propagating (including the `SystemExit` from `sys.exit(1)`), detected via `sys.exc_info()` captured before `stop()`:

```python
def _stop_and_maybe_wipe(fixture):
    failed = sys.exc_info()[0] is not None
    fixture.stop()
    if not failed:
        fixture.wipe_data_dir()
```

The server log now survives for the archive step on failure; disk reclamation on a clean pass is unchanged.

## Verification

- `python3 -m py_compile system_test/test.py` passes.
- Confirmed `sys.exc_info()[0]` in a `finally` is `None` on success and reports the in-flight exception (incl. `SystemExit`, when read from a called function, and through an inner `try/except`) on failure.
- Test that simulates both suite shapes (simple + matrix/smoke nested TLS-proxy `finally`) plus a `start()`-failure case: wipe skipped on every failure path, still runs on success.

## Remaining edge case (already mitigated)

If QuestDB never starts (e.g. the jar isn't found, before `data/log` is created) there really is no log and the archive step would still `ENOENT`, which is why those steps already indicate `continueOnError: true`. This change doesn't regress that and removes the noise on the common failure path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture cleanup behavior to conditionally preserve data when test runs encounter failures, enhancing debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->