### PR TITLE
ci: run "Vs QuestDB master" against the nightly docker image

### DIFF
--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -151,112 +151,71 @@ stages:
           - script: ctest --output-on-failure -E rust_tests
             workingDirectory: build_sanitize
             displayName: "ctest under ASan + UBSan"
-      # Runs the full system_test/test.py against a fresh build of
-      # QuestDB master. Moved off Microsoft-hosted ubuntu-latest because
-      # the QWP/WS fuzz portion of the run filled the agent disk ("No
-      # space left", SIGBUS); the hetzner-incus pool — already used by
-      # TestQwpWsFuzzLinux below and by the cron-time fuzz pipeline —
-      # has enough headroom. Pool image is built from
-      # questdb/azure-ci-runners' roles/incus/files/provision.sh, which
-      # provides openjdk-17-jdk, openjdk-25-jdk, maven, build-essential,
-      # zip, curl, gh, and rustup; only cmake and python3-numpy are
-      # apt-installed per job. imageName='hetzner-incus' tells
-      # compile.yaml to skip its pip step.
-      - job: TestVsQuestDBMaster
-        displayName: "Vs QuestDB master"
+      # Runs the integration matrix (system_test/test.py) and the
+      # mid-query failover suite (system_test/test_egress_failover.py)
+      # against the prebuilt QuestDB *nightly docker image* instead of a
+      # from-source build of master. The nightly image tracks master, so
+      # this keeps the "did QuestDB master break the client?" signal while
+      # dropping the Maven + Rust from-source build entirely. The server
+      # runs in a container (config injected via QDB_* env vars, ports
+      # published 1:1 on loopback); the failover crash is a `docker kill`
+      # (SIGKILL), the graceful path a `docker stop` (SIGTERM).
+      #
+      # Back on Microsoft-hosted ubuntu-latest (which ships docker
+      # pre-installed): the disk pressure that originally pushed this job
+      # to hetzner-incus came from the from-source build plus on-host
+      # server data, both now gone (the server lives in an ephemeral
+      # container, removed between configs). If fuzz-portion disk
+      # pressure ever recurs, move this job to a pool with more headroom
+      # that also has docker.
+      #
+      # Scope note: the nightly image is Linux/amd64 only, so the
+      # mac/windows fuzz legs stay from-source, as does any run that must
+      # test a specific commit not yet in nightly. QWP UDP is not
+      # exercised here (it is gated on `--repo` in test.py); that
+      # coverage still runs in the from-source jobs.
+      - job: TestVsQuestDBNightly
+        displayName: "Vs QuestDB nightly (docker)"
         pool:
-          name: hetzner-incus
+          vmImage: "ubuntu-latest"
         timeoutInMinutes: 90
         variables:
-          imageName: hetzner-incus
+          QUESTDB_IMAGE: "questdb/questdb:nightly"
         steps:
           - checkout: self
             fetchDepth: 1
             lfs: false
             submodules: false
-          - bash: |
-              rm -rf /tmp/junit* /tmp/surefire-agent /tmp/libquestdbr* /tmp/libqdbsqllogic*
-            displayName: "Cleanup /tmp leftovers"
-          - bash: |
-              set -eux
-              sudo apt-get update
-              # Ubuntu 24.04's python3-numpy is 1.26 which caps NPY_MAXDIMS at 32;
-              # the >32-dim sender-rejection test (TestSender.test_f64_arr_max_dims)
-              # needs numpy >= 2.0 to construct the input array. Install numpy
-              # only via pip (apt would pull in 1.26 and pip refuses to replace
-              # debian-installed packages because the wheel RECORD file is
-              # missing). --break-system-packages overrides PEP 668.
-              sudo apt-get install -y --no-install-recommends cmake python3-pip
-              sudo python3 -m pip install --break-system-packages 'numpy>=2'
-              JAVA_PATH_17="/usr/lib/jvm/java-17-openjdk-amd64"
-              JAVA_PATH_25="/usr/lib/jvm/java-25-openjdk-amd64"
-              for p in "$JAVA_PATH_17" "$JAVA_PATH_25"; do
-                if [ ! -x "$p/bin/javac" ]; then
-                  echo "Expected JDK missing at $p" >&2
-                  ls /usr/lib/jvm/ >&2 || true
-                  exit 1
-                fi
-              done
-              # `set -x` traces `echo "##vso[...]VALUE"` as `+ echo
-              # '##vso[...]VALUE'`; Azure's stdout parser matches `##vso[`
-              # anywhere on the line and takes everything past `]` to EOL
-              # as the value, including the trailing `'` bash added.
-              # Disable trace just for these two echoes so JAVA_HOME does
-              # not end up as `/usr/lib/jvm/java-25-openjdk-amd64'`.
-              set +x
-              echo "##vso[task.setvariable variable=JAVA_HOME_17_X64]$JAVA_PATH_17"
-              echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_PATH_25"
-            displayName: "Install missing deps + resolve JDKs"
-          - bash: |
-              set -eux
-              # `|| true` lets the fallback path take over if the file
-              # references something the build user can't read (e.g.
-              # /etc/profile.d/rust.sh sources /root/.cargo/env).
-              if [ -f /etc/profile.d/rust.sh ]; then . /etc/profile.d/rust.sh || true; fi
-              if [ -f "$HOME/.cargo/env" ]; then . "$HOME/.cargo/env" || true; fi
-              if ! command -v cargo >/dev/null 2>&1; then
-                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-                  | sh -s -- -y --default-toolchain stable --profile minimal
-                . "$HOME/.cargo/env"
-              fi
-              CARGO_BIN="$(dirname "$(command -v cargo)")"
-              echo "Using cargo from: $CARGO_BIN"
-              # See JAVA_HOME comment above re: `set -x` + `##vso[...]`.
-              set +x
-              echo "##vso[task.prependpath]$CARGO_BIN"
-            displayName: "Resolve Rust toolchain"
           - template: templates/compile.yaml
