### PR TITLE
feat(rust): pooled `Db` facade with custom high-performance connection pooling

### DIFF
--- a/questdb-rs/Cargo.toml
+++ b/questdb-rs/Cargo.toml
@@ -172,6 +172,11 @@ sync-reader-ws = ["_egress", "_keystore-roots"]
 ## Decompression for `FLAG_ZSTD` `RESULT_BATCH` payloads.
 compression-zstd = ["_egress", "dep:zstd"]
 
+## Pooled `Db` facade: a custom high-performance pool of ingest `Sender`s and
+## egress `Reader`s behind one cloneable handle. Pulls in the egress reader
+## (WS) plus the HTTP and QWP/WS sender transports the facade relies on.
+pool = ["sync-reader-ws", "sync-sender-http", "sync-sender-qwp-ws"]
+
 ## Run integration tests against a real QuestDB server launched from the
 ## `questdb/` submodule. Requires JDK 25 + Maven and a built jar at
 ## `../questdb/core/target/questdb-*-SNAPSHOT.jar`.
@@ -180,6 +185,7 @@ live-server-tests = [
     "compression-zstd",
     "sync-sender-http",
     "sync-sender-qwp-ws",
+    "pool",
 ]
 
 # Hidden derived features, used in code to enable-disable code sections. Don't use directly.
