### PR TITLE
TEST: c-questdb-client vs questdb PR #6890 (do not merge)

### DIFF
--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -233,7 +233,7 @@ stages:
               mavenPOMFile: "questdb/pom.xml"
               javaHomeOption: "Path"
               jdkDirectory: "$(JAVA_HOME)"
-              options: "-DskipTests -Pbuild-web-console$(CLIENT_PROFILE)"
+              options: "-DskipTests -Pbuild-web-console,build-binaries$(CLIENT_PROFILE)"
           - script: |
               python3 system_test/test.py run --repo ./questdb -v
             displayName: "integration test"
@@ -307,7 +307,7 @@ stages:
               mavenPOMFile: "questdb/pom.xml"
               javaHomeOption: "Path"
               jdkDirectory: "$(JAVA_HOME)"
-              options: "-DskipTests -Pbuild-web-console$(CLIENT_PROFILE)"
+              options: "-DskipTests -Pbuild-web-console,build-binaries$(CLIENT_PROFILE)"
           - script: |
               python3 system_test/test.py run --repo ./questdb TestQwpWsFuzz -v
             displayName: "TestQwpWsFuzz"
@@ -404,7 +404,7 @@ stages:
               mavenPOMFile: "questdb/pom.xml"
               javaHomeOption: "Path"
               jdkDirectory: "$(JAVA_HOME)"
-              options: "-DskipTests -Pbuild-web-console$(CLIENT_PROFILE)"
+              options: "-DskipTests -Pbuild-web-console,build-binaries$(CLIENT_PROFILE)"
           - script: |
               python3 system_test/test.py run --repo ./questdb TestQwpWsFuzz -v
             displayName: "TestQwpWsFuzz"
@@ -457,7 +457,7 @@ stages:
             inputs:
               mavenPOMFile: "questdb/pom.xml"
               jdkVersionOption: "default"
-              options: "-DskipTests -Pbuild-web-console$(CLIENT_PROFILE)"
+              options: "-DskipTests -Pbuild-web-console,build-binaries$(CLIENT_PROFILE)"
           - script: |
               set -euxo pipefail
               cd questdb-rs

--- a/ci/templates/clone_questdb.yaml
+++ b/ci/templates/clone_questdb.yaml
@@ -18,7 +18,7 @@
 # questdb-building job working whichever way questdb master flips next.
 steps:
   - script: |
-      git clone --depth 1 https://github.com/questdb/questdb.git
+      git clone --depth 1 --branch steve-rm-bins https://github.com/questdb/questdb.git
     displayName: git clone questdb
   - bash: |
       # No `pipefail`: the version extraction is `sed ... | head -1`, and


### PR DESCRIPTION
Throwaway test branch — **do not merge**.

Builds QuestDB from the `steve-rm-bins` branch (questdb/questdb PR #6890, "remove pre-compiled native binaries from the repository") instead of master, to validate that the from-source build path still works for downstream client consumers after the committed native libraries are removed.

Changes:
- `ci/templates/clone_questdb.yaml`: clone `--branch steve-rm-bins` instead of master (redirects all four QuestDB-building jobs).
- `ci/run_tests_pipeline.yaml`: add `,build-binaries` to the four Maven compile steps, since #6890 removed the committed native libs and the server jar otherwise has no native libraries to load.

Close once results are read.