### PR TITLE
fix(system_test): add --add-exports java.base/jdk.internal.vm=io.questdb to all QuestDB launchers

### DIFF
--- a/questdb-rs/tests/common/mod.rs
+++ b/questdb-rs/tests/common/mod.rs
@@ -283,6 +283,10 @@ impl QuestDbServer {
             "-Dnoebug",
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+AlwaysPreTouch",
+            // Lets the io.questdb module reach jdk.internal.vm.ContinuationScope
+            // (used by WorkerContinuation); without it every worker thread dies
+            // with IllegalAccessError and the server never binds its HTTP port.
+            "--add-exports=java.base/jdk.internal.vm=io.questdb",
             "-p",
         ])
         .arg(&jar)

--- a/system_test/fixture.py
+++ b/system_test/fixture.py
@@ -551,6 +551,13 @@ class QuestDbFixture(QuestDbFixtureBase):
             # '-Debug',
             '-XX:+UnlockExperimentalVMOptions',
             '-XX:+AlwaysPreTouch',
+            # QuestDB's worker pools use jdk.internal.vm.ContinuationScope via
+            # io.questdb.mp.continuation.WorkerContinuation. When the server is
+            # launched as the named module io.questdb (-m below), java.base does
+            # not export jdk.internal.vm to it, so every worker thread dies with
+            # IllegalAccessError and the HTTP service never comes up. QuestDB's
+            # own launcher passes this flag; mirror it here.
+            '--add-exports=java.base/jdk.internal.vm=io.questdb',
             '-p', str(self._root_dir / 'bin' / 'questdb.jar'),
             '-m', 'io.questdb/io.questdb.ServerMain',
             '-d', str(self._data_dir)]

--- a/system_test/test_egress_failover.py
+++ b/system_test/test_egress_failover.py
@@ -194,6 +194,11 @@ class StandaloneInstance:
             '-Dnoebug',
             '-XX:+UnlockExperimentalVMOptions',
             '-XX:+AlwaysPreTouch',
+            # Required so the io.questdb module can reach
+            # jdk.internal.vm.ContinuationScope (used by WorkerContinuation);
+            # without it every worker thread dies with IllegalAccessError and
+            # the server never binds its HTTP port. Mirrors fixture.py.
+            '--add-exports=java.base/jdk.internal.vm=io.questdb',
             '-p', str(self.jar),
             '-m', 'io.questdb/io.questdb.ServerMain',
             '-d', str(self.data_dir),


### PR DESCRIPTION
## Problem

QuestDB master added `io.questdb.mp.continuation.WorkerContinuation`, which
references the JDK-internal API `jdk.internal.vm.ContinuationScope`. Our test
harnesses launch the server **as the named JPMS module** `io.questdb`
(`-m io.questdb/io.questdb.ServerMain`), and `java.base` does not export
`jdk.internal.vm` to that module. So every QuestDB worker pool crashes at
startup:

```
java.lang.IllegalAccessError: class io.questdb.mp.continuation.WorkerContinuation
  (in module io.questdb) cannot access class jdk.internal.vm.ContinuationScope
  (in module java.base) because module java.base does not export
  jdk.internal.vm to module io.questdb
  at io.questdb.mp.continuation.WorkerContinuation.<clinit>(WorkerContinuation.java:44)
```

The HTTP listener never binds, so the test harness times out (300s) waiting
for the server. This took down the scheduled **Fuzz Tests** build
([242833](https://dev.azure.com/questdb/questdb/_build/results?buildId=242833))
and the **egress integration test**
([242848](https://dev.azure.com/questdb/questdb/_build/results?buildId=242848)).

This is **not a regression in the C client** — it's a launch-flag mismatch
against the master-tracking QuestDB server dependency. QuestDB's own launcher
already passes this `--add-exports`; our harnesses replicate the launch by
hand and had fallen out of sync.

## Fix

Add `--add-exports=java.base/jdk.internal.vm=io.questdb` to **every in-repo
QuestDB module launcher**:

| File | Launcher |
|------|----------|
| `system_test/fixture.py` | `QuestDbFixture` (main system tests / fuzz) |
| `system_test/test_egress_failover.py` | `StandaloneInstance.start` (egress failover) |
| `questdb-rs/tests/common/mod.rs` | Rust integration test harness |

(`questdb-rs/src/egress/binds.rs` only mentions `TestServerMain` in comments —
no launcher there.)

## Testing

- `python3 -m py_compile` passes for both Python files.
- `cargo build --manifest-path questdb-rs/Cargo.toml --tests` builds clean.
- Launch-args only; no change to client behavior. Real verification is the
  server now coming up in CI (the step that was failing).