-          - template: templates/clone_questdb.yaml
-          - task: Maven@3
-            displayName: "Compile QuestDB"
-            inputs:
-              mavenPOMFile: "questdb/pom.xml"
-              javaHomeOption: "Path"
-              jdkDirectory: "$(JAVA_HOME)"
-              options: "-DskipTests -Pbuild-web-console$(CLIENT_PROFILE)"
           - script: |
-              python3 system_test/test.py run --repo ./questdb -v
-            displayName: "integration test"
+              docker pull $(QUESTDB_IMAGE)
+            displayName: "Pull QuestDB nightly image"
           - script: |
-              python3 system_test/test_egress_failover.py run --repo ./questdb -v
-            displayName: "egress integration test"
+              python3 system_test/test.py run --docker $(QUESTDB_IMAGE) -v
+            displayName: "integration test (docker)"
+          - script: |
+              python3 system_test/test_egress_failover.py run --docker $(QUESTDB_IMAGE) -v
+            displayName: "egress failover test (docker)"
           - task: ArchiveFiles@2
             displayName: "Compress QuestDB server log on failure"
             condition: failed()
             continueOnError: true
             inputs:
-              rootFolderOrFile: $(Build.SourcesDirectory)/build/questdb/repo/data/log
+              # The docker fixtures capture `docker logs` under build/questdb/
+              # (docker/, server1/, server2/) since the containers are
+              # removed on stop().
+              rootFolderOrFile: $(Build.SourcesDirectory)/build/questdb
               includeRootFolder: false
               archiveType: zip
-              archiveFile: $(Build.ArtifactStagingDirectory)/qdb-log-vs-master-$(Agent.OS).zip
+              archiveFile: $(Build.ArtifactStagingDirectory)/qdb-log-vs-nightly-$(Agent.OS).zip
               quiet: true
           - task: PublishBuildArtifacts@1
             displayName: "Publish QuestDB server log on failure"
             condition: failed()
             continueOnError: true
             inputs:
-              pathToPublish: $(Build.ArtifactStagingDirectory)/qdb-log-vs-master-$(Agent.OS).zip
-              artifactName: qdb-log-vs-master-$(Agent.OS)
+              pathToPublish: $(Build.ArtifactStagingDirectory)/qdb-log-vs-nightly-$(Agent.OS).zip
+              artifactName: qdb-log-vs-nightly-$(Agent.OS)
       - job: TestQwpWsFuzz
         displayName: "QWP/WS fuzz suite (mac/windows hosted)"
         strategy:

--- a/system_test/failover_clients/src/bin/exhaustion_client.rs
+++ b/system_test/failover_clients/src/bin/exhaustion_client.rs
@@ -98,15 +98,52 @@ fn main() {
         // succeeded (which it can't — every endpoint is dead) or
         // returned a clean terminal (impossible without a healthy
         // server delivering RESULT_END).
-        match cursor.next_batch() {
-            Ok(_) => die(
-                "exhaustion",
-                12,
-                "next_batch returned Ok after every endpoint was killed".into(),
-            ),
-            Err(e) => {
-                eprintln!("exhausted_code={:?} exhausted_msg={}", e.code(), e.msg());
-                e.code()
+        // After every endpoint is dead the reader may still hand back
+        // batches the server streamed ahead before it died: a fast
+        // server (e.g. the release container image) can push the next
+        // batch into our receive buffer before the kill lands, whereas a
+        // slower from-source server usually has not yet. Those buffered
+        // batches are valid, already-received data, so drain them. The
+        // contract under test is that once the buffer is exhausted and
+        // the reader must touch the now-dead network, it surfaces an Err
+        // (failover budget exhausted) - not Ok forever, not a clean
+        // RESULT_END terminal, and not a panic.
+        let mut drained_after_kill = 0u32;
+        loop {
+            match cursor.next_batch() {
+                Ok(Some(_)) => {
+                    drained_after_kill += 1;
+                    // ~64 batches total for this fixture (1M rows / 16384
+                    // per batch); a generous cap still catches an "Ok
+                    // forever" / duplication bug.
+                    if drained_after_kill > 1024 {
+                        die(
+                            "exhaustion",
+                            12,
+                            "next_batch kept returning Ok(Some) after every \
+                             endpoint was killed"
+                                .into(),
+                        );
+                    }
+                }
+                Ok(None) => die(
+                    "exhaustion",
+                    12,
+                    format!(
+                        "next_batch returned Ok(None) [clean terminal] after \
+                         {drained_after_kill} buffered batches with every \
+                         endpoint dead"
+                    ),
+                ),
+                Err(e) => {
+                    eprintln!(
+                        "exhausted_code={:?} exhausted_msg={} drained_after_kill={}",
+                        e.code(),
+                        e.msg(),
+                        drained_after_kill
+                    );
+                    break e.code();
+                }
             }
         }
     };

--- a/system_test/fixture.py
+++ b/system_test/fixture.py
@@ -34,6 +34,7 @@ import tarfile
 import shutil
 import signal
 import subprocess
+import tempfile
 import time
 import socket
 import atexit
@@ -287,6 +288,33 @@ def _find_java():
     if res is None:
         raise RuntimeError('Could not find `java` executable.')
     return res
+
+
+# The docker CLI used by the docker-backed fixtures. Overridable so a CI
+# agent can point at podman or a wrapper without code changes.
+DOCKER_BIN = os.environ.get('QUESTDB_SYSTEST_DOCKER_BIN', 'docker')
+
+# Monotonic suffix so concurrent/sequential containers never collide on a
+# name within one test process.
+_docker_name_counter = 0
+
+
+def _docker(*args, check=True, capture=False, timeout=None):
+    """Run a `docker` CLI sub-command. With ``capture`` the combined
+    stdout/stderr is returned on the CompletedProcess; otherwise it is
+    inherited. ``check`` controls whether a non-zero exit raises."""
+    return subprocess.run(
+        [DOCKER_BIN, *args],
+        check=check,
+        timeout=timeout,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.STDOUT if capture else None)
+
+
+def _unique_container_name(prefix):
+    global _docker_name_counter
+    _docker_name_counter += 1
+    return f'{prefix}_{os.getpid()}_{_docker_name_counter}'
 
 
 class QueryError(Exception):
@@ -764,6 +792,244 @@ class QuestDbFixture(QuestDbFixtureBase):
                     child.unlink()
                 except OSError:
                     pass
+
+    def __exit__(self, _ty, _value, _tb):
+        self.stop()
+
+
+class QuestDbDockerFixture(QuestDbFixtureBase):
+    """A QuestDB server running inside a docker container.
+
+    Drop-in replacement for ``QuestDbFixture`` that runs a prebuilt
+    QuestDB image (e.g. ``questdb/questdb:nightly``) instead of building
+    and launching the jar locally. It exposes the same public surface
+    (the same port attributes, ``start()`` / ``stop()`` / ``kill()`` /
+    ``wipe_data_dir()`` / ``print_log()``) so the test bodies are
+    unchanged.
+
+    Configuration is injected via ``QDB_*`` environment variables rather
+    than a ``server.conf`` file, so nothing is mounted for the common
+    case; data is kept inside the container and discarded when the
+    container is removed in ``stop()``. The server log is read with
+    ``docker logs`` (the image logs to stdout). Container ports are
+    published 1:1 on loopback to the host ports discovered up front, so
+    a client connecting to ``127.0.0.1:<port>`` behaves exactly as
+    against the local-process fixture.
+    """
+
+    def __init__(
+            self,
+            image,
+            auth=False,
+            wrap_tls=False,
+            http=False,
+            protocol_version=None,
+            qwp_udp=False,
+            http_auth=False):
+        self.image = image
+        # Refined from the live server on first start, like QuestDbFixture.
+        self.version = None
+        self._version_queried = False
+        self._container = None
+        self._auth_file = None
+        self.host = '127.0.0.1'
+        self.http_server_port = None
+        self.line_tcp_port = None
+        self.qwp_udp_port = None
+        self.pg_port = None
+
+        self.wrap_tls = wrap_tls
+        self._tls_proxy = None
+        self.tls_line_tcp_port = None
+
+        self.auth = auth
+        self.http_auth = http_auth
+        self.http = http
+        self.protocol_version = protocol_version
+        self.qwp_udp = qwp_udp
+
+    def _env_config(self):
+        # Mirrors the server.conf that QuestDbFixture.start() writes, but
+        # as QDB_* env overrides. Run the in-container server as the host
+        # user so any bind-mounted file (auth.txt) stays host-owned;
+        # harmless when nothing is mounted.
+        env = {
+            'QDB_HTTP_BIND_TO': f'0.0.0.0:{self.http_server_port}',
+            'QDB_LINE_TCP_NET_BIND_TO': f'0.0.0.0:{self.line_tcp_port}',
+            'QDB_PG_NET_BIND_TO': f'0.0.0.0:{self.pg_port}',
+            'QDB_HTTP_MIN_ENABLED': 'false',
+            'QDB_LINE_UDP_ENABLED': 'false',
+            'QDB_QWP_UDP_ENABLED': 'true' if self.qwp_udp else 'false',
+            'QDB_LINE_TCP_MAINTENANCE_JOB_INTERVAL': '100',
+            'QDB_LINE_TCP_MIN_IDLE_MS_BEFORE_WRITER_RELEASE': '300',
+            'QDB_TELEMETRY_ENABLED': 'false',
+            'QDB_CAIRO_COMMIT_LAG': '100',
+            'QDB_CAIRO_WRITER_DATA_APPEND_PAGE_SIZE': '64k',
+            'QDB_CAIRO_WRITER_DATA_INDEX_VALUE_APPEND_PAGE_SIZE': '64k',
+            'QDB_LINE_TCP_COMMIT_INTERVAL_FRACTION': '0.1',
+        }
+        if hasattr(os, 'getuid'):
+            env['QUESTDB_UID'] = str(os.getuid())
+            env['QUESTDB_GID'] = str(os.getgid())
+        if self.qwp_udp:
+            env['QDB_QWP_UDP_BIND_TO'] = f'0.0.0.0:{self.qwp_udp_port}'
+            env['QDB_QWP_UDP_UNICAST'] = 'true'
+            env['QDB_QWP_UDP_COMMIT_RATE'] = '1'
+        if self.http:
+            env['QDB_LINE_HTTP_ENABLED'] = 'true'
+        if self.http_auth:
+            env['QDB_HTTP_USER'] = HTTP_AUTH['username']
+            env['QDB_HTTP_PASSWORD'] = HTTP_AUTH['password']
+        if self.auth:
+            env['QDB_LINE_TCP_AUTH_DB_PATH'] = 'conf/auth.txt'
+        return env
+
+    def start(self):
+        if self.http_server_port is None:
+            ports = discover_avail_ports(3)
+            self.http_server_port, self.line_tcp_port, self.pg_port = ports
+        if self.qwp_udp and self.qwp_udp_port is None:
+            self.qwp_udp_port = discover_avail_udp_port()
+
+        cmd = ['run', '-d', '--name', _unique_container_name('qdb_systest')]
+        self._container = cmd[3]
+        for key, value in self._env_config().items():
+            cmd += ['-e', f'{key}={value}']
+        for port in (self.http_server_port, self.line_tcp_port, self.pg_port):
+            cmd += ['-p', f'127.0.0.1:{port}:{port}']
+        if self.qwp_udp:
+            cmd += ['-p', f'127.0.0.1:{self.qwp_udp_port}:{self.qwp_udp_port}/udp']
+        if self.auth:
+            # QuestDB resolves the auth db path relative to the data root,
+            # so the file must land under /var/lib/questdb. A read-only
+            # single-file bind mount overlays it onto the image-seeded
+            # conf/ dir; the entrypoint's chown of a read-only file fails
+            # harmlessly and the server still reads it.
+            handle = tempfile.NamedTemporaryFile(
+                mode='w', suffix='_auth.txt', delete=False, encoding='utf-8')
+            handle.write(AUTH_TXT + '\n')
+            handle.close()
+            self._auth_file = handle.name
+            cmd += ['-v',
+                    f'{self._auth_file}:/var/lib/questdb/conf/auth.txt:ro']
+        cmd += [self.image]
+
+        sys.stderr.write(
+            f'Starting QuestDB container {self._container} from '
+            f'{self.image!r} (auth: {self.auth}, http_auth: {self.http_auth}, '
+            f'http: {self.http}, qwp_udp: {self.qwp_udp})\n')
+        _docker(*cmd)
+
+        try:
+            sys.stderr.write('Waiting until HTTP service is up.\n')
+            retry(
+                self._check_http_up,
+                timeout_sec=300,
+                msg='Timed out waiting for HTTP service to come up.')
+        except:
+            sys.stderr.write('QuestDB container log:\n')
+            self.print_log()
+            self.stop()
+            raise
+
+        atexit.register(self.stop)
+        sys.stderr.write('QuestDB docker fixture instance is ready.\n')
+
+        if not self._version_queried:
+            self.version = self.query_version()
+            self._version_queried = True
+
+        if self.wrap_tls:
+            self._tls_proxy = TlsProxyFixture(self.line_tcp_port)
+            self._tls_proxy.start()
+            self.tls_line_tcp_port = self._tls_proxy.listen_port
+
+    def _is_running(self):
+        res = _docker(
+            'inspect', '-f', '{{.State.Running}}', self._container,
+            check=False, capture=True)
+        return res.returncode == 0 and res.stdout.strip() == b'true'
+
+    def _check_http_up(self):
+        if not self._is_running():
+            raise RuntimeError('QuestDB container died during startup.')
+        req = urllib.request.Request(
+            f'http://{self.host}:{self.http_server_port}/ping',
+            headers=self.http_headers(),
+            method='GET')
+        try:
+            resp = urllib.request.urlopen(req, timeout=1)
+            if resp.status == 204:
+                return True
+        except urllib.error.URLError:
+            pass
+        except OSError:
+            # Docker publishes the host port before QuestDB is ready, so an
+            # early probe can connect and then be reset
+            # (http.client.RemoteDisconnected, a ConnectionResetError /
+            # OSError). The local-process fixture only sees connection-refused
+            # (URLError) because its port opens with the app. socket.timeout
+            # is an OSError too.
+            pass
+        return False
+
+    def __enter__(self):
+        self.start()
+
+    def print_log(self):
+        if self._container is None:
+            sys.stderr.write('questdb container log unavailable.\n')
+            return
+        res = _docker('logs', self._container, check=False, capture=True)
+        log = (res.stdout or b'').decode('utf-8', errors='replace')
+        sys.stderr.write(textwrap.indent(log, '    '))
+        sys.stderr.write('\n\n')
+
+    def _dump_log_to_file(self):
+        # Persist the container log where the CI "archive log on failure"
+        # step looks, since stop() removes the container (and its logs).
+        if self._container is None:
+            return
+        try:
+            log_dir = Project().questdb_dir / 'docker' / 'data' / 'log'
+            log_dir.mkdir(parents=True, exist_ok=True)
+            res = _docker('logs', self._container, check=False, capture=True)
+            with open(log_dir / 'log.txt', 'wb') as log_file:
+                log_file.write(res.stdout or b'')
+        except Exception:
+            pass
+
+    def _remove_container(self, signal_args):
+        if self._tls_proxy:
+            self._tls_proxy.stop()
+            self._tls_proxy = None
+        if self._container is not None:
+            self._dump_log_to_file()
+            _docker(*signal_args, self._container, check=False)
+            _docker('rm', '-f', self._container, check=False)
+            self._container = None
+        if self._auth_file is not None:
+            try:
+                os.unlink(self._auth_file)
+            except OSError:
+                pass
+            self._auth_file = None
+
+    def stop(self, wait_timeout_sec=30):
+        # `docker stop` sends SIGTERM (graceful: the JVM runs shutdown
+        # hooks), then SIGKILLs after the grace period. Equivalent to
+        # QuestDbFixture.stop()'s terminate()-then-kill().
+        self._remove_container(['stop', '-t', str(wait_timeout_sec)])
+
+    def kill(self):
+        # `docker kill` sends SIGKILL: an ungraceful crash with no
+        # shutdown hooks. Equivalent to QuestDbFixture force-kill.
+        self._remove_container(['kill'])
+
+    def wipe_data_dir(self):
+        # The container and its data are removed in stop(); the next
+        # start() runs a fresh container, so there is nothing to wipe.
+        pass
 
     def __exit__(self, _ty, _value, _tb):
         self.stop()

--- a/system_test/test.py
+++ b/system_test/test.py
@@ -46,6 +46,7 @@ import uuid
 from fixture import (
     Project,
     QuestDbFixtureBase,
+    QuestDbDockerFixture,
     QuestDbExternalFixture,
     QuestDbFixture,
     TlsProxyFixture,
@@ -4114,6 +4115,13 @@ def parse_args():
         help=('Test against existing jar from a ' +
               '`mvn install -DskipTests -P build-web-console`' +
               '-ed questdb repo such as `~/questdb/repos/questdb/`'))
+    version_g.add_argument(
+        '--docker',
+        type=str,
+        metavar='IMAGE',
+        help=('Test against a QuestDB docker image, e.g. ' +
+              '`questdb/questdb:nightly`. The server runs in a container; ' +
+              'config is injected via QDB_* env vars.'))
     list_p = sub_p.add_parser('list', help='List latest -n releases.')
     list_p.set_defaults(command='list')
     list_p.add_argument('-n', type=int, default=30, help='number of releases')
@@ -4147,6 +4155,13 @@ def iter_versions(args):
     Returns a generator of prepared questdb directories.
     Ensure that the DB is stopped after each use.
     """
+    if getattr(args, 'docker', None):
+        # The "target" is a docker image reference. QuestDbDockerFixture
+        # injects config via QDB_* env vars, so there is no directory to
+        # prepare here.
+        yield args.docker
+        return
+
     if getattr(args, 'repo', None):
         # A specific repo path was provided.
         repo = pathlib.Path(args.repo)
@@ -4192,12 +4207,22 @@ def _stop_and_maybe_wipe(fixture):
         fixture.wipe_data_dir()
 
 
+def _new_fixture(target, is_docker, **kwargs):
+    """Build the fixture for the active run mode. In docker mode ``target``
+    is an image reference (``QuestDbDockerFixture``); otherwise it is a
+    prepared questdb directory (``QuestDbFixture``)."""
+    if is_docker:
+        return QuestDbDockerFixture(target, **kwargs)
+    return QuestDbFixture(target, **kwargs)
+
+
 def run_with_fixtures(args):
     global QDB_FIXTURE
     global TLS_PROXY_FIXTURE
     global BUILD_MODE
     global QWP_WS_SMOKE_TLS
 
+    is_docker = bool(getattr(args, 'docker', None))
     latest_protocol = sorted(list(qls.ProtocolVersion))[-1]
     run_matrix_suite = _select_tests(SUITE_MATRIX).countTestCases() > 0
     run_qwp_ws_smoke_suite = _select_tests(SUITE_QWP_WS_SMOKE).countTestCases() > 0
@@ -4208,8 +4233,9 @@ def run_with_fixtures(args):
     for questdb_dir in iter_versions(args):
         if run_matrix_suite:
             for auth in (False, True):
-                QDB_FIXTURE = QuestDbFixture(
+                QDB_FIXTURE = _new_fixture(
                     questdb_dir,
+                    is_docker,
                     auth=auth,
                     qwp_udp=bool(getattr(args, 'repo', None)))
                 TLS_PROXY_FIXTURE = None
@@ -4250,8 +4276,9 @@ def run_with_fixtures(args):
 
         if run_qwp_ws_smoke_suite:
             for http_auth in (False, True):
-                QDB_FIXTURE = QuestDbFixture(
+                QDB_FIXTURE = _new_fixture(
                     questdb_dir,
+                    is_docker,
                     auth=False,
                     http_auth=http_auth,
                     qwp_udp=False)
@@ -4283,8 +4310,9 @@ def run_with_fixtures(args):
                     _stop_and_maybe_wipe(QDB_FIXTURE)
 
         if run_qwp_ws_protocol_suite:
-            QDB_FIXTURE = QuestDbFixture(
+            QDB_FIXTURE = _new_fixture(
                 questdb_dir,
+                is_docker,
                 auth=False,
                 qwp_udp=False)
             TLS_PROXY_FIXTURE = None
@@ -4301,8 +4329,9 @@ def run_with_fixtures(args):
                 _stop_and_maybe_wipe(QDB_FIXTURE)
 
         if run_qwp_ws_restart_suite:
-            QDB_FIXTURE = QuestDbFixture(
+            QDB_FIXTURE = _new_fixture(
                 questdb_dir,
+                is_docker,
                 auth=False,
                 qwp_udp=False)
             TLS_PROXY_FIXTURE = None
@@ -4319,8 +4348,9 @@ def run_with_fixtures(args):
                 _stop_and_maybe_wipe(QDB_FIXTURE)
 
         if run_qwp_ws_fuzz_suite:
-            QDB_FIXTURE = QuestDbFixture(
+            QDB_FIXTURE = _new_fixture(
                 questdb_dir,
+                is_docker,
                 auth=False,
                 qwp_udp=False)
             TLS_PROXY_FIXTURE = None

--- a/system_test/test_egress_failover.py
+++ b/system_test/test_egress_failover.py
@@ -74,7 +74,9 @@ from fixture import (
     install_questdb,
     install_questdb_from_repo,
     list_questdb_releases,
+    _docker,
     _find_java,
+    _unique_container_name,
 )
 
 
@@ -265,6 +267,129 @@ class StandaloneInstance:
             sys.stderr.write(f'    {line}\n')
 
 
+class DockerStandaloneInstance:
+    """
+    Docker-backed analogue of `StandaloneInstance` for the failover test.
+
+    Each instance is its own container running the QuestDB image (e.g.
+    `questdb/questdb:nightly`). Config is injected via QDB_* env vars and
+    ports are published 1:1 on loopback, so the helper clients connect to
+    `127.0.0.1:<port>` exactly as against the local-process fixture.
+
+    The crash/graceful distinction that the failover test depends on maps
+    onto docker signals:
+
+      - `kill()` => `docker kill` (SIGKILL): an ungraceful crash, the
+        container vanishes without the JVM running shutdown hooks, so the
+        in-flight cursor sees an abrupt reset and failover engages. This
+        is the behaviour under test; `docker stop` (SIGTERM) would let
+        the server close gracefully and would NOT exercise failover.
+      - `stop()` => `docker stop` (SIGTERM): a graceful shutdown.
+
+    The data dir is only used as a place to persist the captured
+    container log (`docker logs`) for `dump_log()` and CI archival; the
+    server's own data lives inside the ephemeral container.
+    """
+
+    def __init__(self, image, data_dir, label):
+        self.image = image
+        self.data_dir = pathlib.Path(data_dir)
+        self.label = label
+        self.host = '127.0.0.1'
+        self.http_port = None
+        self.ilp_port = None
+        self.pg_port = None
+        self._container = None
+
+    def start(self):
+        if self.data_dir.exists():
+            shutil.rmtree(self.data_dir)
+        (self.data_dir / 'log').mkdir(parents=True)
+
+        self.http_port, self.ilp_port, self.pg_port = discover_avail_ports(3)
+        self._container = _unique_container_name(f'qdb_failover_{self.label}')
+        env = {
+            'QDB_HTTP_BIND_TO': f'0.0.0.0:{self.http_port}',
+            'QDB_LINE_TCP_NET_BIND_TO': f'0.0.0.0:{self.ilp_port}',
+            'QDB_PG_NET_BIND_TO': f'0.0.0.0:{self.pg_port}',
+            'QDB_HTTP_MIN_ENABLED': 'false',
+            'QDB_LINE_UDP_ENABLED': 'false',
+            'QDB_TELEMETRY_ENABLED': 'false',
+            'QDB_CAIRO_COMMIT_LAG': '100',
+        }
+        cmd = ['run', '-d', '--name', self._container]
+        for key, value in env.items():
+            cmd += ['-e', f'{key}={value}']
+        for port in (self.http_port, self.ilp_port, self.pg_port):
+            cmd += ['-p', f'127.0.0.1:{port}:{port}']
+        cmd += [self.image]
+        sys.stderr.write(
+            f'[{self.label}] docker run {self._container} '
+            f'http={self.http_port} ilp={self.ilp_port} pg={self.pg_port}\n')
+        _docker(*cmd)
+        try:
+            _wait_for_ping(self.host, self.http_port)
+        except Exception:
+            self.dump_log()
+            self.kill()
+            raise
+        sys.stderr.write(f'[{self.label}] /ping is up.\n')
+
+    def http_exec(self, sql):
+        return _http_exec(self.host, self.http_port, sql)
+
+    def is_alive(self):
+        if self._container is None:
+            return False
+        res = _docker(
+            'inspect', '-f', '{{.State.Running}}', self._container,
+            check=False, capture=True)
+        return res.returncode == 0 and res.stdout.strip() == b'true'
+
+    def _capture_log(self):
+        if self._container is None:
+            return
+        try:
+            res = _docker(
+                'logs', self._container, check=False, capture=True)
+            log_path = self.data_dir / 'log' / 'log.txt'
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(log_path, 'wb') as log_file:
+                log_file.write(res.stdout or b'')
+        except Exception:
+            pass
+
+    def kill(self):
+        """SIGKILL via `docker kill` - simulates a crash, no graceful WS
+        Close."""
+        if self._container is not None:
+            self._capture_log()
+            _docker('kill', self._container, check=False)
+            _docker('rm', '-f', self._container, check=False)
+            self._container = None
+
+    def stop(self):
+        """SIGTERM via `docker stop` - graceful shutdown. Use kill() to
+        simulate a crash."""
+        if self._container is not None:
+            self._capture_log()
+            _docker('stop', '-t', '15', self._container, check=False)
+            _docker('rm', '-f', self._container, check=False)
+            self._container = None
+
+    def dump_log(self, tail_lines=100):
+        self._capture_log()
+        log_path = self.data_dir / 'log' / 'log.txt'
+        if not log_path.exists():
+            sys.stderr.write(f'[{self.label}] no log at {log_path}\n')
+            return
+        text = log_path.read_text(encoding='utf-8', errors='replace')
+        lines = text.splitlines()
+        sys.stderr.write(f'[{self.label}] last {tail_lines} log lines:\n')
+        for line in lines[-tail_lines:]:
+            sys.stderr.write(f'    {line}\n')
+
+
 # ---------------------------------------------------------------------------
 # Setup helpers
 # ---------------------------------------------------------------------------
@@ -370,7 +495,7 @@ def _seed_table(server, table, row_count, timeout_sec=60):
 # ---------------------------------------------------------------------------
 
 
-_ARGS = argparse.Namespace(repo=None, versions=None)
+_ARGS = argparse.Namespace(repo=None, versions=None, docker=None)
 
 
 class FailoverTest(unittest.TestCase):
@@ -398,7 +523,9 @@ class FailoverTest(unittest.TestCase):
     def setUpClass(cls):
         proj = Project()
 
-        cls.jar = _resolve_jar(_ARGS)
+        # In docker mode the image supplies the server; otherwise resolve
+        # (or download/build) a jar to run as a local process.
+        cls.jar = None if _ARGS.docker else _resolve_jar(_ARGS)
 
         # The two data dirs the test brief asks for, side by side under
         # the project's build/questdb/.
@@ -413,8 +540,16 @@ class FailoverTest(unittest.TestCase):
             cls.exhaustion_client_bin,
         ) = _build_helper_clients()
 
-        cls.server1 = StandaloneInstance(cls.jar, cls.server1_dir, 'server1')
-        cls.server2 = StandaloneInstance(cls.jar, cls.server2_dir, 'server2')
+        if _ARGS.docker:
+            cls.server1 = DockerStandaloneInstance(
+                _ARGS.docker, cls.server1_dir, 'server1')
+            cls.server2 = DockerStandaloneInstance(
+                _ARGS.docker, cls.server2_dir, 'server2')
+        else:
+            cls.server1 = StandaloneInstance(
+                cls.jar, cls.server1_dir, 'server1')
+            cls.server2 = StandaloneInstance(
+                cls.jar, cls.server2_dir, 'server2')
         cls.server1.start()
         try:
             cls.server2.start()
@@ -1014,6 +1149,11 @@ def _add_run_flags(p):
         '--versions', nargs='+',
         help='Test against this specific QuestDB version (only the '
              'first is used).')
+    p.add_argument(
+        '--docker', metavar='IMAGE',
+        help='Test against a QuestDB docker image, e.g. '
+             '`questdb/questdb:nightly`. Each instance runs in its own '
+             'container; the crash is a `docker kill` (SIGKILL).')
     p.add_argument(
         '-v', '--verbose', action='store_true',
         help='Pass -v through to unittest.')

--- a/system_test/test_egress_failover.py
+++ b/system_test/test_egress_failover.py
@@ -286,6 +286,19 @@ class DockerStandaloneInstance:
         the server close gracefully and would NOT exercise failover.
       - `stop()` => `docker stop` (SIGTERM): a graceful shutdown.
 
+    Networking uses `--network host` rather than published ports. A
+    published port goes through docker-proxy, a userland copy-loop that
+    eagerly drains the server's stream into its own buffer regardless of
+    the WS reader's app-level pacing; after `docker kill` the client
+    keeps reading those buffered batches, so the exhaustion tests (which
+    require next_batch() to fail once every endpoint is dead) wrongly see
+    Ok. `--network host` removes docker-proxy, so the client talks
+    straight to the server on loopback and the kill is observed
+    immediately - exactly as for a local process. (Consequence:
+    docker-mode failover requires a Linux host with real host
+    networking; Docker Desktop on macOS/Windows cannot reach a
+    host-networked container, so use --repo there.)
+
     The data dir is only used as a place to persist the captured
     container log (`docker logs`) for `dump_log()` and CI archival; the
     server's own data lives inside the ephemeral container.
@@ -317,11 +330,13 @@ class DockerStandaloneInstance:
             'QDB_TELEMETRY_ENABLED': 'false',
             'QDB_CAIRO_COMMIT_LAG': '100',
         }
-        cmd = ['run', '-d', '--name', self._container]
+        # --network host (not -p): see the class docstring. The server
+        # binds the discovered ports directly on the host stack, so the
+        # client reaches it on 127.0.0.1:<port> with no docker-proxy
+        # buffering between them.
+        cmd = ['run', '-d', '--name', self._container, '--network', 'host']
         for key, value in env.items():
             cmd += ['-e', f'{key}={value}']
-        for port in (self.http_port, self.ilp_port, self.pg_port):
-            cmd += ['-p', f'127.0.0.1:{port}:{port}']
         cmd += [self.image]
         sys.stderr.write(
             f'[{self.label}] docker run {self._container} '

--- a/system_test/test_egress_failover.py
+++ b/system_test/test_egress_failover.py
@@ -286,18 +286,13 @@ class DockerStandaloneInstance:
         the server close gracefully and would NOT exercise failover.
       - `stop()` => `docker stop` (SIGTERM): a graceful shutdown.
 
-    Networking uses `--network host` rather than published ports. A
-    published port goes through docker-proxy, a userland copy-loop that
-    eagerly drains the server's stream into its own buffer regardless of
-    the WS reader's app-level pacing; after `docker kill` the client
-    keeps reading those buffered batches, so the exhaustion tests (which
-    require next_batch() to fail once every endpoint is dead) wrongly see
-    Ok. `--network host` removes docker-proxy, so the client talks
-    straight to the server on loopback and the kill is observed
-    immediately - exactly as for a local process. (Consequence:
-    docker-mode failover requires a Linux host with real host
-    networking; Docker Desktop on macOS/Windows cannot reach a
-    host-networked container, so use --repo there.)
+    Ports are published 1:1 on loopback (same as the integration
+    fixture), so the client reaches the server at 127.0.0.1:<port>. Note
+    that with a published port the optimised release server can stream
+    the next result batch into the client's buffer before `docker kill`
+    lands, so after the kill `next_batch()` may still return one or more
+    already-received batches; the exhaustion helper drains those before
+    asserting the reader surfaces an error (see exhaustion_client.rs).
 
     The data dir is only used as a place to persist the captured
     container log (`docker logs`) for `dump_log()` and CI archival; the
@@ -330,13 +325,11 @@ class DockerStandaloneInstance:
             'QDB_TELEMETRY_ENABLED': 'false',
             'QDB_CAIRO_COMMIT_LAG': '100',
         }
-        # --network host (not -p): see the class docstring. The server
-        # binds the discovered ports directly on the host stack, so the
-        # client reaches it on 127.0.0.1:<port> with no docker-proxy
-        # buffering between them.
-        cmd = ['run', '-d', '--name', self._container, '--network', 'host']
+        cmd = ['run', '-d', '--name', self._container]
         for key, value in env.items():
             cmd += ['-e', f'{key}={value}']
+        for port in (self.http_port, self.ilp_port, self.pg_port):
+            cmd += ['-p', f'127.0.0.1:{port}:{port}']
         cmd += [self.image]
         sys.stderr.write(
             f'[{self.label}] docker run {self._container} '


### PR DESCRIPTION
## What

Replaces the from-source build of QuestDB master in the **"Vs QuestDB master"** integration job with the prebuilt **`questdb/questdb:nightly`** docker image. The nightly image tracks master, so the "did QuestDB master break the client?" signal is preserved while the Maven + Rust from-source build is dropped from this job.

Both the integration matrix and the mid-query failover suite now run against the container (the scope agreed up front).

## How

**Harness (`system_test/`)**
- `fixture.py` — new `QuestDbDockerFixture`, a drop-in for `QuestDbFixture`:
  - config injected via `QDB_*` env vars (no conf file mount needed);
  - container ports published **1:1 on loopback**, so a client still connects to `127.0.0.1:<port>`;
  - server log read via `docker logs` (the image logs to stdout); data is ephemeral and removed with the container on `stop()`;
  - ILP TCP auth via a read-only single-file bind mount at `conf/auth.txt`;
  - `stop()` → `docker stop` (graceful SIGTERM); `kill()` → `docker kill` (SIGKILL);
  - `_check_http_up()` tolerates a connection reset, because docker publishes the host port *before* QuestDB is ready (the local-process fixture never saw this).
- `test_egress_failover.py` — new `DockerStandaloneInstance` with the same crash semantics.
- `test.py` / `test_egress_failover.py` — new `--docker IMAGE` flag.

**CI (`ci/run_tests_pipeline.yaml`)**
- The job pulls `questdb/questdb:nightly` and runs `test.py run --docker` + `test_egress_failover.py run --docker`. No Maven/Rust QuestDB build.
- Moved back to Microsoft-hosted `ubuntu-latest` (docker preinstalled). The disk pressure that originally pushed this job to `hetzner-incus` was the from-source build + on-host server data, both now gone.
- The from-source `clone_questdb.yaml` template is unchanged and still used by the mac/windows/linux fuzz jobs.

## Why `docker kill`, not `docker stop`, for failover

The failover test deliberately SIGKILLs the primary mid-stream to simulate a crash with **no graceful WebSocket Close** — that ungraceful drop is what makes the client fail over. `docker stop` sends a trappable SIGTERM (the JVM closes connections cleanly), which would *not* engage failover. So the crash maps to `docker kill` (SIGKILL); only the genuinely-graceful path uses `docker stop`.

## Local validation (against `questdb/questdb:nightly`)

- Integration matrix: `auth` on/off, build modes (API/CONF/ENV), TLS proxy — pass.
- Mid-query failover: `docker kill` of server #1 → `failover_resets=1`, 1,000,000 rows replayed, final endpoint = server #2 — pass.
- No leftover containers after runs.

## Tradeoffs / things to check before merge

- **Pool choice.** `ubuntu-latest` guarantees docker but the disk-fill that moved this job to `hetzner-incus` was attributed to the fuzz portion. The from-source build (the bigger consumer) is gone, so this should be fine, but if disk pressure recurs the fallback is a higher-headroom pool that also has docker.
- **Required-check name changed.** The job is renamed `TestVsQuestDBMaster` → `TestVsQuestDBNightly` ("Vs QuestDB nightly (docker)"). If a branch policy lists the old check name as required, update it.
- **Coverage delta: QWP UDP.** It is gated on `--repo` in `test.py`, so it is not exercised in docker mode. That coverage still runs in the from-source jobs; not ported here to avoid an unvalidated UDP-over-docker path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Docker container support for running system tests against prebuilt Docker images
  * Improved test infrastructure to support multiple execution modes

* **Chores**
  * Updated CI pipeline to execute tests using nightly Docker images instead of building from source
  * Enhanced failover testing to support both local and containerized execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->