@@ -200,6 +206,7 @@ almost-all-features = [
     "sync-sender",
     "sync-reader-ws",
     "compression-zstd",
+    "pool",
     "tls-webpki-certs",
     "tls-native-certs",
     "ring-crypto",
@@ -254,6 +261,10 @@ required-features = ["sync-reader-ws"]
 [[example]]
 name = "qwp_ws_unified_sfa_bench"
 required-features = ["sync-sender-qwp-ws"]
+
+[[example]]
+name = "db_pool"
+required-features = ["pool"]
 
 # Decoder microbenchmark anchoring the perf claims from commits
 # `8ec0a85` (zero-copy decode) and `1163d43` (tighter SYMBOL/VARCHAR

--- a/questdb-rs/examples/db_pool.rs
+++ b/questdb-rs/examples/db_pool.rs
@@ -1,0 +1,91 @@
+//! Pooled `Db` facade: one cloneable handle that pools both ingest senders
+//! and egress readers, so application code never opens or closes a connection.
+//!
+//! Run (needs a local QuestDB on :9000):
+//!     cargo run --example db_pool --features pool
+//!
+//! Env:
+//!     QDB_HOST=localhost  QDB_PORT=9000
+
+use questdb::db::Db;
+use questdb::egress::column::ColumnView;
+use questdb::ingress::TimestampNanos;
+use std::time::Duration;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let host = std::env::var("QDB_HOST").unwrap_or_else(|_| "localhost".into());
+    let port: u16 = std::env::var("QDB_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(9000);
+
+    // Build one handle for the whole deployment. Ingest over HTTP, query over
+    // WS, with explicit pool sizing. `Db` is `Clone` (cheap, Arc-backed) — clone
+    // it into every thread; the pools guarantee mutual exclusion of slots.
+    let db = Db::builder()
+        .ingest_config(&format!("http::addr={host}:{port};"))
+        .query_config(&format!("ws::addr={host}:{port};"))
+        .sender_pool_max(8)
+        .query_pool_max(4)
+        .acquire_timeout(Duration::from_secs(5))
+        .idle_timeout(Duration::from_secs(30))
+        .build()?;
+
+    // --- Ingest: borrow a sender, build rows, flush. Returns to the pool on
+    // drop; no connection lifecycle in user code. ---
+    {
+        let mut sender = db.borrow_sender()?;
+        let mut buf = sender.new_buffer();
+        for i in 0..1_000i64 {
+            buf.table("db_pool_demo")?
+                .symbol("sym", if i % 2 == 0 { "ETH-USD" } else { "BTC-USD" })?
+                .column_i64("id", i)?
+                .column_f64("price", i as f64 * 1.5)?
+                .at(TimestampNanos::now())?;
+        }
+        sender.flush(&mut buf)?;
+        println!(
+            "ingested 1000 rows; sender pool size = {}",
+            db.sender_pool_size()
+        );
+    }
+
+    // --- Query: run a SELECT and consume batches. The reader returns to the
+    // pool clean once the query reaches its terminal. ---
+    let mut total_price = 0.0f64;
+    let summary = db.execute_query("select id, price from db_pool_demo", |batch| {
+        if let Ok(ColumnView::Double(price)) = batch.column(1) {
+            for r in 0..batch.row_count() {
+                if !price.is_null(r) {
+                    total_price += price.value(r);
+                }
+            }
+        }
+        true // keep streaming; return false to stop early (auto-cancels)
+    })?;
+
+    println!(
+        "queried {} rows in {} batches; price sum = {total_price:.1}; query pool size = {}",
+        summary.rows,
+        summary.batches,
+        db.reader_pool_size()
+    );
+
+    // Demonstrate concurrent use from multiple threads sharing the one handle.
+    let mut handles = Vec::new();
+    for t in 0..4 {
+        let db = db.clone();
+        handles.push(std::thread::spawn(move || {
+            let s = db
+                .execute_query("select count() from db_pool_demo", |_b| true)
+                .expect("query");
+            println!("thread {t}: {} batch(es)", s.batches);
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    db.close();
+    Ok(())
+}

--- a/questdb-rs/src/db.rs
+++ b/questdb-rs/src/db.rs
@@ -1,0 +1,839 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2025 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+//! [`Db`]: a pooled, shareable handle to a QuestDB deployment.
+//!
+//! [`Db`] owns two elastic connection pools — one of ingest [`Sender`]s and
+//! one of egress [`Reader`]s — plus a background housekeeper that reaps idle
+//! connections. Construct it once and clone it freely across threads; callers
+//! never open or close a connection themselves.
+//!
+//! This mirrors the reference Java client's `QuestDB` facade, but uses Rust
+//! RAII ([`PooledSender`] / [`PooledReader`] return to the pool on drop)
+//! instead of an explicit `close()`-to-return decorator, and runs queries
+//! synchronously on the calling thread (the egress reader is sync/pull-based,
+//! so no per-query worker thread is needed).
+//!
+//! ```no_run
+//! use questdb::db::Db;
+//! use questdb::ingress::TimestampNanos;
+//!
+//! # fn main() -> Result<(), questdb::db::DbError> {
+//! // One handle for the whole deployment; ingest over HTTP, query over WS.
+//! let db = Db::connect("http::addr=localhost:9000;", "ws::addr=localhost:9000;")?;
+//!
+//! // Ingest: borrow a sender, build rows, flush. Returns to the pool on drop.
+//! {
+//!     let mut sender = db.borrow_sender()?;
+//!     let mut buf = sender.new_buffer();
+//!     buf.table("trades")?
+//!         .symbol("sym", "ETH-USD")?
+//!         .column_f64("price", 2615.54)?
+//!         .at(TimestampNanos::now())?;
+//!     sender.flush(&mut buf)?;
+//! }
+//!
+//! // Query: run a SELECT, consume batches. The reader returns to the pool.
+//! let summary = db.execute_query("select * from trades limit 100", |batch| {
+//!     println!("got {} rows", batch.row_count());
+//!     true // keep streaming; return false to stop early
+//! })?;
+//! println!("total rows: {}", summary.rows);
+//! # Ok(())
+//! # }
+//! ```
+
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use crate::egress::reader::{BatchView, Reader};
+use crate::ingress::Sender;
+use crate::pool::{Manage, Pool, PoolConfig, PoolError, Pooled};
+
+// Both pooled connection types must be `Send` to live behind the pool's mutex
+// and be borrowed from any thread. Pin it at compile time so a future field
+// addition that flips either off `Send` breaks here, not at a confusing use
+// site.
+const _: fn() = || {
+    fn assert_send<T: Send>() {}
+    assert_send::<Sender>();
+    assert_send::<Reader>();
+    assert_send::<Db>();
+};
+
+// ---------------------------------------------------------------------------
+// Defaults (mirroring the Java client's QuestDBBuilder).
+// ---------------------------------------------------------------------------
+
+/// Default [`DbBuilder::acquire_timeout`]: how long a borrow blocks when the
+/// pool is exhausted.
+pub const DEFAULT_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Default [`DbBuilder::housekeeper_interval`]: idle-reap sweep period.
+pub const DEFAULT_HOUSEKEEPER_INTERVAL: Duration = Duration::from_secs(5);
+/// Default [`DbBuilder::idle_timeout`]: idle connections older than this are
+/// reaped.
+pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+/// Default [`DbBuilder::max_lifetime`]: connections older than this are
+/// recycled once idle.
+pub const DEFAULT_MAX_LIFETIME: Duration = Duration::from_secs(30 * 60);
+/// Default minimum pool size (kept warm).
+pub const DEFAULT_POOL_MIN: usize = 1;
+/// Default maximum pool size.
+pub const DEFAULT_POOL_MAX: usize = 4;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors returned by [`Db`] operations.
+#[derive(Debug)]
+pub enum DbError {
+    /// Invalid configuration (bad pool sizing or an unparseable unified
+    /// connect string).
+    Config(String),
+    /// The pool was exhausted and no connection became free within the
+    /// configured acquire timeout. `pool` is `"sender"` or `"query"`.
+    AcquireTimeout {
+        /// Which pool timed out.
+        pool: &'static str,
+    },
+    /// The [`Db`] handle (or the underlying pool) has been closed.
+    Closed,
+    /// An ingest-side error (opening a [`Sender`] or a `flush`).
+    Ingest(crate::Error),
+    /// A query-side error (opening a [`Reader`] or executing a query).
+    Query(crate::egress::Error),
+}
+
+impl std::fmt::Display for DbError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DbError::Config(m) => write!(f, "invalid Db configuration: {m}"),
+            DbError::AcquireTimeout { pool } => {
+                write!(f, "timed out waiting for a connection from the {pool} pool")
+            }
+            DbError::Closed => write!(f, "the Db handle is closed"),
+            DbError::Ingest(e) => write!(f, "ingest error: {e}"),
+            DbError::Query(e) => write!(f, "query error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for DbError {}
+
+impl From<crate::Error> for DbError {
+    fn from(e: crate::Error) -> Self {
+        DbError::Ingest(e)
+    }
+}
+
+impl From<crate::egress::Error> for DbError {
+    fn from(e: crate::egress::Error) -> Self {
+        DbError::Query(e)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pool managers
+// ---------------------------------------------------------------------------
+
+struct SenderManager {
+    conf: String,
+}
+
+impl Manage for SenderManager {
+    type Conn = Sender;
+    type Error = crate::Error;
+
+    fn connect(&self) -> crate::Result<Sender> {
+        Sender::from_conf(&self.conf)
+    }
+
+    fn recycle(&self, sender: &mut Sender) -> bool {
+        // A sender that has latched a fatal error must not be reused. This is
+        // a cheap flag check (no I/O), as `recycle` requires.
+        !sender.must_close()
+    }
+}
+
+struct ReaderManager {
+    conf: String,
+}
+
+impl Manage for ReaderManager {
+    type Conn = Reader;
+    type Error = crate::egress::Error;
+
+    fn connect(&self) -> crate::egress::Result<Reader> {
+        Reader::from_conf(&self.conf)
+    }
+
+    // No cheap liveness probe exists for a Reader, so reuse-fitness is driven
+    // by `Pooled::mark_broken` from the query path instead of `recycle`.
+}
+
+// ---------------------------------------------------------------------------
+// Pooled guards
+// ---------------------------------------------------------------------------
+
+/// A [`Sender`] leased from a [`Db`]'s ingest pool. Derefs to [`Sender`], so
+/// the full ingest API is available directly. Returns to the pool on drop
+/// (discarded instead if the sender has latched a fatal error).
+pub struct PooledSender {
+    inner: Pooled<SenderManager>,
+}
+
+impl std::ops::Deref for PooledSender {
+    type Target = Sender;
+    fn deref(&self) -> &Sender {
+        &self.inner
+    }
+}
+
+impl std::ops::DerefMut for PooledSender {
+    fn deref_mut(&mut self) -> &mut Sender {
+        &mut self.inner
+    }
+}
+
+/// A [`Reader`] leased from a [`Db`]'s query pool. Derefs to [`Reader`].
+///
+/// Prefer [`Db::execute_query`] for the common case — it drives the query to
+/// completion and guarantees the reader returns to the pool clean. When using
+/// the reader directly and abandoning a cursor before it reaches a terminal
+/// (which closes the underlying connection), call [`PooledReader::mark_broken`]
+/// so the dead connection is discarded rather than returned.
+pub struct PooledReader {
+    inner: Pooled<ReaderManager>,
+}
+
+impl PooledReader {
+    /// Marks the underlying reader unfit for reuse: it is discarded (not
+    /// returned to the pool) when this guard drops.
+    pub fn mark_broken(&mut self) {
+        self.inner.mark_broken();
+    }
+}
+
+impl std::ops::Deref for PooledReader {
+    type Target = Reader;
+    fn deref(&self) -> &Reader {
+        &self.inner
+    }
+}
+
+impl std::ops::DerefMut for PooledReader {
+    fn deref_mut(&mut self) -> &mut Reader {
+        &mut self.inner
+    }
+}
+
+/// Outcome of a [`Db::execute_query`] call.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct QuerySummary {
+    /// Total rows streamed across all batches.
+    pub rows: u64,
+    /// Number of `RESULT_BATCH` frames consumed.
+    pub batches: u64,
+    /// `true` if the caller's handler asked to stop before the stream ended.
+    pub stopped_early: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Housekeeper
+// ---------------------------------------------------------------------------
+
+struct HkSignal {
+    stop: Mutex<bool>,
+    cv: Condvar,
+}
+
+struct Housekeeper {
+    signal: Arc<HkSignal>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Housekeeper {
+    fn start(
+        senders: Pool<SenderManager>,
+        readers: Pool<ReaderManager>,
+        interval: Duration,
+    ) -> Housekeeper {
+        let signal = Arc::new(HkSignal {
+            stop: Mutex::new(false),
+            cv: Condvar::new(),
+        });
+        let sig = Arc::clone(&signal);
+        let handle = thread::Builder::new()
+            .name("questdb-pool-housekeeper".to_string())
+            .spawn(move || {
+                loop {
+                    let stop = sig.stop.lock().unwrap();
+                    if *stop {
+                        return;
+                    }
+                    let (stop, _) = sig.cv.wait_timeout(stop, interval).unwrap();
+                    let stopping = *stop;
+                    drop(stop);
+                    if stopping {
+                        return;
+                    }
+                    // Reaping is best-effort; a closed pool is a no-op.
+                    senders.reap_idle();
+                    readers.reap_idle();
+                }
+            })
+            .expect("failed to spawn questdb-pool-housekeeper thread");
+        Housekeeper {
+            signal,
+            handle: Some(handle),
+        }
+    }
+
+    fn stop(&mut self) {
+        {
+            let mut stop = self.signal.stop.lock().unwrap();
+            *stop = true;
+        }
+        self.signal.cv.notify_all();
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Db
+// ---------------------------------------------------------------------------
+
+struct DbInner {
+    senders: Pool<SenderManager>,
+    readers: Pool<ReaderManager>,
+    housekeeper: Mutex<Housekeeper>,
+}
+
+impl Drop for DbInner {
+    fn drop(&mut self) {
+        if let Ok(mut hk) = self.housekeeper.lock() {
+            hk.stop();
+        }
+        self.readers.close();
+        self.senders.close();
+    }
+}
+
+/// A pooled, cheaply-cloneable handle to a QuestDB deployment. See the
+/// [module docs](self) for an overview.
+#[derive(Clone)]
+pub struct Db {
+    inner: Arc<DbInner>,
+}
+
+impl Db {
+    /// Starts a [`DbBuilder`] for advanced configuration (pool sizes,
+    /// timeouts, differing ingest/query configs).
+    pub fn builder() -> DbBuilder {
+        DbBuilder::new()
+    }
+
+    /// Connects with explicit ingest and query configuration strings, using
+    /// default pool sizing. `ingest_conf` is a [`Sender`] config (e.g.
+    /// `"http::addr=host:9000;"`); `query_conf` is a [`Reader`] config (e.g.
+    /// `"ws::addr=host:9000;"`).
+    pub fn connect(ingest_conf: &str, query_conf: &str) -> Result<Db, DbError> {
+        DbBuilder::new()
+            .ingest_config(ingest_conf)
+            .query_config(query_conf)
+            .build()
+    }
+
+    /// Connects with a single unified config string used for both ingest and
+    /// query. The scheme must be `http`, `https`, `ws`, or `wss`; the other
+    /// half is derived (`http`<->`ws`, `https`<->`wss`).
+    ///
+    /// Only a portable subset of parameters is carried across (`addr`,
+    /// `username`, `password`, `token`, and TLS settings). For transport-
+    /// specific tuning, use [`Db::connect`] or [`Db::builder`] with explicit
+    /// configs.
+    pub fn from_conf(unified: &str) -> Result<Db, DbError> {
+        DbBuilder::new().from_conf(unified)?.build()
+    }
+
+    /// Borrows a [`Sender`] from the ingest pool, blocking up to the
+    /// configured acquire timeout. The returned guard returns the sender to
+    /// the pool when dropped.
+    pub fn borrow_sender(&self) -> Result<PooledSender, DbError> {
+        match self.inner.senders.borrow() {
+            Ok(inner) => Ok(PooledSender { inner }),
+            Err(PoolError::Timeout) => Err(DbError::AcquireTimeout { pool: "sender" }),
+            Err(PoolError::Closed) => Err(DbError::Closed),
+            Err(PoolError::Connect(e)) => Err(DbError::Ingest(e)),
+        }
+    }
+
+    /// Borrows a [`Reader`] from the query pool, blocking up to the configured
+    /// acquire timeout. The returned guard returns the reader to the pool when
+    /// dropped.
+    ///
+    /// For most queries, prefer [`Db::execute_query`] — it guarantees the
+    /// reader returns clean. See [`PooledReader`] for the contract when
+    /// driving the reader directly.
+    pub fn borrow_reader(&self) -> Result<PooledReader, DbError> {
+        match self.inner.readers.borrow() {
+            Ok(inner) => Ok(PooledReader { inner }),
+            Err(PoolError::Timeout) => Err(DbError::AcquireTimeout { pool: "query" }),
+            Err(PoolError::Closed) => Err(DbError::Closed),
+            Err(PoolError::Connect(e)) => Err(DbError::Query(e)),
+        }
+    }
+
+    /// Runs a query, invoking `on_batch` for each result batch, and returns a
+    /// [`QuerySummary`]. The handler returns `true` to keep streaming or
+    /// `false` to stop early (the query is then cancelled cleanly).
+    ///
+    /// Borrows a reader for the duration and returns it to the pool clean on
+    /// success, or discards it if the query errors. This is the recommended
+    /// query entry point.
+    pub fn execute_query<F>(&self, sql: &str, on_batch: F) -> Result<QuerySummary, DbError>
+    where
+        F: FnMut(&BatchView) -> bool,
+    {
+        let mut reader = self.borrow_reader()?;
+        match run_query(&mut reader, sql, on_batch) {
+            Ok(summary) => Ok(summary),
+            Err(e) => {
+                // A mid-stream error may have closed the connection; don't
+                // hand a dead reader back to the next borrower.
+                reader.mark_broken();
+                Err(DbError::Query(e))
+            }
+        }
+    }
+
+    /// Closes both pools, releasing all idle connections. In-flight borrows
+    /// are released as their guards drop. Idempotent. The handle is unusable
+    /// afterwards (borrows return [`DbError::Closed`]). The housekeeper thread
+    /// is stopped when the last [`Db`] clone is dropped.
+    pub fn close(&self) {
+        self.inner.readers.close();
+        self.inner.senders.close();
+    }
+
+    /// Total live connections in the ingest pool (idle + leased). For tests
+    /// and introspection.
+    pub fn sender_pool_size(&self) -> usize {
+        self.inner.senders.size()
+    }
+
+    /// Total live connections in the query pool (idle + leased). For tests and
+    /// introspection.
+    pub fn reader_pool_size(&self) -> usize {
+        self.inner.readers.size()
+    }
+}
+
+fn run_query<F>(
+    reader: &mut Reader,
+    sql: &str,
+    mut on_batch: F,
+) -> crate::egress::Result<QuerySummary>
+where
+    F: FnMut(&BatchView) -> bool,
+{
+    let mut cursor = reader.execute(sql)?;
+    let mut rows: u64 = 0;
+    let mut batches: u64 = 0;
+    let mut stopped_early = false;
+    while let Some(batch) = cursor.next_batch()? {
+        rows += batch.row_count() as u64;
+        batches += 1;
+        if !on_batch(&batch) {
+            stopped_early = true;
+            break;
+        }
+    }
+    if stopped_early {
+        // Drain to terminal so the connection stays reusable (a bare drop
+        // would close the socket).
+        cursor.cancel()?;
+    }
+    Ok(QuerySummary {
+        rows,
+        batches,
+        stopped_early,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+/// Builder for [`Db`]. Defaults match the reference Java client: min 1 / max 4
+/// per pool, 5s acquire timeout, 60s idle timeout, 30min max lifetime, 5s
+/// housekeeper interval.
+pub struct DbBuilder {
+    ingest_conf: Option<String>,
+    query_conf: Option<String>,
+    sender_min: usize,
+    sender_max: usize,
+    query_min: usize,
+    query_max: usize,
+    acquire_timeout: Duration,
+    idle_timeout: Option<Duration>,
+    max_lifetime: Option<Duration>,
+    housekeeper_interval: Duration,
+}
+
+impl Default for DbBuilder {
+    fn default() -> Self {
+        DbBuilder::new()
+    }
+}
+
+impl DbBuilder {
+    fn new() -> Self {
+        DbBuilder {
+            ingest_conf: None,
+            query_conf: None,
+            sender_min: DEFAULT_POOL_MIN,
+            sender_max: DEFAULT_POOL_MAX,
+            query_min: DEFAULT_POOL_MIN,
+            query_max: DEFAULT_POOL_MAX,
+            acquire_timeout: DEFAULT_ACQUIRE_TIMEOUT,
+            idle_timeout: Some(DEFAULT_IDLE_TIMEOUT),
+            max_lifetime: Some(DEFAULT_MAX_LIFETIME),
+            housekeeper_interval: DEFAULT_HOUSEKEEPER_INTERVAL,
+        }
+    }
+
+    /// Sets the ingest-side [`Sender`] config string.
+    pub fn ingest_config(mut self, conf: &str) -> Self {
+        self.ingest_conf = Some(conf.to_string());
+        self
+    }
+
+    /// Sets the query-side [`Reader`] config string.
+    pub fn query_config(mut self, conf: &str) -> Self {
+        self.query_conf = Some(conf.to_string());
+        self
+    }
+
+    /// Derives both ingest and query configs from one unified string by schema
+    /// translation. See [`Db::from_conf`].
+    pub fn from_conf(mut self, unified: &str) -> Result<Self, DbError> {
+        let (ingest, query) = derive_both_sides(unified)?;
+        self.ingest_conf = Some(ingest);
+        self.query_conf = Some(query);
+        Ok(self)
+    }
+
+    /// Minimum ingest-pool size kept warm. Default 1.
+    pub fn sender_pool_min(mut self, min: usize) -> Self {
+        self.sender_min = min;
+        self
+    }
+
+    /// Maximum ingest-pool size. Default 4.
+    pub fn sender_pool_max(mut self, max: usize) -> Self {
+        self.sender_max = max;
+        self
+    }
+
+    /// Fixed ingest-pool size shortcut (`min == max == size`): eager, no
+    /// growth or reaping.
+    pub fn sender_pool_size(mut self, size: usize) -> Self {
+        self.sender_min = size;
+        self.sender_max = size;
+        self
+    }
+
+    /// Minimum query-pool size kept warm. Default 1.
+    pub fn query_pool_min(mut self, min: usize) -> Self {
+        self.query_min = min;
+        self
+    }
+
+    /// Maximum query-pool size. Default 4.
+    pub fn query_pool_max(mut self, max: usize) -> Self {
+        self.query_max = max;
+        self
+    }
+
+    /// Fixed query-pool size shortcut (`min == max == size`): eager, no growth
+    /// or reaping.
+    pub fn query_pool_size(mut self, size: usize) -> Self {
+        self.query_min = size;
+        self.query_max = size;
+        self
+    }
+
+    /// How long a borrow blocks when the pool is exhausted before returning
+    /// [`DbError::AcquireTimeout`]. Default 5s; [`Duration::ZERO`] fails fast.
+    pub fn acquire_timeout(mut self, timeout: Duration) -> Self {
+        self.acquire_timeout = timeout;
+        self
+    }
+
+    /// How long a connection may sit idle before the housekeeper reaps it
+    /// (never below the pool minimum). [`Duration::ZERO`] disables idle
+    /// reaping. Default 60s.
+    pub fn idle_timeout(mut self, timeout: Duration) -> Self {
+        self.idle_timeout = if timeout.is_zero() {
+            None
+        } else {
+            Some(timeout)
+        };
+        self
+    }
+
+    /// Maximum age of a connection before it is recycled once idle.
+    /// [`Duration::ZERO`] disables age-based recycling. Default 30min.
+    pub fn max_lifetime(mut self, lifetime: Duration) -> Self {
+        self.max_lifetime = if lifetime.is_zero() {
+            None
+        } else {
+            Some(lifetime)
+        };
+        self
+    }
+
+    /// Housekeeper sweep interval. Default 5s.
+    pub fn housekeeper_interval(mut self, interval: Duration) -> Self {
+        self.housekeeper_interval = interval;
+        self
+    }
+
+    /// Builds the [`Db`], eagerly pre-warming `min` connections in each pool.
+    pub fn build(self) -> Result<Db, DbError> {
+        let ingest_conf = self
+            .ingest_conf
+            .ok_or_else(|| DbError::Config("ingest configuration is required".to_string()))?;
+        let query_conf = self
+            .query_conf
+            .ok_or_else(|| DbError::Config("query configuration is required".to_string()))?;
+
+        validate_sizing("sender", self.sender_min, self.sender_max)?;
+        validate_sizing("query", self.query_min, self.query_max)?;
+
+        let sender_cfg = PoolConfig {
+            min: self.sender_min,
+            max: self.sender_max,
+            acquire_timeout: self.acquire_timeout,
+            idle_timeout: self.idle_timeout,
+            max_lifetime: self.max_lifetime,
+        };
+        let query_cfg = PoolConfig {
+            min: self.query_min,
+            max: self.query_max,
+            acquire_timeout: self.acquire_timeout,
+            idle_timeout: self.idle_timeout,
+            max_lifetime: self.max_lifetime,
+        };
+
+        let senders = Pool::new(SenderManager { conf: ingest_conf }, sender_cfg)
+            .map_err(map_sender_pool_err)?;
+        let readers = match Pool::new(ReaderManager { conf: query_conf }, query_cfg) {
+            Ok(r) => r,
+            Err(e) => {
+                // Roll back the sender pool we already pre-warmed.
+                senders.close();
+                return Err(map_reader_pool_err(e));
+            }
+        };
+
+        let housekeeper =
+            Housekeeper::start(senders.clone(), readers.clone(), self.housekeeper_interval);
+
+        Ok(Db {
+            inner: Arc::new(DbInner {
+                senders,
+                readers,
+                housekeeper: Mutex::new(housekeeper),
+            }),
+        })
+    }
+}
+
+fn validate_sizing(name: &str, min: usize, max: usize) -> Result<(), DbError> {
+    if max < 1 {
+        return Err(DbError::Config(format!("{name} pool max must be >= 1")));
+    }
+    if min > max {
+        return Err(DbError::Config(format!(
+            "{name} pool min ({min}) must be <= max ({max})"
+        )));
+    }
+    Ok(())
+}
+
+fn map_sender_pool_err(e: PoolError<crate::Error>) -> DbError {
+    match e {
+        PoolError::Connect(e) => DbError::Ingest(e),
+        PoolError::Timeout => DbError::AcquireTimeout { pool: "sender" },
+        PoolError::Closed => DbError::Closed,
+    }
+}
+
+fn map_reader_pool_err(e: PoolError<crate::egress::Error>) -> DbError {
+    match e {
+        PoolError::Connect(e) => DbError::Query(e),
+        PoolError::Timeout => DbError::AcquireTimeout { pool: "query" },
+        PoolError::Closed => DbError::Closed,
+    }
+}
+
+/// Parameters carried across when deriving both sides from a unified config.
+/// Everything else is transport-specific and dropped; use explicit configs to
+/// pass those.
+const PORTABLE_KEYS: &[&str] = &[
+    "addr",
+    "username",
+    "password",
+    "token",
+    "tls_verify",
+    "tls_ca",
+    "tls_roots",
+    "tls_roots_password",
+];
+
+fn derive_both_sides(unified: &str) -> Result<(String, String), DbError> {
+    let (scheme, params) = unified.split_once("::").ok_or_else(|| {
+        DbError::Config(format!(
+            "unified config must start with a scheme, e.g. \"http::addr=...\" (got {unified:?})"
+        ))
+    })?;
+
+    let (ingest_scheme, query_scheme) = match scheme {
+        "http" | "ws" => ("http", "ws"),
+        "https" | "wss" => ("https", "wss"),
+        other => {
+            return Err(DbError::Config(format!(
+                "unified config scheme must be http|https|ws|wss (got {other:?}); \
+                 use Db::connect or Db::builder with explicit ingest/query configs"
+            )));
+        }
+    };
+
+    let mut carried: Vec<&str> = Vec::new();
+    for part in params.split(';') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let key = part.split_once('=').map(|(k, _)| k).unwrap_or(part);
+        if PORTABLE_KEYS.contains(&key) {
+            carried.push(part);
+        }
+    }
+    if !carried.iter().any(|p| p.starts_with("addr=")) {
+        return Err(DbError::Config(
+            "unified config must contain an addr= parameter".to_string(),
+        ));
+    }
+
+    let suffix = {
+        let mut s = String::new();
+        for p in &carried {
+            s.push_str(p);
+            s.push(';');
+        }
+        s
+    };
+
+    Ok((
+        format!("{ingest_scheme}::{suffix}"),
+        format!("{query_scheme}::{suffix}"),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_http_to_both() {
+        let (ingest, query) =
+            derive_both_sides("http::addr=localhost:9000;username=u;password=p;").unwrap();
+        assert_eq!(ingest, "http::addr=localhost:9000;username=u;password=p;");
+        assert_eq!(query, "ws::addr=localhost:9000;username=u;password=p;");
+    }
+
+    #[test]
+    fn derive_wss_to_both() {
+        let (ingest, query) = derive_both_sides("wss::addr=h:9000;tls_verify=on;").unwrap();
+        assert_eq!(ingest, "https::addr=h:9000;tls_verify=on;");
+        assert_eq!(query, "wss::addr=h:9000;tls_verify=on;");
+    }
+
+    #[test]
+    fn derive_drops_transport_specific_params() {
+        // `compression` (reader-only) and `auto_flush_rows` (sender-only) are
+        // dropped so neither side rejects the string.
+        let (ingest, query) =
+            derive_both_sides("ws::addr=h:9000;compression=zstd;auto_flush_rows=1000;").unwrap();
+        assert_eq!(ingest, "http::addr=h:9000;");
+        assert_eq!(query, "ws::addr=h:9000;");
+    }
+
+    #[test]
+    fn derive_requires_addr() {
+        assert!(matches!(
+            derive_both_sides("http::username=u;"),
+            Err(DbError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn derive_rejects_unknown_scheme() {
+        assert!(matches!(
+            derive_both_sides("tcp::addr=h:9009;"),
+            Err(DbError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn derive_requires_scheme() {
+        assert!(matches!(
+            derive_both_sides("addr=h:9000;"),
+            Err(DbError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn builder_validates_sizing() {
+        let err = DbBuilder::new()
+            .ingest_config("http::addr=h:9000;")
+            .query_config("ws::addr=h:9000;")
+            .sender_pool_min(5)
+            .sender_pool_max(2)
+            .build();
+        assert!(matches!(err, Err(DbError::Config(_))));
+    }
+
+    #[test]
+    fn builder_requires_configs() {
+        assert!(matches!(DbBuilder::new().build(), Err(DbError::Config(_))));
+    }
+}

--- a/questdb-rs/src/lib.rs
+++ b/questdb-rs/src/lib.rs
@@ -47,6 +47,15 @@ pub mod ingress;
 #[cfg(feature = "_egress")]
 pub mod egress;
 
+// Custom high-performance connection pooling + the `Db` facade. Gated on
+// `pool`, which pulls in both the egress reader and the sender transports the
+// facade needs.
+#[cfg(feature = "pool")]
+pub mod pool;
+
+#[cfg(feature = "pool")]
+pub mod db;
+
 pub use error::*;
 
 #[cfg(test)]

--- a/questdb-rs/src/pool.rs
+++ b/questdb-rs/src/pool.rs
@@ -1,0 +1,1035 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2025 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+//! A small, allocation-light, blocking connection pool.
+//!
+//! This is the engine behind [`crate::db::Db`]; it is deliberately generic
+//! (and free of any QuestDB specifics) so the ingress [`Sender`] pool and the
+//! egress [`Reader`] pool share one battle-tested core, and so it can be
+//! unit-tested against a mock connection without a live server.
+//!
+//! [`Sender`]: crate::ingress::Sender
+//! [`Reader`]: crate::egress::reader::Reader
+//!
+//! # Design
+//!
+//! The pool mirrors the semantics of the reference Java client
+//! (`SenderPool` / `QueryClientPool`):
+//!
+//! * **Elastic.** [`PoolConfig::min`] connections are pre-warmed eagerly; the
+//!   pool then grows on demand up to [`PoolConfig::max`] and is shrunk back
+//!   toward `min` by [`Pool::reap_idle`] (driven by a housekeeper thread in
+//!   the `db` layer).
+//! * **Blocking acquire.** [`Pool::borrow`] hands out an idle connection if
+//!   one exists, otherwise opens a new one (up to `max`), otherwise blocks on
+//!   a [`Condvar`] until a connection is returned or
+//!   [`PoolConfig::acquire_timeout`] elapses.
+//! * **Connect off-lock.** New connections are opened *without* the pool lock
+//!   held — a slow TLS handshake or DNS lookup must not stall other borrowers.
+//!   An `in_flight` counter keeps the capacity check correct meanwhile.
+//! * **RAII return.** [`Pool::borrow`] returns a [`Pooled`] guard that derefs
+//!   to the connection and returns it to the pool on `Drop` — the Rust
+//!   equivalent of the Java `PooledSender.close()` decorator. A guard marked
+//!   broken (or rejected by [`Manage::recycle`]) is discarded instead.
+//!
+//! The hot borrow/return path takes a single [`Mutex`] and performs no
+//! per-call heap allocation: the free list is a [`VecDeque`] pre-sized to
+//! `max` and connections are moved in and out of it by value.
+
+use std::collections::VecDeque;
+use std::ops::{Deref, DerefMut};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::{Duration, Instant};
+
+/// Teaches the pool how to create and validate a connection of type
+/// [`Manage::Conn`]. Implementations are cheap, immutable handles (e.g. a
+/// config string); the pool clones nothing per borrow.
+pub trait Manage: Send + Sync + 'static {
+    /// The pooled connection type. Must be [`Send`] so it can live behind the
+    /// pool's [`Mutex`] and be borrowed from any thread.
+    type Conn: Send + 'static;
+
+    /// The error returned when opening a connection fails.
+    type Error;
+
+    /// Opens a brand-new connection. Called both during pre-warm and when the
+    /// pool grows under load (the latter happens off the pool lock).
+    fn connect(&self) -> Result<Self::Conn, Self::Error>;
+
+    /// Decides whether a returned connection is safe to reuse. Returning
+    /// `false` discards it (and frees a slot for a fresh one). The default
+    /// keeps every connection.
+    ///
+    /// This runs on the returning thread *before* the pool lock is taken, so
+    /// it must be cheap and must not block — a `must_close()`-style flag check,
+    /// not a network round-trip.
+    fn recycle(&self, _conn: &mut Self::Conn) -> bool {
+        true
+    }
+}
+
+/// Sizing and lifetime knobs for a [`Pool`].
+#[derive(Debug, Clone, Copy)]
+pub struct PoolConfig {
+    /// Connections kept warm at all times. Pre-created eagerly by
+    /// [`Pool::new`]; [`Pool::reap_idle`] never shrinks below this.
+    pub min: usize,
+    /// Hard cap on live connections (idle + leased + in-flight). Must be `>= 1`
+    /// and `>= min`.
+    pub max: usize,
+    /// How long [`Pool::borrow`] blocks when the pool is exhausted before
+    /// returning [`PoolError::Timeout`]. [`Duration::ZERO`] fails fast.
+    pub acquire_timeout: Duration,
+    /// Idle connections older than this are reaped. `None` disables idle
+    /// reaping.
+    pub idle_timeout: Option<Duration>,
+    /// Connections whose total age exceeds this are reaped once idle. `None`
+    /// disables age-based reaping.
+    pub max_lifetime: Option<Duration>,
+}
+
+impl PoolConfig {
+    fn validate(&self) -> Result<(), &'static str> {
+        if self.max < 1 {
+            return Err("pool max must be >= 1");
+        }
+        if self.min > self.max {
+            return Err("pool min must be <= max");
+        }
+        Ok(())
+    }
+}
+
+/// Failure modes of [`Pool::borrow`].
+#[derive(Debug)]
+pub enum PoolError<E> {
+    /// The pool was exhausted and no connection became free within
+    /// [`PoolConfig::acquire_timeout`].
+    Timeout,
+    /// The pool has been [`closed`](Pool::close).
+    Closed,
+    /// Opening a new connection failed; carries the underlying
+    /// [`Manage::Error`].
+    Connect(E),
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for PoolError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PoolError::Timeout => write!(f, "timed out waiting for a connection from the pool"),
+            PoolError::Closed => write!(f, "the pool is closed"),
+            PoolError::Connect(e) => write!(f, "failed to open a pooled connection: {e}"),
+        }
+    }
+}
+
+impl<E: std::fmt::Debug + std::fmt::Display> std::error::Error for PoolError<E> {}
+
+struct Slot<C> {
+    conn: C,
+    created_at: Instant,
+    idle_since: Instant,
+}
+
+struct State<C> {
+    /// Free connections, most-recently-returned at the back (LIFO borrow for
+    /// cache warmth; oldest at the front for reaping).
+    idle: VecDeque<Slot<C>>,
+    /// Count of connections currently checked out via a live [`Pooled`].
+    leased: usize,
+    /// Count of `connect()` calls in progress off-lock.
+    in_flight: usize,
+    /// Count of discarded connections whose slot is still reserved while the
+    /// connection is being closed (dropped) off-lock. Keeps the capacity cap
+    /// honest: without it, a discard would free the slot accounting-wise
+    /// *before* the OS resource is released, letting a concurrent borrow open a
+    /// replacement and briefly exceed `max` real connections. Mirrors the Java
+    /// client's `closingSlots`.
+    closing: usize,
+    closed: bool,
+}
+
+impl<C> State<C> {
+    /// Connections that count against [`PoolConfig::max`]: idle + checked out +
+    /// being opened + being closed. The cap is enforced against this so the
+    /// number of *real* connections in existence never exceeds `max`.
+    #[inline]
+    fn live(&self) -> usize {
+        self.idle.len() + self.leased + self.in_flight + self.closing
+    }
+}
+
+struct Inner<M: Manage> {
+    manage: M,
+    cfg: PoolConfig,
+    state: Mutex<State<M::Conn>>,
+    cond: Condvar,
+}
+
+/// A blocking, elastic connection pool. Cheap to [`Clone`] (it is an
+/// [`Arc`] internally); every clone shares the same connections.
+pub struct Pool<M: Manage> {
+    inner: Arc<Inner<M>>,
+}
+
+impl<M: Manage> Clone for Pool<M> {
+    fn clone(&self) -> Self {
+        Pool {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<M: Manage> Pool<M> {
+    /// Builds a pool and eagerly pre-warms [`PoolConfig::min`] connections.
+    ///
+    /// If any pre-warm connection fails, the ones already created are closed
+    /// and the error is returned.
+    pub fn new(manage: M, cfg: PoolConfig) -> Result<Pool<M>, PoolError<M::Error>> {
+        // Sizing is validated by the `db` builder before we get here; an
+        // invalid config is a programmer error, so assert loudly in debug.
+        debug_assert!(cfg.validate().is_ok(), "invalid PoolConfig: {cfg:?}");
+
+        let inner = Arc::new(Inner {
+            manage,
+            cfg,
+            state: Mutex::new(State {
+                idle: VecDeque::with_capacity(cfg.max),
+                leased: 0,
+                in_flight: 0,
+                closing: 0,
+                closed: false,
+            }),
+            cond: Condvar::new(),
+        });
+
+        // Pre-warm runs single-threaded here; hold the lock for simplicity.
+        {
+            let mut st = inner.state.lock().unwrap();
+            for _ in 0..cfg.min {
+                match inner.manage.connect() {
+                    Ok(conn) => {
+                        let now = Instant::now();
+                        st.idle.push_back(Slot {
+                            conn,
+                            created_at: now,
+                            idle_since: now,
+                        });
+                    }
+                    Err(e) => {
+                        // Close what we already built before bailing.
+                        let built: Vec<_> = st.idle.drain(..).map(|s| s.conn).collect();
+                        drop(st);
+                        drop(built);
+                        return Err(PoolError::Connect(e));
+                    }
+                }
+            }
+        }
+
+        Ok(Pool { inner })
+    }
+
+    /// Borrows a connection, blocking up to [`PoolConfig::acquire_timeout`].
+    ///
+    /// Returns a [`Pooled`] guard that derefs to the connection and returns it
+    /// to the pool when dropped.
+    pub fn borrow(&self) -> Result<Pooled<M>, PoolError<M::Error>> {
+        let deadline = Instant::now().checked_add(self.inner.cfg.acquire_timeout);
+        let mut st = self.inner.state.lock().unwrap();
+        loop {
+            if st.closed {
+                return Err(PoolError::Closed);
+            }
+
+            // 1. Reuse a warm connection.
+            if let Some(slot) = st.idle.pop_back() {
+                st.leased += 1;
+                drop(st);
+                return Ok(Pooled::new(
+                    Arc::clone(&self.inner),
+                    slot.conn,
+                    slot.created_at,
+                ));
+            }
+
+            // 2. Grow the pool (open a new connection off-lock).
+            if st.live() < self.inner.cfg.max {
+                st.in_flight += 1;
+                drop(st);
+
+                let result = self.inner.manage.connect();
+
+                let mut st2 = self.inner.state.lock().unwrap();
+                st2.in_flight -= 1;
+                match result {
+                    Ok(conn) => {
+                        if st2.closed {
+                            drop(st2);
+                            self.inner.cond.notify_all();
+                            drop(conn);
+                            return Err(PoolError::Closed);
+                        }
+                        st2.leased += 1;
+                        drop(st2);
+                        return Ok(Pooled::new(Arc::clone(&self.inner), conn, Instant::now()));
+                    }
+                    Err(e) => {
+                        // A freed in_flight slot may now admit another waiter's
+                        // creation attempt.
+                        drop(st2);
+                        self.inner.cond.notify_all();
+                        return Err(PoolError::Connect(e));
+                    }
+                }
+            }
+
+            // 3. Exhausted: wait for a return (or time out).
+            let now = Instant::now();
+            let remaining = match deadline {
+                Some(d) if d > now => d - now,
+                // Either already past the deadline, or acquire_timeout was so
+                // large it overflowed Instant — treat overflow as "effectively
+                // forever" by waiting in bounded chunks.
+                Some(_) => return Err(PoolError::Timeout),
+                None => Duration::from_secs(3600),
+            };
+            let (guard, wait) = self.inner.cond.wait_timeout(st, remaining).unwrap();
+            st = guard;
+            if wait.timed_out() && deadline.is_some() && Instant::now() >= deadline.unwrap() {
+                // Re-check the fast paths one last time before giving up: a
+                // connection may have been returned in the wakeup race.
+                if !st.closed && (!st.idle.is_empty() || st.live() < self.inner.cfg.max) {
+                    continue;
+                }
+                return Err(PoolError::Timeout);
+            }
+        }
+    }
+
+    /// Closes idle connections that have exceeded [`PoolConfig::idle_timeout`]
+    /// or [`PoolConfig::max_lifetime`], never shrinking below
+    /// [`PoolConfig::min`]. Leased connections are untouched. Called by the
+    /// housekeeper.
+    pub fn reap_idle(&self) {
+        let now = Instant::now();
+        let idle_timeout = self.inner.cfg.idle_timeout;
+        let max_lifetime = self.inner.cfg.max_lifetime;
+        if idle_timeout.is_none() && max_lifetime.is_none() {
+            return;
+        }
+
+        let mut to_close: Vec<M::Conn> = Vec::new();
+        {
+            let mut st = self.inner.state.lock().unwrap();
+            if st.closed {
+                return;
+            }
+            // Most we may remove without dropping below `min`.
+            let mut removable = st.live().saturating_sub(self.inner.cfg.min);
+            if removable == 0 {
+                return;
+            }
+            let mut kept: VecDeque<Slot<M::Conn>> = VecDeque::with_capacity(st.idle.len());
+            while let Some(slot) = st.idle.pop_front() {
+                let idle_expired = idle_timeout
+                    .is_some_and(|t| now.saturating_duration_since(slot.idle_since) >= t);
+                let over_age = max_lifetime
+                    .is_some_and(|t| now.saturating_duration_since(slot.created_at) >= t);
+                if removable > 0 && (idle_expired || over_age) {
+                    removable -= 1;
+                    to_close.push(slot.conn);
+                } else {
+                    kept.push_back(slot);
+                }
+            }
+            st.idle = kept;
+        }
+        // Close outside the lock.
+        drop(to_close);
+    }
+
+    /// Permanently closes the pool. Idle connections are closed immediately;
+    /// leased connections are closed as their guards drop. Blocked borrowers
+    /// wake with [`PoolError::Closed`]. Idempotent.
+    pub fn close(&self) {
+        let drained: Vec<M::Conn> = {
+            let mut st = self.inner.state.lock().unwrap();
+            if st.closed {
+                return;
+            }
+            st.closed = true;
+            st.idle.drain(..).map(|s| s.conn).collect()
+        };
+        self.inner.cond.notify_all();
+        drop(drained);
+    }
+
+    /// Total live connections (idle + leased + in-flight). For tests and
+    /// introspection.
+    pub fn size(&self) -> usize {
+        self.inner.state.lock().unwrap().live()
+    }
+
+    /// Number of idle (immediately borrowable) connections. For tests and
+    /// introspection.
+    pub fn idle(&self) -> usize {
+        self.inner.state.lock().unwrap().idle.len()
+    }
+
+    /// Whether the pool has been closed.
+    pub fn is_closed(&self) -> bool {
+        self.inner.state.lock().unwrap().closed
+    }
+}
+
+/// An RAII handle to a borrowed connection. Derefs to the connection; returns
+/// it to the pool on drop (or discards it if [`Pooled::mark_broken`] was
+/// called or [`Manage::recycle`] rejects it).
+pub struct Pooled<M: Manage> {
+    inner: Arc<Inner<M>>,
+    conn: Option<M::Conn>,
+    created_at: Instant,
+    broken: bool,
+}
+
+impl<M: Manage> Pooled<M> {
+    fn new(inner: Arc<Inner<M>>, conn: M::Conn, created_at: Instant) -> Self {
+        Pooled {
+            inner,
+            conn: Some(conn),
+            created_at,
+            broken: false,
+        }
+    }
+
+    /// Marks this connection unfit for reuse: it will be discarded (not
+    /// returned to the pool) when the guard drops. Use after an error that may
+    /// have left the connection in an inconsistent state.
+    pub fn mark_broken(&mut self) {
+        self.broken = true;
+    }
+
+    /// Whether the connection has been marked broken.
+    pub fn is_broken(&self) -> bool {
+        self.broken
+    }
+}
+
+impl<M: Manage> Deref for Pooled<M> {
+    type Target = M::Conn;
+
+    fn deref(&self) -> &M::Conn {
+        // `conn` is `Some` for the whole guard lifetime; only `Drop` takes it.
+        self.conn.as_ref().unwrap()
+    }
+}
+
+impl<M: Manage> DerefMut for Pooled<M> {
+    fn deref_mut(&mut self) -> &mut M::Conn {
+        self.conn.as_mut().unwrap()
+    }
+}
+
+impl<M: Manage> Drop for Pooled<M> {
+    fn drop(&mut self) {
+        let mut conn = match self.conn.take() {
+            Some(c) => c,
+            None => return,
+        };
+
+        // Decide fitness off-lock (recycle must be cheap/non-blocking).
+        let discard = self.broken || !self.inner.manage.recycle(&mut conn);
+
+        let mut st = self.inner.state.lock().unwrap();
+        st.leased -= 1;
+        if discard || st.closed {
+            // Keep the slot reserved (via `closing`) across the off-lock close
+            // so a concurrent borrow can't open a replacement until this
+            // connection's resources are actually released — otherwise real
+            // connections could momentarily exceed `max`.
+            st.closing += 1;
+            drop(st);
+            // Close (drop) the connection outside the lock.
+            drop(conn);
+            let mut st2 = self.inner.state.lock().unwrap();
+            st2.closing -= 1;
+            drop(st2);
+            self.inner.cond.notify_all();
+        } else {
+            let now = Instant::now();
+            st.idle.push_back(Slot {
+                conn,
+                created_at: self.created_at,
+                idle_since: now,
+            });
+            drop(st);
+            self.inner.cond.notify_one();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
+
+    /// Shared, atomically-tracked stats for the mock connection. The key
+    /// invariant under test is `max_live <= pool.max`: the pool must never
+    /// have more connections alive at once than its cap allows.
+    #[derive(Default)]
+    struct Stats {
+        connects: AtomicUsize,
+        live: AtomicUsize,
+        max_live: AtomicUsize,
+        fail: AtomicBool,
+        /// Inverted so `Default` (false) means "recycle keeps the connection".
+        recycle_rejects: AtomicBool,
+    }
+
+    impl Stats {
+        fn connects(&self) -> usize {
+            self.connects.load(Ordering::SeqCst)
+        }
+        fn live(&self) -> usize {
+            self.live.load(Ordering::SeqCst)
+        }
+        fn max_live(&self) -> usize {
+            self.max_live.load(Ordering::SeqCst)
+        }
+    }
+
+    struct MockConn {
+        stats: Arc<Stats>,
+    }
+
+    impl Drop for MockConn {
+        fn drop(&mut self) {
+            self.stats.live.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    struct MockManager {
+        stats: Arc<Stats>,
+        connect_delay: Duration,
+    }
+
+    impl MockManager {
+        fn new() -> (MockManager, Arc<Stats>) {
+            Self::with_delay(Duration::ZERO)
+        }
+
+        fn with_delay(delay: Duration) -> (MockManager, Arc<Stats>) {
+            let stats = Arc::new(Stats::default());
+            (
+                MockManager {
+                    stats: Arc::clone(&stats),
+                    connect_delay: delay,
+                },
+                stats,
+            )
+        }
+    }
+
+    impl Manage for MockManager {
+        type Conn = MockConn;
+        type Error = String;
+
+        fn connect(&self) -> Result<MockConn, String> {
+            if self.stats.fail.load(Ordering::SeqCst) {
+                return Err("connect disabled".to_string());
+            }
+            if !self.connect_delay.is_zero() {
+                std::thread::sleep(self.connect_delay);
+            }
+            self.stats.connects.fetch_add(1, Ordering::SeqCst);
+            let n = self.stats.live.fetch_add(1, Ordering::SeqCst) + 1;
+            self.stats.max_live.fetch_max(n, Ordering::SeqCst);
+            Ok(MockConn {
+                stats: Arc::clone(&self.stats),
+            })
+        }
+
+        fn recycle(&self, _conn: &mut MockConn) -> bool {
+            !self.stats.recycle_rejects.load(Ordering::SeqCst)
+        }
+    }
+
+    fn cfg(min: usize, max: usize, acquire_ms: u64) -> PoolConfig {
+        PoolConfig {
+            min,
+            max,
+            acquire_timeout: Duration::from_millis(acquire_ms),
+            idle_timeout: None,
+            max_lifetime: None,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Single-threaded behavioural tests.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn prewarms_min() {
+        let (m, stats) = MockManager::new();
+        let pool = Pool::new(m, cfg(2, 4, 1000)).unwrap();
+        assert_eq!(stats.connects(), 2);
+        assert_eq!(pool.idle(), 2);
+        assert_eq!(pool.size(), 2);
+    }
+
+    #[test]
+    fn borrow_reuses_then_grows() {
+        let (m, stats) = MockManager::new();
+        let pool = Pool::new(m, cfg(1, 3, 1000)).unwrap();
+        assert_eq!(stats.connects(), 1);
+
+        let a = pool.borrow().unwrap(); // reuse warm
+        assert_eq!(stats.connects(), 1);
+        let b = pool.borrow().unwrap(); // grow
+        let c = pool.borrow().unwrap(); // grow
+        assert_eq!(stats.connects(), 3);
+        assert_eq!(pool.size(), 3);
+        assert_eq!(pool.idle(), 0);
+        drop((a, b, c));
+        assert_eq!(pool.idle(), 3);
+    }
+
+    #[test]
+    fn returns_to_pool_on_drop() {
+        let (m, stats) = MockManager::new();
+        let pool = Pool::new(m, cfg(0, 2, 1000)).unwrap();
+        {
+            let _g = pool.borrow().unwrap();
+            assert_eq!(pool.size(), 1);
+            assert_eq!(pool.idle(), 0);
+        }
+        assert_eq!(pool.idle(), 1);
+        let _g = pool.borrow().unwrap();
+        assert_eq!(stats.connects(), 1); // reused, no new connect
+    }
+
+    #[test]
+    fn broken_is_discarded() {
+        let (m, stats) = MockManager::new();
+        let pool = Pool::new(m, cfg(0, 2, 1000)).unwrap();
+        {
+            let mut g = pool.borrow().unwrap();
+            g.mark_broken();
+            assert!(g.is_broken());
+        }
+        assert_eq!(pool.idle(), 0);
+        assert_eq!(pool.size(), 0);
+        let _g = pool.borrow().unwrap();
+        assert_eq!(stats.connects(), 2); // fresh one
+    }
+
+    #[test]
+    fn recycle_false_discards() {
+        let (m, stats) = MockManager::new();
+        let pool = Pool::new(m, cfg(0, 2, 1000)).unwrap();
+        stats.recycle_rejects.store(true, Ordering::SeqCst);
+        {
+            let _g = pool.borrow().unwrap();
+        }
+        assert_eq!(pool.idle(), 0);
+        assert_eq!(pool.size(), 0);
+        assert_eq!(stats.live(), 0);
+    }
+
+    #[test]
+    fn exhausted_times_out() {
+        let (m, _stats) = MockManager::new();
+        let pool = Pool::new(m, cfg(0, 1, 50)).unwrap();
+        let _g = pool.borrow().unwrap();
+        let start = Instant::now();
+        match pool.borrow() {
+            Err(PoolError::Timeout) => {}
+            Err(other) => panic!("expected Timeout, got {other:?}"),
+            Ok(_) => panic!("expected Timeout, got a connection"),
+        }
+        assert!(start.elapsed() >= Duration::from_millis(40));
+    }
+
+    #[test]
+    fn blocked_borrow_wakes_on_return() {
+        let (m, _stats) = MockManager::new();
+        let pool = Pool::new(m, cfg(0, 1, 2000)).unwrap();
+        let g = pool.borrow().unwrap();
+        let pool2 = pool.clone();
+        let handle = std::thread::spawn(move || {
+            let start = Instant::now();
+            let _g2 = pool2.borrow().unwrap();
+            start.elapsed()
+        });
+        std::thread::sleep(Duration::from_millis(100));
+        drop(g);
+        let waited = handle.join().unwrap();
+        assert!(waited >= Duration::from_millis(80));
+        assert!(waited < Duration::from_millis(1500));
+    }
+
+    #[test]
+    fn connect_failure_surfaces() {
+        let (m, stats) = MockManager::new();
+        let pool = Pool::new(m, cfg(0, 2, 1000)).unwrap();
+        stats.fail.store(true, Ordering::SeqCst);
+        match pool.borrow() {
+            Err(PoolError::Connect(e)) => assert!(e.contains("disabled")),
+            Err(other) => panic!("expected Connect error, got {other:?}"),
+            Ok(_) => panic!("expected Connect error, got a connection"),
+        }
+        // `in_flight` was decremented; the pool is still usable.
+        stats.fail.store(false, Ordering::SeqCst);
+        let _g = pool.borrow().unwrap();
+        assert_eq!(pool.size(), 1);
+    }
+
+    #[test]
+    fn closed_pool_rejects_borrow() {
+        let (m, _stats) = MockManager::new();
+        let pool = Pool::new(m, cfg(1, 2, 1000)).unwrap();
+        pool.close();
+        assert!(pool.is_closed());
+        assert!(matches!(pool.borrow(), Err(PoolError::Closed)));
+        pool.close(); // idempotent
+    }
+
+    #[test]
+    fn reap_respects_min() {
+        let (m, _stats) = MockManager::new();
+        let mut c = cfg(1, 4, 1000);
+        c.idle_timeout = Some(Duration::from_millis(10));
+        let pool = Pool::new(m, c).unwrap();
+        let a = pool.borrow().unwrap();
+        let b = pool.borrow().unwrap();
+        let cc = pool.borrow().unwrap();
+        drop((a, b, cc));
+        assert_eq!(pool.idle(), 3);
+        std::thread::sleep(Duration::from_millis(30));
+        pool.reap_idle();
+        assert_eq!(pool.size(), 1); // never below min
+        assert_eq!(pool.idle(), 1);
+    }
+
+    #[test]
+    fn reap_keeps_fresh() {
+        let (m, _stats) = MockManager::new();
+        let mut c = cfg(0, 4, 1000);
+        c.idle_timeout = Some(Duration::from_secs(100));
+        let pool = Pool::new(m, c).unwrap();
+        let a = pool.borrow().unwrap();
+        let b = pool.borrow().unwrap();
+        drop((a, b));
+        assert_eq!(pool.idle(), 2);
+        pool.reap_idle();
+        assert_eq!(pool.idle(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Concurrency stress tests. These are the heart of "mission critical":
+    // many threads hammering the pool must never error spuriously, never
+    // exceed the capacity cap, never deadlock, and never leak connections.
+    // -----------------------------------------------------------------------
+
+    /// Asserts the standard end-of-test invariants for a quiesced pool: no
+    /// connection is leased, the idle set matches the live connection count,
+    /// and the cap was never breached.
+    fn assert_quiesced(pool: &Pool<MockManager>, stats: &Stats, max: usize) {
+        assert!(
+            stats.max_live() <= max,
+            "capacity breached: max_live={} > max={}",
+            stats.max_live(),
+            max
+        );
+        // Everything has been returned: size == idle (leased == 0), and the
+        // tracked live count equals what the pool thinks is idle.
+        assert_eq!(pool.size(), pool.idle(), "connections still leased");
+        assert_eq!(
+            stats.live(),
+            pool.idle(),
+            "tracked-live {} != pool idle {}",
+            stats.live(),
+            pool.idle()
+        );
+        assert!(pool.idle() <= max, "idle {} > max {}", pool.idle(), max);
+    }
+
+    #[test]
+    fn concurrent_borrow_return_no_errors() {
+        let (m, stats) = MockManager::new();
+        let max = 4;
+        let pool = Pool::new(m, cfg(1, max, 10_000)).unwrap();
+        let threads = 16;
+        let iters = 500;
+
+        let mut handles = Vec::new();
+        for _ in 0..threads {
+            let p = pool.clone();
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..iters {
+                    let g = p.borrow().expect("borrow must not fail under capacity");
+                    // Touch the connection so the borrow isn't optimised away.
+                    std::hint::black_box(&*g);
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_quiesced(&pool, &stats, max);
+        assert!(pool.idle() >= 1, "min should keep at least one warm");
+        // No connection was ever discarded, so the total created can never
+        // exceed the cap (reuse, not re-create).
+        assert!(
+            stats.connects() <= max,
+            "connects {} exceeded max {} despite reuse",
+            stats.connects(),
+            max
+        );
+    }
+
+    #[test]
+    fn concurrent_capacity_never_exceeds_max() {
+        // Far more threads than slots, each holding its connection briefly so
+        // contention is real. The cap must hold regardless.
+        let (m, stats) = MockManager::with_delay(Duration::from_micros(50));
+        let max = 3;
+        let pool = Pool::new(m, cfg(0, max, 10_000)).unwrap();
+        let threads = 24;
+        let iters = 100;
+
+        let mut handles = Vec::new();
+        for _ in 0..threads {
+            let p = pool.clone();
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..iters {
+                    let g = p.borrow().expect("borrow");
+                    std::hint::black_box(&*g);
+                    std::thread::sleep(Duration::from_micros(50));
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_quiesced(&pool, &stats, max);
+    }
+
+    #[test]
+    fn concurrent_random_breakage_self_heals() {
+        // A fraction of borrows are marked broken and discarded, forcing
+        // reconnects under load. The pool must stay healthy and bounded.
+        let (m, stats) = MockManager::new();
+        let max = 4;
+        let pool = Pool::new(m, cfg(1, max, 10_000)).unwrap();
+        let threads = 12;
+        let iters = 300;
+
+        let mut handles = Vec::new();
+        for t in 0..threads {
+            let p = pool.clone();
+            handles.push(std::thread::spawn(move || {
+                for i in 0..iters {
+                    let mut g = p.borrow().expect("borrow");
+                    std::hint::black_box(&*g);
+                    // Deterministic ~25% breakage, decorrelated per thread.
+                    if (t * 7 + i) % 4 == 0 {
+                        g.mark_broken();
+                    }
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_quiesced(&pool, &stats, max);
+        // Discards forced reconnects, so total creations exceeded the cap.
+        assert!(
+            stats.connects() > max,
+            "expected reconnects beyond the cap, got {}",
+            stats.connects()
+        );
+    }
+
+    #[test]
+    fn concurrent_reap_during_load_no_deadlock() {
+        // A reaper thread aggressively recycles idle connections while many
+        // borrowers churn. Tests lock ordering / liveness, not just counts.
+        let (m, stats) = MockManager::new();
+        let max = 6;
+        let mut c = cfg(1, max, 10_000);
+        c.idle_timeout = Some(Duration::from_millis(1));
+        let pool = Pool::new(m, c).unwrap();
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let reaper = {
+            let p = pool.clone();
+            let stop = Arc::clone(&stop);
+            std::thread::spawn(move || {
+                while !stop.load(Ordering::Relaxed) {
+                    p.reap_idle();
+                    std::thread::sleep(Duration::from_micros(200));
+                }
+            })
+        };
+
+        let threads = 8;
+        let iters = 300;
+        let mut handles = Vec::new();
+        for _ in 0..threads {
+            let p = pool.clone();
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..iters {
+                    let g = p.borrow().expect("borrow");
+                    std::hint::black_box(&*g);
+                    std::thread::sleep(Duration::from_micros(20));
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        stop.store(true, Ordering::Relaxed);
+        reaper.join().unwrap();
+
+        // Let one more reap settle, then check invariants.
+        pool.reap_idle();
+        assert!(stats.max_live() <= max, "capacity breached under reaping");
+        assert_eq!(pool.size(), pool.idle(), "connections still leased");
+    }
+
+    #[test]
+    fn concurrent_close_no_panic_no_leak() {
+        // Threads borrow in a loop while the pool is closed underneath them.
+        // Every outcome must be a clean Ok/Closed (never a panic), and every
+        // connection must be destroyed once the dust settles.
+        let (m, stats) = MockManager::new();
+        let max = 4;
+        let pool = Pool::new(m, cfg(2, max, 2000)).unwrap();
+
+        let threads = 12;
+        let mut handles = Vec::new();
+        for _ in 0..threads {
+            let p = pool.clone();
+            handles.push(std::thread::spawn(move || {
+                loop {
+                    match p.borrow() {
+                        Ok(g) => {
+                            std::hint::black_box(&*g);
+                            std::thread::sleep(Duration::from_micros(100));
+                            // guard drops here
+                        }
+                        Err(PoolError::Closed) => break,
+                        Err(PoolError::Timeout) => break,
+                        Err(PoolError::Connect(e)) => panic!("unexpected connect error: {e}"),
+                    }
+                }
+            }));
+        }
+
+        std::thread::sleep(Duration::from_millis(50));
+        pool.close();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // All idle were closed; all leased were discarded on guard drop.
+        assert_eq!(stats.live(), 0, "leaked {} connections", stats.live());
+        assert!(matches!(pool.borrow(), Err(PoolError::Closed)));
+    }
+
+    #[test]
+    fn concurrent_growth_liveness_all_held_at_once() {
+        // With max == threads and a barrier, every thread must successfully
+        // hold its own connection simultaneously — proving the pool grows to
+        // the cap and no thread is starved.
+        let (m, stats) = MockManager::with_delay(Duration::from_micros(100));
+        let threads = 8;
+        let max = threads;
+        let pool = Pool::new(m, cfg(0, max, 10_000)).unwrap();
+        let barrier = Arc::new(Barrier::new(threads));
+
+        let mut handles = Vec::new();
+        for _ in 0..threads {
+            let p = pool.clone();
+            let b = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                let g = p.borrow().expect("borrow");
+                // Hold while every sibling also holds: peak concurrency.
+                b.wait();
+                std::hint::black_box(&*g);
+                std::thread::sleep(Duration::from_millis(5));
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(
+            stats.max_live(),
+            max,
+            "expected all {max} connections live at the barrier peak"
+        );
+        assert_quiesced(&pool, &stats, max);
+    }
+
+    #[test]
+    fn concurrent_borrow_blocks_then_succeeds_under_tight_cap() {
+        // max == 1 with many contenders and a generous timeout: every borrow
+        // must eventually succeed (serialised), none time out.
+        let (m, stats) = MockManager::new();
+        let max = 1;
+        let pool = Pool::new(m, cfg(1, max, 30_000)).unwrap();
+        let threads = 10;
+        let iters = 50;
+        let ok = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+        for _ in 0..threads {
+            let p = pool.clone();
+            let ok = Arc::clone(&ok);
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..iters {
+                    let g = p.borrow().expect("must serialise, not time out");
+                    std::hint::black_box(&*g);
+                    std::thread::sleep(Duration::from_micros(50));
+                    ok.fetch_add(1, Ordering::Relaxed);
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(ok.load(Ordering::Relaxed), threads * iters);
+        assert_eq!(stats.max_live(), 1, "tight cap must hold");
+        assert_quiesced(&pool, &stats, max);
+    }
+}

--- a/questdb-rs/tests/db_pool_live.rs
+++ b/questdb-rs/tests/db_pool_live.rs
@@ -1,0 +1,511 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2025 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+//! Live-server concurrency tests for the pooled [`Db`] facade.
+//!
+//! Boots a real QuestDB from the `questdb/` submodule and hammers the ingest
+//! (`Sender`) and egress (`Reader`) pools from many threads sharing one cloned
+//! `Db` handle, proving that concurrent borrowers never error spuriously, the
+//! pools serialise / grow correctly under contention, and a full ingest+query
+//! round trip is correct across threads.
+//!
+//! Verification strategy:
+//! * **Ingress** tests verify row counts via the HTTP `/exec` endpoint, so they
+//!   exercise the *sender pool* without depending on the egress endpoint.
+//! * **Egress** tests drive the *reader pool*; they begin with
+//!   [`wait_egress_ready`] (the QWP/WS egress endpoint can lag `/ping` at boot).
+//!
+//! Gated behind `live-server-tests` (which pulls in `pool`) so the default
+//! `cargo test` doesn't spin up a JVM.
+
+#![cfg(all(feature = "live-server-tests", feature = "pool"))]
+
+mod common;
+
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use questdb::db::{Db, DbError};
+use questdb::egress::column::ColumnView;
+use questdb::egress::reader::Reader;
+use questdb::ingress::TimestampNanos;
+
+use common::QuestDbServer;
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+fn server() -> &'static QuestDbServer {
+    static SERVER: OnceLock<QuestDbServer> = OnceLock::new();
+    SERVER.get_or_init(QuestDbServer::start)
+}
+
+fn unique_table(stem: &str) -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!(
+        "dbpool_{}_{}_{}_{}",
+        stem,
+        std::process::id(),
+        nanos as u64 & 0xFFFF_FFFF,
+        n
+    )
+}
+
+/// `http://host:port` base derived from the server's HTTP connect string.
+fn http_base(srv: &QuestDbServer) -> String {
+    let conf = srv.http_conf(); // "http::addr=H:P"
+    let addr = conf
+        .strip_prefix("http::addr=")
+        .expect("http_conf shape")
+        .trim_end_matches(';');
+    format!("http://{addr}")
+}
+
+/// `select count() from <table>` via HTTP `/exec` (independent of egress).
+fn http_count(srv: &QuestDbServer, table: &str) -> i64 {
+    let url = format!("{}/exec", http_base(srv));
+    let sql = format!("select count() from \"{table}\"");
+    let mut resp = ureq::get(&url)
+        .query("query", &sql)
+        .call()
+        .expect("/exec call");
+    let body = resp.body_mut().read_to_string().expect("/exec body");
+    parse_dataset_scalar(&body)
+        .unwrap_or_else(|| panic!("could not parse count from /exec body: {body}"))
+}
+
+/// Pull the first scalar out of a `{"dataset":[[N,...]],...}` `/exec` reply.
+fn parse_dataset_scalar(body: &str) -> Option<i64> {
+    let idx = body.find("\"dataset\":[[")?;
+    let tail = &body[idx + "\"dataset\":[[".len()..];
+    let end = tail.find([',', ']'])?;
+    tail[..end].trim().parse().ok()
+}
+
+fn wait_for_http_count(srv: &QuestDbServer, table: &str, expected: i64) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if http_count(srv, table) >= expected {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    panic!(
+        "{table} did not reach {expected} rows within 30s (last count={})",
+        http_count(srv, table)
+    );
+}
+
+/// Retry an egress reader connect until it succeeds or the deadline passes.
+/// The QWP/WS egress endpoint can accept connections slightly after `/ping`
+/// goes green, so the first reader connect may need a few retries.
+fn wait_egress_ready(srv: &QuestDbServer) {
+    let conf = srv.qwp_conf();
+    let deadline = Instant::now() + Duration::from_secs(45);
+    loop {
+        match Reader::from_conf(&conf) {
+            Ok(_reader) => return,
+            Err(e) => {
+                if Instant::now() >= deadline {
+                    panic!("egress endpoint not ready within 45s: {e}");
+                }
+                std::thread::sleep(Duration::from_millis(200));
+            }
+        }
+    }
+}
+
+fn create_table(srv: &QuestDbServer, table: &str) {
+    let status = srv.http_exec(&format!(
+        "CREATE TABLE \"{table}\" (sym SYMBOL, v LONG, ts TIMESTAMP) \
+         TIMESTAMP(ts) PARTITION BY DAY WAL"
+    ));
+    assert_eq!(status, 200, "create table failed (HTTP {status})");
+}
+
+/// Elastic `Db` with a lazy (min 0) query pool — for ingress-only tests that
+/// must not touch the egress endpoint.
+fn make_db_ingest(srv: &QuestDbServer) -> Db {
+    Db::builder()
+        .ingest_config(&srv.http_conf())
+        .query_config(&srv.qwp_conf())
+        .sender_pool_min(1)
+        .sender_pool_max(6)
+        .query_pool_min(0)
+        .query_pool_max(4)
+        .acquire_timeout(Duration::from_secs(30))
+        .housekeeper_interval(Duration::from_millis(500))
+        .build()
+        .expect("build Db")
+}
+
+/// Elastic `Db` with both pools warm — for egress tests (call
+/// [`wait_egress_ready`] first).
+fn make_db_full(srv: &QuestDbServer) -> Db {
+    Db::builder()
+        .ingest_config(&srv.http_conf())
+        .query_config(&srv.qwp_conf())
+        .sender_pool_min(1)
+        .sender_pool_max(6)
+        .query_pool_min(1)
+        .query_pool_max(4)
+        .acquire_timeout(Duration::from_secs(30))
+        .housekeeper_interval(Duration::from_millis(500))
+        .build()
+        .expect("build Db")
+}
+
+/// Ingest `count` rows tagged with `tag` via a pooled sender.
+fn ingest_rows(db: &Db, table: &str, tag: &str, base: i64, count: i64) -> Result<(), DbError> {
+    let mut sender = db.borrow_sender()?;
+    let mut buf = sender.new_buffer();
+    for i in 0..count {
+        buf.table(table)?
+            .symbol("sym", tag)?
+            .column_i64("v", base + i)?
+            .at(TimestampNanos::now())?;
+    }
+    sender.flush(&mut buf)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Ingress concurrency (sender pool) — verified over HTTP /exec.
+// ---------------------------------------------------------------------------
+
+/// Many threads ingest into one table through the shared sender pool. No borrow
+/// should error, and every row must land.
+#[test]
+fn db_concurrent_ingest_pooled_senders() {
+    let srv = server();
+    let db = make_db_ingest(srv);
+    let table = unique_table("ingest");
+    create_table(srv, &table);
+
+    let threads = 8;
+    let per_thread = 500i64;
+
+    let mut handles = Vec::new();
+    for t in 0..threads {
+        let db = db.clone();
+        let table = table.clone();
+        handles.push(std::thread::spawn(move || {
+            ingest_rows(&db, &table, "ingest", t as i64 * per_thread, per_thread)
+                .expect("concurrent ingest must not error");
+        }));
+    }
+    for h in handles {
+        h.join().expect("ingest thread panicked");
+    }
+
+    let expected = threads as i64 * per_thread;
+    wait_for_http_count(srv, &table, expected);
+    assert_eq!(http_count(srv, &table), expected);
+    db.close();
+}
+
+/// Hold every borrowed sender simultaneously (barrier) so the pool is forced to
+/// grow to the cap; prove all borrows succeed and the pool grew past `min`.
+#[test]
+fn db_sender_pool_grows_under_contention() {
+    use std::sync::{Arc, Barrier};
+
+    let srv = server();
+    let db = make_db_ingest(srv);
+    let table = unique_table("grow");
+    create_table(srv, &table);
+
+    let threads = 6; // == sender_pool_max
+    let per_thread = 100i64;
+    let barrier = Arc::new(Barrier::new(threads));
+
+    let mut handles = Vec::new();
+    for t in 0..threads {
+        let db = db.clone();
+        let table = table.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(std::thread::spawn(move || {
+            let mut sender = db.borrow_sender().expect("borrow");
+            // Force all slots to be held at once -> the pool must grow to max.
+            barrier.wait();
+            let mut buf = sender.new_buffer();
+            for i in 0..per_thread {
+                buf.table(table.as_str())
+                    .unwrap()
+                    .symbol("sym", "grow")
+                    .unwrap()
+                    .column_i64("v", t as i64 * per_thread + i)
+                    .unwrap()
+                    .at(TimestampNanos::now())
+                    .unwrap();
+            }
+            sender.flush(&mut buf).expect("flush");
+        }));
+    }
+    for h in handles {
+        h.join().expect("thread panicked");
+    }
+
+    assert!(
+        db.sender_pool_size() > 1,
+        "pool should have grown beyond min under contention, got {}",
+        db.sender_pool_size()
+    );
+    assert!(
+        db.sender_pool_size() <= 6,
+        "pool exceeded max: {}",
+        db.sender_pool_size()
+    );
+
+    let expected = threads as i64 * per_thread;
+    wait_for_http_count(srv, &table, expected);
+    assert_eq!(http_count(srv, &table), expected);
+    db.close();
+}
+
+/// A deliberately tiny sender pool (one slot) with many contenders and a
+/// generous acquire timeout: borrows must serialise, never time out.
+#[test]
+fn db_tight_pool_serialises_without_timeout() {
+    let srv = server();
+    let db = Db::builder()
+        .ingest_config(&srv.http_conf())
+        .query_config(&srv.qwp_conf())
+        .sender_pool_size(1)
+        .query_pool_min(0)
+        .query_pool_max(1)
+        .acquire_timeout(Duration::from_secs(60))
+        .build()
+        .expect("build Db");
+    let table = unique_table("tight");
+    create_table(srv, &table);
+
+    let threads = 6;
+    let per_thread = 200i64;
+
+    let mut handles = Vec::new();
+    for t in 0..threads {
+        let db = db.clone();
+        let table = table.clone();
+        handles.push(std::thread::spawn(move || {
+            ingest_rows(&db, &table, "tight", t as i64 * per_thread, per_thread)
+                .expect("tight-pool ingest must serialise, not time out");
+        }));
+    }
+    for h in handles {
+        h.join().expect("tight thread panicked");
+    }
+
+    let expected = threads as i64 * per_thread;
+    wait_for_http_count(srv, &table, expected);
+    assert_eq!(http_count(srv, &table), expected);
+    assert_eq!(db.sender_pool_size(), 1, "tight pool must stay at 1");
+    db.close();
+}
+
+/// Unified `Db::from_conf` (single `ws::` string -> http ingest + ws query)
+/// round trip across threads, ingress verified over HTTP.
+#[test]
+fn db_from_conf_unified_ingest() {
+    let srv = server();
+    let db = Db::builder()
+        .from_conf(&srv.qwp_conf())
+        .expect("from_conf")
+        .query_pool_min(0)
+        .build()
+        .expect("build Db");
+    let table = unique_table("unified");
+    create_table(srv, &table);
+
+    let threads = 4;
+    let per_thread = 250i64;
+    let mut handles = Vec::new();
+    for t in 0..threads {
+        let db = db.clone();
+        let table = table.clone();
+        handles.push(std::thread::spawn(move || {
+            ingest_rows(&db, &table, "unified", t as i64 * per_thread, per_thread)
+                .expect("unified ingest");
+        }));
+    }
+    for h in handles {
+        h.join().expect("unified thread panicked");
+    }
+
+    let expected = threads as i64 * per_thread;
+    wait_for_http_count(srv, &table, expected);
+    assert_eq!(http_count(srv, &table), expected);
+    db.close();
+}
+
+// ---------------------------------------------------------------------------
+// Egress concurrency (reader pool). Requires the QWP/WS egress endpoint.
+// ---------------------------------------------------------------------------
+
+/// `select count() from <table>` through the pooled reader.
+fn db_count(db: &Db, table: &str) -> i64 {
+    let sql = format!("select count() from \"{table}\"");
+    let mut out: i64 = -1;
+    db.execute_query(&sql, |batch| {
+        if batch.row_count() > 0
+            && let Ok(ColumnView::Long(c)) = batch.column(0)
+            && !c.is_null(0)
+        {
+            out = c.value(0);
+        }
+        true
+    })
+    .expect("count query");
+    out
+}
+
+/// Seed once, then many threads run queries through the shared reader pool
+/// concurrently. Every query must see the full row set.
+#[test]
+fn db_concurrent_query_pooled_readers() {
+    let srv = server();
+    wait_egress_ready(srv);
+    let db = make_db_full(srv);
+    let table = unique_table("query");
+    create_table(srv, &table);
+
+    let total: i64 = 2000;
+    ingest_rows(&db, &table, "seed", 0, total).expect("seed");
+    wait_for_http_count(srv, &table, total);
+
+    let threads = 8;
+    let iters = 15;
+    let select = format!("select v from \"{table}\"");
+
+    let mut handles = Vec::new();
+    for _ in 0..threads {
+        let db = db.clone();
+        let select = select.clone();
+        handles.push(std::thread::spawn(move || {
+            for _ in 0..iters {
+                let mut seen: u64 = 0;
+                let summary = db
+                    .execute_query(&select, |batch| {
+                        seen += batch.row_count() as u64;
+                        true
+                    })
+                    .expect("concurrent query must not error");
+                assert_eq!(summary.rows, total as u64);
+                assert_eq!(seen, total as u64);
+            }
+        }));
+    }
+    for h in handles {
+        h.join().expect("query thread panicked");
+    }
+    db.close();
+}
+
+/// Threads simultaneously ingest *and* query, exercising both pools at once.
+/// Nothing must error; the final count must equal everything ingested.
+#[test]
+fn db_concurrent_mixed_ingest_and_query() {
+    let srv = server();
+    wait_egress_ready(srv);
+    let db = make_db_full(srv);
+    let table = unique_table("mixed");
+    create_table(srv, &table);
+
+    let writers = 5;
+    let readers = 5;
+    let per_writer = 300i64;
+
+    let mut handles = Vec::new();
+
+    for t in 0..writers {
+        let db = db.clone();
+        let table = table.clone();
+        handles.push(std::thread::spawn(move || {
+            for batch in 0..3 {
+                let base = (t as i64 * 3 + batch) * per_writer;
+                ingest_rows(&db, &table, "mixed", base, per_writer)
+                    .expect("mixed ingest must not error");
+            }
+        }));
+    }
+
+    for _ in 0..readers {
+        let db = db.clone();
+        let table = table.clone();
+        handles.push(std::thread::spawn(move || {
+            for _ in 0..20 {
+                // Counts climb as writers run; we only assert the calls never
+                // error or panic.
+                let _ = db_count(&db, &table);
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("mixed thread panicked");
+    }
+
+    let expected = writers as i64 * 3 * per_writer;
+    wait_for_http_count(srv, &table, expected);
+    assert_eq!(db_count(&db, &table), expected);
+    db.close();
+}
+
+/// Stopping a query early (handler returns false) must cancel cleanly and
+/// leave the pooled reader reusable for the next borrower.
+#[test]
+fn db_query_early_stop_keeps_reader_reusable() {
+    let srv = server();
+    wait_egress_ready(srv);
+    let db = make_db_full(srv);
+    let table = unique_table("earlystop");
+    create_table(srv, &table);
+
+    let total: i64 = 1000;
+    ingest_rows(&db, &table, "es", 0, total).expect("seed");
+    wait_for_http_count(srv, &table, total);
+
+    let select = format!("select v from \"{table}\"");
+
+    // Stop after the first batch.
+    let summary = db
+        .execute_query(&select, |_batch| false)
+        .expect("early-stop query");
+    assert!(summary.stopped_early, "expected early stop");
+
+    // Reader must have returned clean: follow-up full queries still work,
+    // repeatedly, reusing pooled readers.
+    for _ in 0..10 {
+        assert_eq!(db_count(&db, &table), total);
+    }
+    db.close();
+}


### PR DESCRIPTION
## Summary

Adds a single, cheaply-cloneable **`Db`** handle that pools both ingest `Sender`s and egress `Reader`s, so application code never opens or closes a connection itself. This mirrors the Java client's `QuestDB` facade (`SenderPool` / `QueryClientPool` / `PooledSender` / `PoolHousekeeper`), adapted to idiomatic Rust (RAII return instead of `close()`-to-return; synchronous query execution since the egress reader is sync/pull-based).

Pooling is **custom** — no external pool crate (no `r2d2`) — and the whole feature is gated behind a new `pool` Cargo feature.

```rust
use questdb::db::Db;
use questdb::ingress::TimestampNanos;

// One handle for the whole deployment; clone it across threads.
let db = Db::connect("http::addr=localhost:9000;", "ws::addr=localhost:9000;")?;

// Ingest — borrow a sender, build rows, flush. Returns to the pool on drop.
let mut sender = db.borrow_sender()?;
let mut buf = sender.new_buffer();
buf.table("trades")?.symbol("sym", "ETH-USD")?.column_f64("price", 2615.54)?.at(TimestampNanos::now())?;
sender.flush(&mut buf)?;

// Query — run a SELECT, consume batches; reader returns to the pool clean.
let summary = db.execute_query("select * from trades limit 100", |batch| {
    println!("{} rows", batch.row_count());
    true // return false to stop early (auto-cancels)
})?;
```

## What's added

**`src/pool.rs` — generic pool engine (`Pool<M: Manage>`)**
Transport-agnostic core shared by both sides, unit-testable without a server.
- Elastic: pre-warms `min`, grows on demand to `max`, `reap_idle` shrinks back toward `min`.
- Blocking acquire with timeout via `Mutex` + `Condvar`.
- New connections opened **off-lock** with an `in_flight` counter (a slow TLS/DNS connect never stalls other borrowers).
- RAII return: `Pooled<M>` derefs to the connection and returns it on `Drop`; broken (`mark_broken`) or rejected (`Manage::recycle`) connections are discarded.
- No per-borrow heap allocation; free list is a `VecDeque` pre-sized to `max`.

**`src/db.rs` — the `Db` facade**
- `Db` is `Clone` (Arc-backed); construct once, share everywhere — pooling is hidden.
- `DbBuilder` with defaults matching the Java client: min 1 / max 4 per pool, 5s acquire, 60s idle, 30min max-lifetime, 5s housekeeper.
- RAII `PooledSender` / `PooledReader` guards (deref to `Sender` / `Reader`).
- `execute_query(sql, on_batch)` drives a cursor to terminal and cancels cleanly on early stop, guaranteeing the reader returns reusable; errors discard the reader.
- Unified `Db::from_conf` with `http`<->`ws` / `https`<->`wss` schema translation.
- A background housekeeper thread reaps idle/over-age connections; stopped when the last `Db` clone drops.

## Capacity-correctness fix (found by the stress tests)

Under churn with discards, a naive pool can briefly hold `max + 1` **real** connections, because a discarded slot is freed (accounting-wise) before the connection is actually closed off-lock. Fixed with a `closing` counter that keeps the slot reserved during the off-lock close — the same mechanism as the Java client's `closingSlots`. The cap is now honoured against `idle + leased + in_flight + closing`.

## Tests

**Pool-core (deterministic, server-free, always in CI) — 18 tests**, including 7 concurrency stress tests against an instrumented mock that tracks peak-live connections:
- capacity cap never exceeded under heavy contention,
- self-healing under ~25% random breakage,
- reap-during-load (no deadlock),
- close-under-load (no panic, no leak),
- growth liveness (all `max` held at once via a barrier),
- tight-cap serialisation (max=1, many contenders, no spurious timeouts).

**Live-server (`tests/db_pool_live.rs`, gated behind `live-server-tests`, which now pulls in `pool`)** — many threads share one cloned `Db`:
- **Ingress (sender pool):** concurrent ingest, pool growth under a barrier, tight-pool serialisation, unified `from_conf` — verified via HTTP `/exec`. Run locally against a real QuestDB.
- **Egress (reader pool):** concurrent queries, mixed ingest+query, early-stop reader reuse.

> Note: the egress live tests are compile- and clippy-verified but were not run locally — the QWP/WS egress endpoint isn't answering in my local server build (the existing `egress_live_server` tests fail identically here), so it's an environment limit, not a code issue. They follow the standard harness conventions and will run in CI. The egress reader **pool mechanics** are fully covered by the deterministic concurrency tests.

**`examples/db_pool.rs`** — end-to-end demo (ingest + query + multi-thread sharing).

## Verification
- `cargo test --features almost-all-features --lib` → **1594 passed, 0 failed**.
- `cargo clippy` clean on lib, tests, and examples.
- `cargo fmt --check` clean.
- Live ingress concurrency tests pass repeatedly against a real QuestDB.

## Notes / follow-ups (intentionally out of scope)
- Thread-affine sender pinning (`sender()` / `releaseSender()` via `thread_local!`).
- Store-and-forward per-slot `sender_id` / flock management for pooled QWP/WS senders sharing one `sf_dir` (the Java `SenderPool` slot-index machinery).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added connection pooling support for ingest and query operations with configurable pool sizing, acquire/idle timeouts, and connection lifetime recycling
* Introduced `Db` facade for simplified pooled database access with automatic connection lifecycle management
* Added example demonstrating pooled ingestion, streaming queries, and multi-threaded operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->