### PR TITLE
QWP DataFrame bench plan + Rust Polars parity (ingress + egress)

### DIFF
--- a/doc/QWP_DATAFRAME_BENCH_PLAN.md
+++ b/doc/QWP_DATAFRAME_BENCH_PLAN.md
@@ -1,0 +1,439 @@
+# QWP DataFrame Benchmark Plan — pandas (Python) & Polars (Rust), ingress + egress
+
+**Status:** draft, pending approval
+**Scope:** benchmark suite for the QWP/WebSocket DataFrame paths — pandas in
+`py-questdb-client`, Polars in `c-questdb-client/questdb-rs`. Both directions:
+**ingress** (DataFrame → wire) and **egress** (query result → DataFrame).
+**Supersedes:** the missing `plan-pandas-columnar-performance.md` (referenced 4×
+in the now-deleted `plan-egress-to-pandas.md` / `plan-conn-pool-and-writers.md`).
+**Relationship:** this is the concrete realisation of `c-questdb-client`'s
+`doc/COLUMN_SENDER_PLAN.md` **WS-6** (Rust benches) and **WS-7** (Python
+end-to-end throughput, the `pandas_to_questdb_throughput` deliverable). Methodology
+is inherited from `doc/COLUMN_SENDER_PERF.md`.
+
+**This doc lives in `c-questdb-client/doc/`.** Path conventions: Rust paths are
+relative to `c-questdb-client/questdb-rs/` (e.g. `benches/decoder.rs`,
+`src/ingress/column_sender/encoder.rs`); Python paths are relative to the
+`py-questdb-client/` repo (e.g. `test/benchmark_pandas_columnar.py`).
+
+---
+
+## 1. Goal & priorities
+
+Build the smallest benchmark suite that delivers, in priority order:
+
+1. **DataFrame path characterisation** — where does time go in pandas/Polars
+   encode (ingress) and decode (egress), per column type; verify the zero-copy
+   claims. This is the biggest gap today: **there is no egress benchmark in
+   either client**, despite egress→DataFrame being the marquee QWP feature.
+2. **Cross-client parity table** — one comparable `rows/s` + `GiB/s` per client
+   (pandas, Polars, and the Java/Go anchors) on a single shared schema.
+
+Non-goals for v1: QWP-vs-ILP/PGWire/CSV protocol shootout (Java `StacBenchmarkClient`
+and Go `bench/qwp-egress-read` already own that); a precomputed combinatorial
+sweep matrix (see §2).
+
+---
+
+## 2. Guiding principles (narrow-v1 discipline)
+
+Inherited from `COLUMN_SENDER_PLAN.md` ("that is the *whole* goal; anything else
+is out of scope") and from the Go finding that a full `max_batch_rows`/`credit`/
+`bufpool` sweep was wasted because "the path is pipeline-coupling-bound, **not
+param-bound**." We do not front-load breadth.
+
+- **Exhaustive only where it's cheap.** Per-type coverage lives in the
+  no-network micro/floor tier (Rust Criterion; Python `columnar-populate` /
+  decode-from-bytes). The expensive real-server tier stays **narrow**.
+- **One schema (S1) for the expensive paths.** Vary with **knobs, not a matrix**.
+- **Defer every secondary axis until a number implicates it** (compression, TLS,
+  ack-level, pooled-vs-per-call, concurrency, output-backend matrix, chunk layout).
+- **Report the honest sum, not the near-free part.** After borrow-not-copy a
+  `column_i64` append is ~57 ns (descriptor only — it doesn't move data); the
+  honest ingress metric is `populate_plus_encode`. Symmetrically on egress the
+  honest metric is `decode_plus_assemble`, not the near-free zero-copy column view.
+- **Report baseline-relative.** Each type as a ratio to its raw floor
+  (`extend_from_slice`/memcpy on ingress; `np.frombuffer(...).copy()` / `Bytes`
+  slice on egress).
+
+This discipline *serves* both priorities: the parity table wants one comparable
+number per client (not a matrix to align), and characterisation's per-type breadth
+is cheap (no server), so narrowing the expensive tier costs nothing there.
+
+---
+
+## 3. Shared infrastructure ("the spine")
+
+Steps 1 and 2 build this once; every later step plugs into it.
+
+### 3.1 Canonical scenario set
+
+**S1 — `narrow` (headline, all expensive paths).** 5 columns, matches Go/Rust
+`qwp-egress-read` and (loosely) Java STAC so numbers line up cross-client:
+
+| Column | QWP type | pandas dtype | Polars/Arrow |
+|---|---|---|---|
+| `ts`    | TIMESTAMP (designated) | `datetime64[ns]` | `Datetime(ns)` |
+| `id`    | LONG    | `int64`     | `Int64` |
+| `price` | DOUBLE  | `float64`   | `Float64` |
+| `sym`   | SYMBOL  | `Categorical` (card 8) | `Categorical` |
+| `note`  | VARCHAR | `string` (Arrow), len ~16 | `Utf8` |
+
+Defaults: `rows=10_000_000` (headline), `rows=100_000` (CI), no-null.
+
+**Cheap tier — per-type (broaden here, no server).** Split by direction because
+column **ingress** is v1-scoped while **egress** decodes everything:
+
+- *Ingress S4* (v1 types only, per `COLUMN_SENDER_PLAN.md` §6): bool, i8, i16,
+  i32, i64, f32, f64, varchar, symbol, timestamp, date, uuid, ipv4, long256.
+  **Excluded** (not implemented for column ingress): decimal, long/double array,
+  geohash, char, binary.
+- *Egress S4* (full decode set — maps to `egress.pxi` chunk functions):
+  - fast / zero-copy (`_numpy_fixed_chunk`): bool, byte, short, int, long, float,
+    double, char, ipv4, timestamp, date;
+  - slow / per-row Python loop (prime targets): varchar+binary
+    (`_numpy_varlen_chunk`), uuid (`_numpy_uuid_chunk`), long256
+    (`_numpy_long256_chunk`), decimal (`_numpy_decimal_chunk`), long/double array
+    (`_numpy_array_chunk`); symbol → `pd.Categorical.from_codes`.
+
+Use `COLUMN_SENDER_PLAN.md` §6 as the authority for which dtype to construct per
+type and which are "no native" (uuid→bytes, ipv4→uint32, long256→bytes).
+
+**Deferred until a number says it matters:** S2 wide; output-backend matrix
+(numpy / pyarrow / numpy_nullable / `__arrow_c_stream__`); chunk layout
+(rechunked vs multi-chunk); no-null-vs-nullable per type; Categorical
+"100k categories, few referenced"; zstd; TLS (`wss`); ack-level
+(`Ok` vs `Durable`); pooled-vs-per-call; concurrency (N pooled senders).
+
+### 3.2 Metric / JSON contract (one schema, both languages → one aggregator)
+
+Formalise the existing `benchmark_pandas_columnar.py` report. Rust examples emit
+the **same** JSON so a single aggregator builds the parity table.
+
+```jsonc
+{
+  "schema": "s1-narrow", "rows": 10000000, "columns": 5,
+  "direction": "ingress",            // or "egress"
+  "client": "py-pandas",             // py-pandas | py-polars | rust-polars | java | go
+  "warmups": 3,
+  "machine": { "platform": "...", "cpu": "...", "python|rustc": "...",
+               "pandas": "...", "pyarrow": "...", "polars": "..." },
+  "commits": { "py_questdb_client": "...", "c_questdb_client": "..." },
+  "run_mode": "quick|full",
+  "paths": {
+    "<name>": {
+      "median_s": 0.0, "p50_s": 0.0, "p90_s": 0.0, "p99_s": 0.0,
+      "rows_per_s_median": 0, "cells_per_s_median": 0,
+      "wire_bytes": 0, "mib_per_s": 0.0,
+      "process_cpu": { "user_s": 0.0, "sys_s": 0.0 },
+      "cov": 0.0, "copies": 0, "zero_copy": true,
+      "phase": "floor|e2e", "warm": true
+    }
+  }
+}
+```
+
+### 3.3 Knobs (parity names with the Rust suite)
+
+Mirror `COLUMN_SENDER_PERF.md`: `--rows` (`QUESTDB_COLUMN_BENCH_ROWS`, default
+100k), `--sym-card` (`QUESTDB_COLUMN_BENCH_SYM_CARD`, default 8 for S1),
+`--varchar-len` (`QUESTDB_COLUMN_BENCH_VARCHAR_LEN`, default 16). CI runs use
+`--quick` (Rust: `cargo bench -- --quick --noplot`).
+
+### 3.4 Correctness — DEDUP (mandatory for real-server throughput)
+
+QWP/WS is **at-least-once on reconnect**; replayed frames inflate row counts
+5–16 % (c-questdb-client PR #143). Every real-server path must pre-create the
+table and use monotonic-unique timestamps:
+
+```sql
+CREATE TABLE bench_s1 (...) TIMESTAMP(ts) PARTITION BY HOUR WAL DEDUP UPSERT KEYS(ts);
+```
+
+`run_pandas_columnar_layer3.py` currently lets ingestion auto-create the table
+(no DEDUP keys) and only `SELECT count()` to verify — Step 1 must add the explicit
+`CREATE TABLE … DEDUP` and unique-ts generation.
+
+### 3.5 Cold vs warm (verified against code, not the stale doc)
+
+`COLUMN_SENDER_PERF.md:53` claims a "REFERENCE mode" schema-signature cache. That
+is **stale**: the encoder rebuilds and writes the schema signature inline on every
+frame (`column_sender/encoder.rs:153-224`); `COLUMN_SENDER_PLAN.md:83` ("no schema
+cache") is correct. So there is **no schema FULL/REFERENCE axis**.
+
+The real cold/warm axis is the **symbol delta-dict + commit mode**
+(`column_sender/sender.rs:90-96,144-145`): the first frame on a fresh connection
+sends the full symbol dict from id 0 with an immediate commit (warms the server's
+`ClientSymbolCache`); later frames send `FLAG_DELTA_SYMBOL_DICT` deltas with
+`FLAG_DEFER_COMMIT`. `first_frame_sent` travels with the pool slot, so a
+warm-recycled connection skips the cold cost. Benchmarks must report **first-flush
+(cold)** separately from **warm steady-state**, and note warm-from-pool.
+
+### 3.6 Honest-sum & baseline-relative (see §2)
+
+Ingress: report `populate` / `encode` / `populate_plus_encode` and headline the
+**sum**. Egress: report `decode` / `assemble` / `decode_plus_assemble` and
+headline the sum. Always alongside the raw floor.
+
+### 3.7 Environment recording
+
+Record machine, CPU, library versions, both repo commits, and run-mode in every
+JSON (already present in the Python harness; add to Rust). Parity table runs must
+be single-box, single-stream (prior numbers are Apple-Silicon loopback).
+
+---
+
+## 4. Step 1 — Python pandas **ingress** e2e (`pandas_to_questdb_throughput`)  *[DETAILED]*
+
+The WS-7 deliverable, scoped to current branch state and narrow-v1.
+
+### 4.1 Current branch state (`jh_experiment_new_ilp`)
+
+Already exists — Step 1 is **alignment + hardening, not greenfield**:
+
+- `Client.dataframe()` columnar fast path → Rust `column_sender_flush_arrow_batch`
+  FFI (the WS-7 "build a wrapper" TODO is already done).
+- `test/benchmark_pandas_columnar.py` (963 lines): paths `columnar-populate`
+  (no-network floor), `client-ack` / `client-ack-reuse` (mock-server e2e via
+  `qwp_ws_ack_server.py`, with `ack_delay_s` injection), `real-client` /
+  `real-row` (real server), `arrow-materialize`. Emits the JSON report
+  (machine, commits, percentiles, CPU, `columnar_io_stats`); has a perf
+  assertion (`--ack-reuse-min-calls` default 100 within `--ack-reuse-max-seconds`
+  default 10). Schemas: `numeric-core`, `numeric-wide`, `categorical-symbols`,
+  `arrow-strings`, `arrow-large-strings`, `mixed-physical`, `nullable-extension`.
+- `test/run_pandas_columnar_layer3.py`: installs/builds a real QuestDB
+  (`system_test.py`), runs `real-*` paths, verifies via `SELECT count()`.
+
+### 4.2 Work items
+
+1. **Add the `s1-narrow` schema** (§3.1) to `SCHEMAS` in
+   `benchmark_pandas_columnar.py` (+ its `CREATE TABLE` template with
+   `DEDUP UPSERT KEYS(ts)`), with `--sym-card`/`--varchar-len` knobs feeding its
+   generator. This becomes the single headline schema; keep the existing schemas
+   available for the cheap tier.
+2. **Lock the JSON metric contract v1** (§3.2): add `direction`, `client`,
+   `wire_bytes`, `mib_per_s`, `phase` (`floor`/`e2e`), `warm`, `run_mode`. Keep
+   the existing fields.
+3. **Wire DEDUP + unique-ts** into `run_pandas_columnar_layer3.py` and the
+   `real-*` setup (§3.4): explicit `CREATE TABLE … DEDUP`, monotonic-unique `ts`,
+   and assert `count() == rows` (no inflation).
+4. **Pair floor + e2e in one run**: the headline invocation runs
+   `columnar-populate` (floor) **and** `real-client` (e2e) on S1 and reports both
+   + the `populate_plus_encode`-style sum (§3.6).
+5. **Cold/warm split** (§3.5): report the first `real-client` flush separately
+   from warm steady-state (the `client-ack-reuse` machinery already exercises
+   warm reuse — extend its reporting rather than add a path).
+6. **Name the entrypoint** `pandas_to_questdb_throughput` (a thin documented
+   wrapper / make-target that runs items 4–5 on S1). `ack_level=Ok`; note
+   `Durable` is Enterprise + deferred (§13).
+7. **CI**: local-run-first via `run_pandas_columnar_layer3.py` (unblocked today);
+   wire a real server into CI as a fast-follow (the WS-7 "done when" gate).
+
+### 4.3 Deliverables
+
+- `s1-narrow` schema + DEDUP table template.
+- JSON contract v1 emitted by the harness.
+- `pandas_to_questdb_throughput` headline run (floor + e2e + cold/warm) on S1.
+- DEDUP-correct real-server fixture.
+
+### 4.4 Done when
+
+- One command yields S1 `rows/s` + `MiB/s` for **e2e (`real-client`)** alongside
+  the **`columnar-populate` floor**, on 10M rows, with `count() == rows`.
+- Cold first-flush vs warm steady-state both reported.
+- JSON conforms to the contract; machine + both commits recorded.
+- Runs locally via `run_pandas_columnar_layer3.py`; CI wiring tracked.
+
+### 4.5 Run
+
+```sh
+python test/run_pandas_columnar_layer3.py --questdb-repo ../../questdb \
+  --schema s1-narrow --rows 10000000 --iterations 5 \
+  --path columnar-populate --path real-client --pretty
+```
+
+---
+
+## 5. Step 2 — Python pandas **egress** e2e (symmetry)  *[DETAILED]*
+
+The mirror of Step 1, closing the #1 gap. New harness, **same spine**.
+
+### 5.1 Current branch state
+
+No egress benchmark exists. `src/questdb/egress.pxi` exposes the API to bench:
+`Client.query(...)` → `to_pandas()` (numpy default), `to_pandas(dtype_backend=
+"pyarrow"|"numpy_nullable")`, `to_polars()`, `__arrow_c_stream__` (pyarrow-free),
+`iter_pandas()` / `iter_arrow()` (lazy per-batch). Fast `_numpy_fixed_chunk`
+(zero-copy `np.frombuffer`) vs slow per-row loops (§3.1).
+
+### 5.2 Fixture decision (narrow-v1)
+
+**Read back the S1 table that Step 1 ingested** on the real server (natural
+symmetry: write in Step 1, read in Step 2; reuses the Step 1 spine, DEDUP-correct).
+A server-free **RESULT_BATCH replay server** (extend `qwp_ws_ack_server.py` to
+stream captured/synthesised batches) is **deferred to Step 5** — it's only needed
+for CI-isolated decode micro and the cheap-tier egress per-type set.
+
+### 5.3 Paths (symmetry to ingress)
+
+- `decode-only` — iterate the cursor's Arrow batches without building a DataFrame
+  (the egress floor; analog of `columnar-populate`).
+- `to-pandas` — default numpy materialise (the headline).
+- `to-polars` — Polars output (shares the Arrow path; cheap to add).
+- `arrow-c-stream` — `__arrow_c_stream__` → `polars.from_arrow` (pyarrow-free).
+- `iter-pandas` — lazy per-batch vs `to-pandas` full materialise.
+- `real-egress` — end-to-end against the real server (reads the S1 table).
+
+Headline run pairs `decode-only` (floor) + `to-pandas` (e2e) and reports the
+`decode_plus_assemble` sum (§3.6).
+
+### 5.4 Work items
+
+1. New `test/benchmark_pandas_egress.py` mirroring the ingress harness structure
+   and **emitting the identical JSON contract** (`direction="egress"`).
+2. Extend `run_pandas_columnar_layer3.py` to ingest S1 then query it back (or a
+   sibling `run_pandas_egress_layer3.py`), reusing the DEDUP fixture.
+3. Implement the §5.3 paths on **S1 only**, 10M rows, no-null.
+4. Verify zero-copy on the fixed-width fast path (assert `_numpy_fixed_chunk`
+   taken; buffer-shares-memory check) — characterisation deliverable.
+
+### 5.5 Deliverables
+
+- `benchmark_pandas_egress.py` (S1, paths in §5.3, contract-conformant JSON).
+- Real-server read-back fixture.
+- First egress `rows/s` + `MiB/s` numbers for `to_pandas` / `to_polars` /
+  `arrow_c_stream`, with the decode/assemble split.
+
+### 5.6 Done when
+
+- One command yields S1 egress `rows/s` + `MiB/s` for `to_pandas` (+ `to_polars`,
+  `arrow_c_stream`) alongside the `decode-only` floor, reading back the DEDUP'd
+  S1 table, 10M rows.
+- Zero-copy verified on the fast path.
+- JSON conforms; comparable in shape to Step 1 and to the Go anchor
+  (40.7M rows/s narrow).
+
+### 5.7 Run
+
+```sh
+python test/run_pandas_egress_layer3.py --questdb-repo ../../questdb \
+  --schema s1-narrow --rows 10000000 --iterations 5 \
+  --path decode-only --path to-pandas --path to-polars --pretty
+```
+
+---
+
+## 6. Step 3 — Rust **Polars** parity, ingress + egress  *[summary]*
+
+Bring the Rust side onto the same S1 + JSON contract → 4 comparable headline
+numbers (pandas/Polars × ingress/egress).
+
+- **Ingress:** `examples/qwp_ingress_polars.rs` measuring `flush_polars_dataframe()`
+  on S1; report e2e + the `column_sender.rs` encode floor (already exists) so the
+  DataFrame→batches overhead is isolated.
+- **Egress:** `examples/qwp_egress_polars.rs` (`fetch_all_polars` / `iter_polars` /
+  `next_polars`) on S1, plus a `→ polars` arm in `benches/decoder.rs` (Criterion
+  synthesises batches in-process → server-free decode→DataFrame micro). Report
+  `decode` (the existing 13.3M rows/s floor) vs `assemble` vs the sum.
+- Emit the §3.2 JSON from both examples.
+
+## 7. Step 4 — Parity table  *[summary]*
+
+Aggregator script consumes all §3.2 JSON (pandas, Polars, + Go/Java anchors run
+on the same box) → one S1 `rows/s` + `GiB/s` table per direction. Single-box,
+single-stream; environment block enforced.
+
+## 8. Step 5 — First deepening: S2 wide + DataFrame characterisation  *[summary]*
+
+Only after the 4 headline numbers exist.
+
+- **S2 — `wide` (15 col):** 1 TIMESTAMP + 7 fixed (bool, short, int, long, long,
+  float, double) + 1 VARCHAR + 5 SYMBOL (card 10k–100k). The "QWP wins on wide
+  rows" claim + symbol-dict stress. Add to both harnesses + Rust examples.
+- **DataFrame-specific knobs (cheap):** output-backend matrix (numpy / pyarrow /
+  numpy_nullable / `__arrow_c_stream__`); chunk layout (rechunked vs multi-chunk);
+  no-null vs nullable per type (memcpy vs invert+gather — expect the ~57 ns→289 ns
+  ratio from `COLUMN_SENDER_PERF.md`); Categorical "100k categories, few
+  referenced" (tests the scan-only-referenced path, `encoder.rs:1110,1128`).
+- **RESULT_BATCH replay server** (extend `qwp_ws_ack_server.py`) for CI-stable
+  egress decode micro + the cheap-tier egress per-type set.
+
+## 9. Step 6 — Secondary axes  *[summary]*
+
+Each gated on a prior number implicating it: zstd (raw vs `compression-zstd`);
+TLS (`wss`); ack-level (`Ok` vs `Durable`, Enterprise); pooled-vs-per-call;
+**concurrency** — N pooled senders / one frame in flight each
+(`COLUMN_SENDER_PLAN.md` parallelism model; the Go "single-stream is
+pipeline-coupling-bound" missing axis).
+
+## 10. Step 7 — Soak  *[summary]*
+
+Nightly CI, 1-hour run, random chunks: assert no leaks, no reconnects, latched-error
+handling (`COLUMN_SENDER_PLAN.md` WS-6).
+
+---
+
+## 11. Baselines & targets
+
+| Path | Known number (Apple-Silicon, loopback) | Source |
+|---|---|---|
+| Egress decode, 15-col | Rust 13.3M rows/s ~1.0 GiB/s (≈7 % off Java 1.3 GiB/s); Go 40.7M rows/s @ 1003 MiB/s narrow | c #140, go #62 |
+| Ingress encode floor | no-null f64/i64 ≈ memcpy ~54 GiB/s; symbol intern 16×; varchar within ~5 % memcpy | `COLUMN_SENDER_PERF.md` |
+| Ingress pipelined e2e | Rust 350 MB/s; per-chunk p50 0.72 ms | c #140 |
+| Ingress latency | Java ~38 µs p50 SF `flush()` | `QwpIngressLatencyBenchmark` |
+| 5-col 100k chunk | populate ~76 µs, encode ~500 µs, **e2e ~575 µs**; i64 no-null ~57 ns vs nullable ~289 ns | `COLUMN_SENDER_PERF.md` |
+
+**Pass/fail targets:** VARCHAR within ~2× of f64; SYMBOL within 2× of f64 at
+10M × 1000-card (`COLUMN_SENDER_PLAN.md` WS-3/WS-4). DataFrame-assembly overhead
+is reported as a **% on top of these floors** per type.
+
+---
+
+## 12. Gotchas
+
+- **DEDUP** `UPSERT KEYS(ts)` + monotonic-unique `ts` on every real-server run
+  (at-least-once inflates 5–16 %).
+- **Cold/warm = symbol-dict delta + commit mode**, not schema (verified
+  `sender.rs:90-96`, `encoder.rs:153-224`); `PERF.md`'s REFERENCE-mode note is
+  stale.
+- **Buffer pre-size** (`estimate_frame_size`): payloads > 64 KiB regress without
+  one-shot sizing (~880 µs vs ~575 µs); ensure benches pre-size; one scenario
+  should deliberately exceed 64 KiB.
+- **Honest sum** (`populate_plus_encode` / `decode_plus_assemble`), never the
+  near-free zero-copy view.
+- **No cell-by-cell row-vs-column microbench** — ruled out as apples/oranges
+  (`PERF.md:95`); row-vs-column is a DataFrame-level comparison (`real-row` vs
+  `real-client`).
+
+---
+
+## 13. Open decisions
+
+1. **Doc home** — resolved: lives in `c-questdb-client/doc/` alongside
+   `COLUMN_SENDER_PLAN.md` / `COLUMN_SENDER_PERF.md` (single source of truth).
+   Add a one-line pointer from `py-questdb-client` when Step 1 lands.
+2. **Step 1 CI** — local-run-first (default, unblocked now) vs real-server-in-CI
+   inside Step 1 (matches WS-7 "done when").
+3. **Durable ack-level** — defer (Enterprise, `request_durable_ack=on`) vs
+   in-scope for Step 6.
+4. **Egress fixture** — read-back real server for v1 (default) vs build the
+   RESULT_BATCH replay server earlier than Step 5.
+
+---
+
+## Appendix — existing assets inventory
+
+**Python (`py-questdb-client`):** `test/benchmark_pandas_columnar.py`,
+`test/run_pandas_columnar_layer3.py`, `test/qwp_ws_ack_server.py`,
+`test/benchmark.py` (10M row-path + GIL-release scaling), `perf/README.md`,
+`src/questdb/egress.pxi`, `src/questdb/dataframe.pxi`.
+
+**Rust (`c-questdb-client/questdb-rs`):** `benches/decoder.rs`,
+`benches/column_sender.rs`; examples `qwp_egress_read.rs`,
+`qwp_egress_read_wide.rs`, `qwp_egress_latency.rs`, `qwp_egress_hits.rs`,
+`qwp_ws_l1_quotes.rs`, `qwp_ws_unified_sfa_bench.rs`, `polars.rs`;
+`src/ingress/polars.rs`, `src/egress/arrow/polars.rs`;
+`doc/COLUMN_SENDER_PLAN.md`, `doc/COLUMN_SENDER_PERF.md`.
+
+**Anchors:** Java `StacBenchmarkClient.java`, `QwpIngressLatencyBenchmark.java`;
+Go `bench/qwp-egress-read[-wide]/main.go`.

--- a/questdb-rs/Cargo.toml
+++ b/questdb-rs/Cargo.toml
@@ -75,7 +75,14 @@ arrow-data = { version = "58", optional = true, default-features = false }
 # 64-byte aligned allocations for build-pass Arrow buffers (validity,
 # BOOLEAN bit-pack, ARRAY offsets, SYMBOL union dict).
 aligned-vec = { version = "0.6", optional = true }
-polars = { version = ">=0.50, <1.0", optional = true, default-features = false, features = ["dtype-categorical"] }
+# `dtype-datetime` + `timezones` are required for the egress
+# `Series::from_arrow` path: every QuestDB table has a designated
+# TIMESTAMP, which the decoder maps to the tz-aware Arrow
+# `Timestamp(Microsecond, Some("UTC"))`. Without these, materialising a
+# real result set into a polars `DataFrame` (`fetch_all_polars` /
+# `next_polars` / `iter_polars`) fails at runtime on the timestamp
+# column. `dtype-date` covers QuestDB DATE columns symmetrically.
+polars = { version = ">=0.50, <1.0", optional = true, default-features = false, features = ["dtype-categorical", "dtype-datetime", "dtype-date", "timezones"] }
 polars-arrow = { version = ">=0.50, <1.0", optional = true, default-features = false, features = ["compute"] }
 
 [target.'cfg(windows)'.dependencies]
@@ -302,6 +309,30 @@ required-features = ["sync-sender-qwp-ws"]
 [[example]]
 name = "polars"
 required-features = ["polars", "sync-sender-qwp-ws"]
+
+# Step 3 (doc/QWP_DATAFRAME_BENCH_PLAN.md §6) — Rust Polars ingress parity
+# on the S1 narrow schema. Measures flush_polars_dataframe() e2e + the
+# column-sender encode floor and emits the §3.2 JSON metric contract
+# (client="rust-polars", direction="ingress"). Uses ureq for the DEDUP
+# table create + WAL count gate, hence sync-sender-http. The crate's
+# polars dep currently needs a nightly toolchain. Run with:
+#
+#   cargo +nightly run --release --example qwp_ingress_polars \
+#       --features polars,sync-sender-qwp-ws,sync-sender-http
+[[example]]
+name = "qwp_ingress_polars"
+required-features = ["polars", "sync-sender-qwp-ws", "sync-sender-http"]
+
+# Step 3 (§6) — Rust Polars egress parity on S1. Reads the table back via
+# fetch_all_polars / iter_polars / next_polars and reports decode vs
+# assemble vs the honest decode_plus_assemble sum, emitting the §3.2 JSON
+# (direction="egress"). Run with:
+#
+#   cargo +nightly run --release --example qwp_egress_polars \
+#       --features polars,sync-reader-ws,sync-sender-http
+[[example]]
+name = "qwp_egress_polars"
+required-features = ["polars", "sync-reader-ws", "sync-sender-http"]
 
 # Decoder microbenchmark anchoring the perf claims from commits
 # `8ec0a85` (zero-copy decode) and `1163d43` (tighter SYMBOL/VARCHAR

--- a/questdb-rs/benches/decoder.rs
+++ b/questdb-rs/benches/decoder.rs
@@ -67,8 +67,12 @@ use std::time::Duration;
 
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 
+#[cfg(feature = "arrow")]
+use questdb::egress::_bench_internals::bench_batch_to_record_batch;
 #[cfg(feature = "polars")]
 use questdb::egress::_bench_internals::bench_batch_to_polars;
+#[cfg(feature = "polars")]
+use questdb::egress::arrow::polars::record_batch_to_dataframe;
 use questdb::egress::_bench_internals::{
     Bytes, Schema, SymbolDict, ZstdScratch, decode_result_batch,
 };
@@ -361,7 +365,7 @@ fn serialize_batch(cols: &[ColSpec], row_count: usize) -> Bytes {
 /// unlike the wide 15-col workload, sticks to the dtypes the crate's
 /// minimal polars feature set (`dtype-categorical` only — no `dtype-i16`
 /// / `dtype-i8`) can build a `Series` from.
-#[cfg(feature = "polars")]
+#[cfg(feature = "arrow")]
 fn build_s1_workload(row_count: usize) -> Bytes {
     let cols: Vec<ColSpec> = vec![
         ColSpec {
@@ -447,18 +451,21 @@ fn bench_decoder(c: &mut Criterion) {
         },
     );
 
-    // `→ polars DataFrame` arms (plan §6 / §3.6): the honest
-    // `decode_plus_assemble` micro on the **S1 narrow** schema (the
-    // shape the cross-client parity table reads back; the wide 15-col
-    // workload above carries Int16/Int8 columns the crate's minimal
-    // polars feature set can't build a Series from). The `decode` arm
-    // is the floor; the `to_polars` arm decodes the same S1 payload and
-    // then assembles it into a polars DataFrame (Arrow RecordBatch build
-    // + zero-copy Arrow C Data Interface handoff), so the difference
-    // isolates the assemble cost. Only compiled when the `polars`
-    // feature is on; the decode-only arm above keeps the bench runnable
-    // under `sync-reader-ws` alone.
-    #[cfg(feature = "polars")]
+    // Decode→assemble arms (plan §6 / §3.6) on the **S1 narrow** schema (the
+    // shape the cross-client parity table reads back; the wide 15-col workload
+    // above carries Int16/Int8 columns the crate's minimal polars feature set
+    // can't build a Series from). Three nested floors so subtraction isolates
+    // each stage:
+    //   * `_decode`     — wire bytes → `DecodedBatch` (raw decode floor).
+    //   * `_to_arrow`   — `+ batch_to_record_batch` (DecodedBatch → Arrow,
+    //                     i.e. `convert.rs` column build). `_to_arrow − _decode`
+    //                     is the Arrow assemble cost.
+    //   * `_to_polars`  — `+ record_batch_to_dataframe` (Arrow → polars via the
+    //                     C Data Interface). `_to_polars − _to_arrow` is the
+    //                     polars FFI / `Series::from_arrow` cost.
+    // `_decode` and `_to_arrow` need only `arrow` (stable toolchain); `_to_polars`
+    // needs `polars`.
+    #[cfg(feature = "arrow")]
     {
         let s1_payload = build_s1_workload(row_count);
         {
@@ -470,10 +477,25 @@ fn bench_decoder(c: &mut Criterion) {
             assert_eq!(batch.row_count, row_count, "S1 row count round-trip");
             assert_eq!(batch.columns.len(), 5, "S1 column count round-trip");
             let schema = reg.as_ref().expect("schema populated by decode");
-            let df = bench_batch_to_polars(schema, batch, &dict)
-                .expect("S1 batch must assemble into a polars DataFrame");
-            assert_eq!(df.height(), row_count, "S1 polars height round-trip");
-            assert_eq!(df.width(), 5, "S1 polars width round-trip");
+            let rb = bench_batch_to_record_batch(schema, batch, &dict)
+                .expect("S1 batch must assemble into an arrow RecordBatch");
+            assert_eq!(rb.num_rows(), row_count, "S1 arrow row round-trip");
+            assert_eq!(rb.num_columns(), 5, "S1 arrow column round-trip");
+            #[cfg(feature = "polars")]
+            {
+                // `bench_batch_to_record_batch` consumed the first decode; the
+                // polars pre-flight re-decodes the same payload.
+                let mut dict = SymbolDict::new();
+                let mut reg: Option<Schema> = None;
+                let mut scratch = ZstdScratch::new();
+                let batch = decode_result_batch(&s1_payload, 0, &mut dict, &mut reg, &mut scratch)
+                    .expect("synthesised S1 workload must decode cleanly");
+                let schema = reg.as_ref().expect("schema populated by decode");
+                let df = bench_batch_to_polars(schema, batch, &dict)
+                    .expect("S1 batch must assemble into a polars DataFrame");
+                assert_eq!(df.height(), row_count, "S1 polars height round-trip");
+                assert_eq!(df.width(), 5, "S1 polars width round-trip");
+            }
         }
         group.bench_function(format!("s1_5col_{}_rows_decode", row_count), |b| {
             b.iter(|| {
@@ -491,6 +513,26 @@ fn bench_decoder(c: &mut Criterion) {
                 black_box(batch);
             });
         });
+        group.bench_function(format!("s1_5col_{}_rows_to_arrow", row_count), |b| {
+            b.iter(|| {
+                let mut dict = SymbolDict::new();
+                let mut reg: Option<Schema> = None;
+                let mut scratch = ZstdScratch::new();
+                let batch = decode_result_batch(
+                    black_box(&s1_payload),
+                    0,
+                    &mut dict,
+                    &mut reg,
+                    &mut scratch,
+                )
+                .expect("decode");
+                let schema = reg.as_ref().expect("schema populated by decode");
+                let rb = bench_batch_to_record_batch(schema, batch, &dict)
+                    .expect("decoded batch must assemble into an arrow RecordBatch");
+                black_box(rb);
+            });
+        });
+        #[cfg(feature = "polars")]
         group.bench_function(format!("s1_5col_{}_rows_to_polars", row_count), |b| {
             b.iter(|| {
                 let mut dict = SymbolDict::new();
@@ -510,6 +552,43 @@ fn bench_decoder(c: &mut Criterion) {
                 black_box(df);
             });
         });
+        // Per-column probe of `record_batch_to_dataframe` (decode/convert once,
+        // outside the loop): `col_id` is the zero-copy baseline; `col_sym/col_note`
+        // minus it isolate the Dictionary→Categorical / Utf8→Utf8View costs.
+        #[cfg(feature = "polars")]
+        {
+            let rb = {
+                let mut dict = SymbolDict::new();
+                let mut reg: Option<Schema> = None;
+                let mut scratch = ZstdScratch::new();
+                let batch = decode_result_batch(&s1_payload, 0, &mut dict, &mut reg, &mut scratch)
+                    .expect("decode");
+                let schema = reg.as_ref().expect("schema populated by decode");
+                bench_batch_to_record_batch(schema, batch, &dict)
+                    .expect("S1 batch must assemble into an arrow RecordBatch")
+            };
+            group.bench_function(format!("s1_5col_{}_rows_to_polars_col_id", row_count), |b| {
+                b.iter(|| {
+                    let sub = rb.project(&[1]).expect("project");
+                    black_box(record_batch_to_dataframe(sub).expect("to df"));
+                });
+            });
+            group.bench_function(format!("s1_5col_{}_rows_to_polars_col_sym", row_count), |b| {
+                b.iter(|| {
+                    let sub = rb.project(&[3]).expect("project");
+                    black_box(record_batch_to_dataframe(sub).expect("to df"));
+                });
+            });
+            group.bench_function(
+                format!("s1_5col_{}_rows_to_polars_col_note", row_count),
+                |b| {
+                    b.iter(|| {
+                        let sub = rb.project(&[4]).expect("project");
+                        black_box(record_batch_to_dataframe(sub).expect("to df"));
+                    });
+                },
+            );
+        }
     }
 
     group.finish();

--- a/questdb-rs/benches/decoder.rs
+++ b/questdb-rs/benches/decoder.rs
@@ -67,6 +67,8 @@ use std::time::Duration;
 
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 
+#[cfg(feature = "polars")]
+use questdb::egress::_bench_internals::bench_batch_to_polars;
 use questdb::egress::_bench_internals::{
     Bytes, Schema, SymbolDict, ZstdScratch, decode_result_batch,
 };
@@ -318,6 +320,13 @@ fn build_workload(row_count: usize) -> Bytes {
         cols.len()
     );
 
+    serialize_batch(&cols, row_count)
+}
+
+/// Serialise a column set into a single `RESULT_BATCH` payload (the
+/// post-FrameHeader bytes `decode_result_batch` consumes). Shared by
+/// the 15-column wide workload and the S1 narrow workload.
+fn serialize_batch(cols: &[ColSpec], row_count: usize) -> Bytes {
     let mut out = Vec::new();
     // Frame prefix: msg_kind + request_id + batch_seq.
     out.push(MSG_KIND_RESULT_BATCH);
@@ -330,18 +339,63 @@ fn build_workload(row_count: usize) -> Bytes {
     varint_u64(cols.len() as u64, &mut out);
 
     // Columns inline: per-column (name, kind). No schema-mode byte, no schema id.
-    for c in &cols {
+    for c in cols {
         varint_u64(c.name.len() as u64, &mut out);
         out.extend_from_slice(c.name.as_bytes());
         out.push(c.kind.as_u8());
     }
 
     // Per-column bodies, in declaration order.
-    for c in &cols {
+    for c in cols {
         out.extend_from_slice(&c.body);
     }
 
     Bytes::from(out)
+}
+
+/// Synthesise the **S1 narrow** `RESULT_BATCH` payload (plan §3.1): the
+/// 5-column headline schema the cross-client parity table reads back —
+/// `ts` TIMESTAMP, `id` LONG, `price` DOUBLE, `sym` SYMBOL (card 8),
+/// `note` VARCHAR (~16 bytes). This is the workload behind the
+/// `→ polars DataFrame` decoder arm: it matches the S1 examples and,
+/// unlike the wide 15-col workload, sticks to the dtypes the crate's
+/// minimal polars feature set (`dtype-categorical` only — no `dtype-i16`
+/// / `dtype-i8`) can build a `Series` from.
+#[cfg(feature = "polars")]
+fn build_s1_workload(row_count: usize) -> Bytes {
+    let cols: Vec<ColSpec> = vec![
+        ColSpec {
+            name: "ts",
+            kind: ColumnKind::Timestamp,
+            body: fixed_le_bytes(row_count, |i| {
+                let base: i64 = 1_700_000_000_000_000;
+                // 1 µs spacing — mirrors the S1 monotonic-unique ts.
+                (base + (i as i64)).to_le_bytes()
+            }),
+        },
+        ColSpec {
+            name: "id",
+            kind: ColumnKind::Long,
+            body: fixed_le_bytes(row_count, |i| (i as i64).to_le_bytes()),
+        },
+        ColSpec {
+            name: "price",
+            kind: ColumnKind::Double,
+            body: fixed_le_bytes(row_count, |i| ((i as f64) * 0.25).to_le_bytes()),
+        },
+        ColSpec {
+            name: "sym",
+            kind: ColumnKind::Symbol,
+            // Cardinality 8 to match the S1 SYMBOL column.
+            body: symbol_body(row_count, 8, 1),
+        },
+        ColSpec {
+            name: "note",
+            kind: ColumnKind::Varchar,
+            body: varchar_body(row_count),
+        },
+    ];
+    serialize_batch(&cols, row_count)
 }
 
 // ---------------------------------------------------------------------------
@@ -392,6 +446,72 @@ fn bench_decoder(c: &mut Criterion) {
             });
         },
     );
+
+    // `→ polars DataFrame` arms (plan §6 / §3.6): the honest
+    // `decode_plus_assemble` micro on the **S1 narrow** schema (the
+    // shape the cross-client parity table reads back; the wide 15-col
+    // workload above carries Int16/Int8 columns the crate's minimal
+    // polars feature set can't build a Series from). The `decode` arm
+    // is the floor; the `to_polars` arm decodes the same S1 payload and
+    // then assembles it into a polars DataFrame (Arrow RecordBatch build
+    // + zero-copy Arrow C Data Interface handoff), so the difference
+    // isolates the assemble cost. Only compiled when the `polars`
+    // feature is on; the decode-only arm above keeps the bench runnable
+    // under `sync-reader-ws` alone.
+    #[cfg(feature = "polars")]
+    {
+        let s1_payload = build_s1_workload(row_count);
+        {
+            let mut dict = SymbolDict::new();
+            let mut reg: Option<Schema> = None;
+            let mut scratch = ZstdScratch::new();
+            let batch = decode_result_batch(&s1_payload, 0, &mut dict, &mut reg, &mut scratch)
+                .expect("synthesised S1 workload must decode cleanly");
+            assert_eq!(batch.row_count, row_count, "S1 row count round-trip");
+            assert_eq!(batch.columns.len(), 5, "S1 column count round-trip");
+            let schema = reg.as_ref().expect("schema populated by decode");
+            let df = bench_batch_to_polars(schema, batch, &dict)
+                .expect("S1 batch must assemble into a polars DataFrame");
+            assert_eq!(df.height(), row_count, "S1 polars height round-trip");
+            assert_eq!(df.width(), 5, "S1 polars width round-trip");
+        }
+        group.bench_function(format!("s1_5col_{}_rows_decode", row_count), |b| {
+            b.iter(|| {
+                let mut dict = SymbolDict::new();
+                let mut reg: Option<Schema> = None;
+                let mut scratch = ZstdScratch::new();
+                let batch = decode_result_batch(
+                    black_box(&s1_payload),
+                    0,
+                    &mut dict,
+                    &mut reg,
+                    &mut scratch,
+                )
+                .expect("decode");
+                black_box(batch);
+            });
+        });
+        group.bench_function(format!("s1_5col_{}_rows_to_polars", row_count), |b| {
+            b.iter(|| {
+                let mut dict = SymbolDict::new();
+                let mut reg: Option<Schema> = None;
+                let mut scratch = ZstdScratch::new();
+                let batch = decode_result_batch(
+                    black_box(&s1_payload),
+                    0,
+                    &mut dict,
+                    &mut reg,
+                    &mut scratch,
+                )
+                .expect("decode");
+                let schema = reg.as_ref().expect("schema populated by decode");
+                let df = bench_batch_to_polars(schema, batch, &dict)
+                    .expect("decoded batch must assemble into a polars DataFrame");
+                black_box(df);
+            });
+        });
+    }
+
     group.finish();
 }
 

--- a/questdb-rs/examples/bench_json/mod.rs
+++ b/questdb-rs/examples/bench_json/mod.rs
@@ -1,0 +1,490 @@
+//! Shared JSON metric contract (QWP_DATAFRAME_BENCH_PLAN.md §3.2) for the
+//! Rust Polars ingress/egress examples. Emits the **same** field names as
+//! the Python harness (`py-questdb-client/test/benchmark_pandas_columnar.py`:
+//! `summarize` + `add_rates` + `_path_summary` + the top-level report) so a
+//! Step 4 aggregator consumes Python (`py-pandas`) and Rust (`rust-polars`)
+//! JSON uniformly.
+//!
+//! Kept dependency-light (hand-rolled JSON, no serde) and outside Cargo's
+//! example auto-discovery (it lives in a subdirectory, referenced by each
+//! example via `mod bench_json;`).
+
+#![allow(dead_code)] // each example uses a subset of the surface.
+
+use std::fmt::Write as _;
+
+const MIB: f64 = 1024.0 * 1024.0;
+
+// ---------------------------------------------------------------------------
+// Process CPU time (the Python harness reports process_cpu via
+// time.process_time_ns()). `libc::getrusage` is the portable equivalent;
+// `libc` is a non-optional dependency of the crate.
+// ---------------------------------------------------------------------------
+
+/// User+system CPU nanoseconds consumed by this process so far.
+pub fn process_cpu_ns() -> u64 {
+    let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) };
+    if rc != 0 {
+        return 0;
+    }
+    let tv_ns =
+        |tv: &libc::timeval| (tv.tv_sec as u64) * 1_000_000_000 + (tv.tv_usec as u64) * 1_000;
+    tv_ns(&usage.ru_utime) + tv_ns(&usage.ru_stime)
+}
+
+// ---------------------------------------------------------------------------
+// JSON building (minimal, ordered, sorted keys for deterministic output).
+// ---------------------------------------------------------------------------
+
+/// A JSON object as ordered key→value pairs (values already serialised).
+pub struct Obj(Vec<(String, String)>);
+
+impl Obj {
+    pub fn new() -> Self {
+        Obj(Vec::new())
+    }
+    pub fn str(&mut self, k: &str, v: &str) -> &mut Self {
+        self.0.push((k.to_string(), json_str(v)));
+        self
+    }
+    pub fn opt_str(&mut self, k: &str, v: Option<&str>) -> &mut Self {
+        self.0
+            .push((k.to_string(), v.map_or("null".to_string(), json_str)));
+        self
+    }
+    pub fn int(&mut self, k: &str, v: u64) -> &mut Self {
+        self.0.push((k.to_string(), v.to_string()));
+        self
+    }
+    pub fn float(&mut self, k: &str, v: f64) -> &mut Self {
+        self.0.push((k.to_string(), json_f64(v)));
+        self
+    }
+    pub fn opt_float(&mut self, k: &str, v: Option<f64>) -> &mut Self {
+        self.0
+            .push((k.to_string(), v.map_or("null".to_string(), json_f64)));
+        self
+    }
+    pub fn bool(&mut self, k: &str, v: bool) -> &mut Self {
+        self.0.push((k.to_string(), v.to_string()));
+        self
+    }
+    pub fn raw(&mut self, k: &str, v: String) -> &mut Self {
+        self.0.push((k.to_string(), v));
+        self
+    }
+    /// Serialise to compact, single-line JSON with keys sorted (matches
+    /// the Python harness's `json.dumps(..., sort_keys=True)` shape; the
+    /// aggregator parses JSON, so whitespace is irrelevant and compact
+    /// output sidesteps nested-indent bookkeeping when objects are
+    /// embedded as raw values). The `_indent` argument is accepted for
+    /// call-site symmetry and ignored.
+    pub fn to_json(&self, _indent: usize) -> String {
+        let mut entries: Vec<&(String, String)> = self.0.iter().collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        let mut s = String::from("{");
+        for (i, (k, v)) in entries.iter().enumerate() {
+            if i > 0 {
+                s.push(',');
+            }
+            let _ = write!(s, "{}:{}", json_str(k), v);
+        }
+        s.push('}');
+        s
+    }
+}
+
+impl Default for Obj {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn json_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn json_f64(v: f64) -> String {
+    if v.is_finite() {
+        // Enough precision to round-trip; trims trailing zeros.
+        let s = format!("{v:.12}");
+        let s = s.trim_end_matches('0').trim_end_matches('.');
+        if s.is_empty() || s == "-" {
+            "0".to_string()
+        } else {
+            s.to_string()
+        }
+    } else {
+        "null".to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// summarize() — mirrors the Python harness field-for-field.
+// ---------------------------------------------------------------------------
+
+/// Percentile of an ascending slice, Python-harness convention
+/// (`round((n-1)*p)`).
+fn percentile(sorted_s: &[f64], p: f64) -> f64 {
+    if sorted_s.is_empty() {
+        return 0.0;
+    }
+    let idx = ((sorted_s.len() as f64 - 1.0) * p).round() as usize;
+    sorted_s[idx.min(sorted_s.len() - 1)]
+}
+
+/// `summarize(samples_ns)` — seconds-domain stats matching the Python
+/// harness (`iterations`, `median_s`, `mean_s`, `min_s`, `max_s`,
+/// `p95_s`, `stdev_s`, `cov`), optionally with rates folded in.
+fn summarize(
+    obj: &mut Obj,
+    samples_ns: &[u64],
+    rows: usize,
+    columns: usize,
+    wire_bytes: Option<u64>,
+) {
+    let secs: Vec<f64> = samples_ns.iter().map(|&n| n as f64 / 1e9).collect();
+    let mut sorted = secs.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let n = secs.len();
+    let mean = if n > 0 {
+        secs.iter().sum::<f64>() / n as f64
+    } else {
+        0.0
+    };
+    let median = if n == 0 {
+        0.0
+    } else if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+    };
+    let stdev = if n > 1 {
+        let var = secs.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (n as f64 - 1.0);
+        var.sqrt()
+    } else {
+        0.0
+    };
+    obj.int("iterations", n as u64);
+    obj.float("median_s", median);
+    obj.float("mean_s", mean);
+    obj.float("min_s", *sorted.first().unwrap_or(&0.0));
+    obj.float("max_s", *sorted.last().unwrap_or(&0.0));
+    obj.float("p95_s", percentile(&sorted, 0.95));
+    obj.float("stdev_s", stdev);
+    obj.float("cov", if mean != 0.0 { stdev / mean } else { 0.0 });
+    add_rates(obj, median, rows, columns, wire_bytes);
+}
+
+/// `add_rates(summary, rows, columns, wire_bytes)` — rows/cells per second
+/// off the median, plus MiB/s when bytes crossed the wire (floor paths
+/// leave `mib_per_s` null, exactly like the Python harness).
+fn add_rates(obj: &mut Obj, median_s: f64, rows: usize, columns: usize, wire_bytes: Option<u64>) {
+    let rows_per_s = if median_s != 0.0 {
+        Some(rows as f64 / median_s)
+    } else {
+        None
+    };
+    let cells_per_s = if median_s != 0.0 {
+        Some((rows * columns) as f64 / median_s)
+    } else {
+        None
+    };
+    obj.opt_float("rows_per_s_median", rows_per_s);
+    obj.opt_float("cells_per_s_median", cells_per_s);
+    let mib_per_s = match (wire_bytes, median_s) {
+        (Some(b), m) if m != 0.0 => Some((b as f64 / MIB) / m),
+        _ => None,
+    };
+    obj.opt_float("mib_per_s", mib_per_s);
+}
+
+/// One contract-conformant per-path summary block (plan §3.2):
+/// `summarize` + rates + `process_cpu` (its own summarize+rates) + `phase`
+/// + `warm` + `wire_bytes`.
+pub struct PathSummary {
+    obj: Obj,
+    pub median_s: f64,
+    pub rows_per_s_median: Option<f64>,
+    pub mib_per_s: Option<f64>,
+}
+
+impl PathSummary {
+    pub fn new(
+        wall_ns: &[u64],
+        cpu_ns: &[u64],
+        rows: usize,
+        columns: usize,
+        phase: &str,
+        warm: bool,
+        wire_bytes: Option<u64>,
+    ) -> Self {
+        // `mib_per_s` is only meaningful for e2e paths (bytes on wire); the
+        // floor leaves it null, matching `_path_summary`'s
+        // `rate_wire_bytes = wire_bytes if phase == "e2e" else None`.
+        let rate_wire_bytes = if phase == "e2e" { wire_bytes } else { None };
+        let mut obj = Obj::new();
+        summarize(&mut obj, wall_ns, rows, columns, rate_wire_bytes);
+
+        // Recompute the headline fields we expose to the caller.
+        let secs: Vec<f64> = wall_ns.iter().map(|&n| n as f64 / 1e9).collect();
+        let mut sorted = secs.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let nn = sorted.len();
+        let median_s = if nn == 0 {
+            0.0
+        } else if nn % 2 == 1 {
+            sorted[nn / 2]
+        } else {
+            (sorted[nn / 2 - 1] + sorted[nn / 2]) / 2.0
+        };
+        let rows_per_s_median = if median_s != 0.0 {
+            Some(rows as f64 / median_s)
+        } else {
+            None
+        };
+        let mib_per_s = match (rate_wire_bytes, median_s) {
+            (Some(b), m) if m != 0.0 => Some((b as f64 / MIB) / m),
+            _ => None,
+        };
+
+        let mut cpu = Obj::new();
+        summarize(&mut cpu, cpu_ns, rows, columns, rate_wire_bytes);
+        obj.raw("process_cpu", cpu.to_json(0));
+
+        obj.str("phase", phase);
+        obj.bool("warm", warm);
+        // `wire_bytes` records the schema's per-flush payload on every path
+        // (the Python harness records it even on floor paths).
+        match wire_bytes {
+            Some(b) => obj.int("wire_bytes", b),
+            None => obj.opt_str("wire_bytes", None),
+        };
+
+        PathSummary {
+            obj,
+            median_s,
+            rows_per_s_median,
+            mib_per_s,
+        }
+    }
+
+    fn into_json(self) -> String {
+        self.obj.to_json(0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Environment / machine block.
+// ---------------------------------------------------------------------------
+
+pub struct Env {
+    obj: Obj,
+}
+
+impl Env {
+    /// Collect the machine block (plan §3.7). `extra` carries any
+    /// language-specific library versions (e.g. polars) the example wants
+    /// recorded alongside platform + rustc.
+    pub fn collect(extra: &[(&str, &str)]) -> Self {
+        let mut obj = Obj::new();
+        obj.str("platform", std::env::consts::OS);
+        obj.str("arch", std::env::consts::ARCH);
+        // An example binary has no compiler version at runtime; the
+        // build/run harness can inject the exact toolchain via
+        // `RUSTC_VERSION` (e.g. `rustc --version`). Falls back to "unknown".
+        obj.str(
+            "rustc",
+            std::env::var("RUSTC_VERSION")
+                .ok()
+                .as_deref()
+                .unwrap_or("unknown"),
+        );
+        obj.str("questdb_rs", env!("CARGO_PKG_VERSION"));
+        for (k, v) in extra {
+            obj.str(k, v);
+        }
+        Env { obj }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level report.
+// ---------------------------------------------------------------------------
+
+pub struct RowCountCheck {
+    pub expected: u64,
+    pub actual: u64,
+    pub ok: bool,
+    pub inflated: bool,
+}
+
+pub struct Report {
+    schema: String,
+    rows: usize,
+    columns: usize,
+    direction: String,
+    client: String,
+    run_mode: String,
+    pub warmups: usize,
+    pub wire_bytes: u64,
+    pub env: Env,
+    paths: Vec<(String, PathSummary)>,
+    headline: Obj,
+    pub row_count_check: Option<RowCountCheck>,
+    pub real_conf: Option<String>,
+    pub http_base: Option<String>,
+}
+
+impl Report {
+    pub fn new(
+        schema: &str,
+        rows: usize,
+        columns: usize,
+        direction: &str,
+        client: &str,
+        run_mode: &str,
+    ) -> Self {
+        Report {
+            schema: schema.to_string(),
+            rows,
+            columns,
+            direction: direction.to_string(),
+            client: client.to_string(),
+            run_mode: run_mode.to_string(),
+            warmups: 0,
+            wire_bytes: 0,
+            env: Env::collect(&[]),
+            paths: Vec::new(),
+            headline: Obj::new(),
+            row_count_check: None,
+            real_conf: None,
+            http_base: None,
+        }
+    }
+
+    pub fn add_path(&mut self, name: &str, summary: PathSummary) {
+        self.paths.push((name.to_string(), summary));
+    }
+
+    fn path(&self, name: &str) -> Option<&PathSummary> {
+        self.paths.iter().find(|(n, _)| n == name).map(|(_, s)| s)
+    }
+
+    /// Ingress headline (plan §3.6): pair the encode floor with the e2e
+    /// `flush_polars_dataframe` and report the e2e (the honest
+    /// `populate_plus_encode`-style sum) + the marginal DataFrame
+    /// overhead on top of the floor.
+    pub fn compute_ingress_headline(&mut self) {
+        let (Some(floor), Some(e2e)) = (
+            self.path("encode-floor"),
+            self.path("flush-polars-dataframe"),
+        ) else {
+            return;
+        };
+        let floor_s = floor.median_s;
+        let e2e_s = e2e.median_s;
+        let mut h = Obj::new();
+        h.float("encode_floor_s", floor_s);
+        h.float("flush_polars_dataframe_s", e2e_s);
+        h.float("dataframe_overhead_s", (e2e_s - floor_s).max(0.0));
+        h.opt_float("encode_floor_rows_per_s", floor.rows_per_s_median);
+        h.opt_float("flush_polars_dataframe_rows_per_s", e2e.rows_per_s_median);
+        h.opt_float("flush_polars_dataframe_mib_per_s", e2e.mib_per_s);
+        self.headline = h;
+    }
+
+    /// Egress headline (plan §3.6): `decode_plus_assemble` is the
+    /// `fetch_all_polars` e2e (decode + assemble); `decode-only` is the
+    /// floor; the marginal assemble is the difference. Headline the sum.
+    pub fn compute_egress_headline(&mut self) {
+        let (Some(decode), Some(assemble)) =
+            (self.path("decode-only"), self.path("fetch-all-polars"))
+        else {
+            return;
+        };
+        let decode_s = decode.median_s;
+        let assemble_s = assemble.median_s;
+        let mut h = Obj::new();
+        h.float("decode_floor_s", decode_s);
+        h.float("assemble_plus_io_s", (assemble_s - decode_s).max(0.0));
+        h.float("decode_plus_assemble_s", assemble_s);
+        h.opt_float(
+            "decode_plus_assemble_rows_per_s",
+            assemble.rows_per_s_median,
+        );
+        h.opt_float("decode_plus_assemble_mib_per_s", assemble.mib_per_s);
+        self.headline = h;
+    }
+
+    pub fn into_json(self) -> String {
+        let mut top = Obj::new();
+        top.str("schema", &self.schema);
+        top.int("rows", self.rows as u64);
+        top.int("columns", self.columns as u64);
+        top.str("direction", &self.direction);
+        top.str("client", &self.client);
+        top.str("run_mode", &self.run_mode);
+        top.int("warmups", self.warmups as u64);
+        top.int("wire_bytes", self.wire_bytes);
+        top.raw("machine", self.env.obj.to_json(0));
+        top.raw("commits", commits_block().to_json(0));
+        if !self.headline.0.is_empty() {
+            top.raw("headline", self.headline.to_json(0));
+        }
+        // paths: a nested object keyed by path name.
+        let mut paths = Obj::new();
+        for (name, summary) in self.paths {
+            paths.raw(&name, summary.into_json());
+        }
+        top.raw("paths", paths.to_json(0));
+        if let Some(rc) = &self.row_count_check {
+            let mut o = Obj::new();
+            o.int("expected", rc.expected);
+            o.int("actual", rc.actual);
+            o.bool("ok", rc.ok);
+            o.bool("inflated", rc.inflated);
+            top.raw("row_count_check", o.to_json(0));
+        }
+        if let Some(c) = &self.real_conf {
+            top.str("real_conf", c);
+        }
+        if let Some(h) = &self.http_base {
+            top.str("http_base", h);
+        }
+        top.to_json(0)
+    }
+}
+
+/// `commits` block (plan §3.2 / §3.7). Reads `C_QUESTDB_CLIENT_COMMIT`
+/// from the environment if set (the build/run harness can inject it);
+/// otherwise null, since an example binary has no repo access at runtime.
+fn commits_block() -> Obj {
+    let mut o = Obj::new();
+    o.opt_str(
+        "c_questdb_client",
+        std::env::var("C_QUESTDB_CLIENT_COMMIT").ok().as_deref(),
+    );
+    o.opt_str(
+        "py_questdb_client",
+        std::env::var("PY_QUESTDB_CLIENT_COMMIT").ok().as_deref(),
+    );
+    o
+}

--- a/questdb-rs/examples/qwp_egress_polars.rs
+++ b/questdb-rs/examples/qwp_egress_polars.rs
@@ -1,0 +1,470 @@
+//! Step 3 (QWP_DATAFRAME_BENCH_PLAN.md §6) — Rust **Polars egress**
+//! parity for the S1 narrow schema.
+//!
+//! Reads the S1 table back over QWP/WS and measures the decode →
+//! DataFrame paths, the mirror of `qwp_ingress_polars.rs`:
+//!
+//!   * `decode-only`     — drive `Cursor::next_batch()` over the result's
+//!     Arrow batches without building a DataFrame (the egress floor; the
+//!     analog of the ingress encode floor / the Python `_drain_arrow`).
+//!   * `fetch-all-polars` — `Cursor::fetch_all_polars()`, the headline
+//!     decode → polars `DataFrame` materialise (decode + assemble).
+//!   * `iter-polars`      — `Cursor::iter_polars()`, lazy per-batch
+//!     `DataFrame`s vstacked (vs the full materialise).
+//!
+//! `Cursor::next_polars()` is exercised once for correctness. The honest
+//! headline (plan §3.6) is `decode_plus_assemble` = the `fetch_all_polars`
+//! median; `decode-only` is the floor; the marginal assemble is the
+//! difference. Emits the §3.2 JSON metric contract with
+//! `client="rust-polars"`, `direction="egress"`, matching the Python
+//! egress harness (`benchmark_pandas_egress.py`).
+//!
+//! By default the example **populates** the S1 table first (DEDUP UPSERT
+//! KEYS(ts), µs-unique ts), waits for the WAL to apply and asserts
+//! `count() == rows`, then reads it back — so it runs standalone. Set
+//! `SKIP_POPULATE=1` to read back an already-ingested table (e.g. the one
+//! `qwp_ingress_polars` filled).
+//!
+//! Run against a QWP-schema-0x3 QuestDB with QWP/WS + HTTP on :9000:
+//!
+//! ```bash
+//! cargo +nightly run --release --example qwp_egress_polars \
+//!     --features polars,sync-reader-ws,sync-sender-http
+//! ```
+//!
+//! (The `polars` feature pulls in `sync-sender-qwp-ws` + `sync-reader-ws`;
+//! `sync-sender-http` is for the table create + WAL count gate.)
+//!
+//! Env knobs:
+//!   ROWS=10000000  ITERATIONS=5  WARMUPS=2  RUN_MODE=full
+//!   QUESTDB_COLUMN_BENCH_SYM_CARD=8  QUESTDB_COLUMN_BENCH_VARCHAR_LEN=16
+//!   QDB_HOST=127.0.0.1  QDB_PORT=9000  SKIP_POPULATE=1
+
+use std::error::Error;
+use std::time::{Duration, Instant};
+
+use polars::prelude::{
+    CategoricalPhysical, Categories, DataFrame, DataType as PlDataType, IntoColumn, NamedFrom,
+    PlSmallStr, Series, TimeUnit,
+};
+use questdb::egress::Reader;
+use questdb::ingress::ColumnName;
+use questdb::ingress::column_sender::QuestDb;
+use questdb::ingress::polars::PolarsIngestOptions;
+
+mod bench_json;
+use bench_json::{Env, PathSummary, Report};
+
+const TABLE: &str = "bench_s1_narrow";
+const SCHEMA: &str = "s1-narrow";
+const COLUMNS: usize = 5;
+const TS_STEP_NANOS: i64 = 1_000;
+const TS_BASE_NANOS: i64 = 1_704_067_200_000_000_000;
+/// Read back all five S1 columns (full parity with the Python egress
+/// `SELECT *`), including the designated `ts`.
+const SELECT_SQL: &str = "SELECT ts, id, price, sym, note FROM bench_s1_narrow";
+
+// ---------------------------------------------------------------------------
+// S1 DataFrame (for the populate step). Same shape as qwp_ingress_polars.
+// ---------------------------------------------------------------------------
+
+fn build_s1_dataframe(
+    rows: usize,
+    sym_card: usize,
+    varchar_len: usize,
+) -> Result<DataFrame, Box<dyn Error>> {
+    let ts_nanos: Vec<i64> = (0..rows as i64)
+        .map(|i| TS_BASE_NANOS + i * TS_STEP_NANOS)
+        .collect();
+    let ts = Series::new(PlSmallStr::from("ts"), &ts_nanos)
+        .cast(&PlDataType::Datetime(TimeUnit::Nanoseconds, None))?;
+
+    let id: Vec<i64> = (0..rows as i64).collect();
+    let id = Series::new(PlSmallStr::from("id"), &id);
+
+    let price: Vec<f64> = (0..rows).map(|i| i as f64 * 0.25).collect();
+    let price = Series::new(PlSmallStr::from("price"), &price);
+
+    let symbols: Vec<String> = (0..sym_card).map(|i| format!("sym_{i:04}")).collect();
+    let sym_strings: Vec<&str> = (0..rows).map(|i| symbols[i % sym_card].as_str()).collect();
+    let cats = Categories::new(
+        PlSmallStr::from("sym"),
+        PlSmallStr::from("bench"),
+        CategoricalPhysical::U32,
+    );
+    let mapping = cats.mapping();
+    let sym = Series::new(PlSmallStr::from("sym"), sym_strings)
+        .cast(&PlDataType::Categorical(cats, mapping))?;
+
+    let template_count = rows.clamp(1, 1024);
+    let templates: Vec<String> = (0..template_count)
+        .map(|i| {
+            let base = format!("note_{i:03}_").repeat(varchar_len);
+            base.chars().take(varchar_len).collect()
+        })
+        .collect();
+    let note_strings: Vec<&str> = (0..rows)
+        .map(|i| templates[i % templates.len()].as_str())
+        .collect();
+    let note = Series::new(PlSmallStr::from("note"), note_strings);
+
+    Ok(DataFrame::new(
+        rows,
+        vec![
+            ts.into_column(),
+            id.into_column(),
+            price.into_column(),
+            sym.into_column(),
+            note.into_column(),
+        ],
+    )?)
+}
+
+// ---------------------------------------------------------------------------
+// Egress measurements
+// ---------------------------------------------------------------------------
+
+fn timed<T>(f: &mut impl FnMut() -> T) -> (u64, u64, T) {
+    let cpu0 = bench_json::process_cpu_ns();
+    let t0 = Instant::now();
+    let out = f();
+    let wall = t0.elapsed().as_nanos() as u64;
+    let cpu = bench_json::process_cpu_ns().saturating_sub(cpu0);
+    (wall, cpu, out)
+}
+
+/// Per-path timing samples: (wall-clock ns, process-CPU ns).
+type Samples = (Vec<u64>, Vec<u64>);
+
+/// Floor: drive the cursor's Arrow batches without assembling a
+/// DataFrame. A fresh `Reader` per iteration so each query is a clean
+/// round-trip (mirrors the Python egress harness's per-iteration
+/// `client.query(sql)`).
+fn measure_decode_only(
+    host: &str,
+    port: u16,
+    rows: u64,
+    iterations: usize,
+    warmups: usize,
+) -> Result<Samples, Box<dyn Error>> {
+    let conf = format!("ws::addr={host}:{port};compression=raw;");
+    let mut run = || -> Result<u64, Box<dyn Error>> {
+        let mut reader = Reader::from_conf(&conf)?;
+        let mut cursor = reader.prepare(SELECT_SQL).execute()?;
+        let mut seen: u64 = 0;
+        while let Some(view) = cursor.next_batch()? {
+            seen += view.row_count() as u64;
+            std::hint::black_box(&view);
+        }
+        Ok(seen)
+    };
+    for _ in 0..warmups {
+        assert_rows(run()?, rows)?;
+    }
+    let mut wall = Vec::with_capacity(iterations);
+    let mut cpu = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let (w, c, r) = timed(&mut run);
+        assert_rows(r?, rows)?;
+        wall.push(w);
+        cpu.push(c);
+    }
+    Ok((wall, cpu))
+}
+
+/// Headline: `fetch_all_polars()` — decode + assemble into one polars
+/// DataFrame. Returns the timings and the per-query on-wire byte count
+/// (the `Reader`'s observed `bytes_received` delta).
+fn measure_fetch_all_polars(
+    host: &str,
+    port: u16,
+    rows: u64,
+    iterations: usize,
+    warmups: usize,
+) -> Result<(Samples, u64), Box<dyn Error>> {
+    let conf = format!("ws::addr={host}:{port};compression=raw;");
+    let mut wire_bytes = 0u64;
+    let mut run = || -> Result<u64, Box<dyn Error>> {
+        let mut reader = Reader::from_conf(&conf)?;
+        reader.reset_timing();
+        let before = reader.bytes_received();
+        let df = {
+            let mut cursor = reader.prepare(SELECT_SQL).execute()?;
+            cursor.fetch_all_polars()?
+        };
+        wire_bytes = reader.bytes_received() - before;
+        let h = df.height() as u64;
+        std::hint::black_box(&df);
+        Ok(h)
+    };
+    for _ in 0..warmups {
+        assert_rows(run()?, rows)?;
+    }
+    let mut wall = Vec::with_capacity(iterations);
+    let mut cpu = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let (w, c, r) = timed(&mut run);
+        assert_rows(r?, rows)?;
+        wall.push(w);
+        cpu.push(c);
+    }
+    Ok(((wall, cpu), wire_bytes))
+}
+
+/// `iter_polars()` — lazy per-batch DataFrames vstacked into one. Same
+/// end result as `fetch_all_polars`, different driver (per-batch
+/// materialise then concat vs whole-result build), so the two together
+/// show whether the streaming path costs anything.
+fn measure_iter_polars(
+    host: &str,
+    port: u16,
+    rows: u64,
+    iterations: usize,
+    warmups: usize,
+) -> Result<Samples, Box<dyn Error>> {
+    let conf = format!("ws::addr={host}:{port};compression=raw;");
+    let mut run = || -> Result<u64, Box<dyn Error>> {
+        let mut reader = Reader::from_conf(&conf)?;
+        let mut cursor = reader.prepare(SELECT_SQL).execute()?;
+        let mut acc: Option<DataFrame> = None;
+        for item in cursor.iter_polars()? {
+            let df = item?;
+            acc = Some(match acc {
+                None => df,
+                Some(mut prev) => {
+                    prev.vstack_mut_owned(df)?;
+                    prev
+                }
+            });
+        }
+        let h = acc.map(|d| d.height() as u64).unwrap_or(0);
+        Ok(h)
+    };
+    for _ in 0..warmups {
+        assert_rows(run()?, rows)?;
+    }
+    let mut wall = Vec::with_capacity(iterations);
+    let mut cpu = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let (w, c, r) = timed(&mut run);
+        assert_rows(r?, rows)?;
+        wall.push(w);
+        cpu.push(c);
+    }
+    Ok((wall, cpu))
+}
+
+/// Exercise `next_polars()` once for correctness: it yields one
+/// DataFrame per QWP batch. Returns the total rows and chunk count seen.
+fn exercise_next_polars(host: &str, port: u16) -> Result<(u64, usize), Box<dyn Error>> {
+    let conf = format!("ws::addr={host}:{port};compression=raw;");
+    let mut reader = Reader::from_conf(&conf)?;
+    let mut cursor = reader.prepare(SELECT_SQL).execute()?;
+    let mut rows = 0u64;
+    let mut batches = 0usize;
+    while let Some(df) = cursor.next_polars()? {
+        if df.width() != COLUMNS {
+            return Err(format!("next_polars: width {} != {COLUMNS}", df.width()).into());
+        }
+        rows += df.height() as u64;
+        batches += 1;
+    }
+    Ok((rows, batches))
+}
+
+fn assert_rows(seen: u64, expected: u64) -> Result<(), Box<dyn Error>> {
+    if seen != expected {
+        return Err(format!("read back {seen} rows, expected {expected}").into());
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Populate (DEDUP table + polars ingress + WAL count gate, plan §3.4)
+// ---------------------------------------------------------------------------
+
+fn exec_sql(base: &str, sql: &str) -> Result<(), Box<dyn Error>> {
+    let url = format!("{base}/exec");
+    let resp = ureq::get(&url).query("query", sql).call()?;
+    if resp.status() != 200 {
+        return Err(format!("/exec {sql} -> HTTP {}", resp.status()).into());
+    }
+    Ok(())
+}
+
+fn create_table(base: &str) -> Result<(), Box<dyn Error>> {
+    exec_sql(base, &format!("DROP TABLE IF EXISTS {TABLE}"))?;
+    exec_sql(
+        base,
+        &format!(
+            "CREATE TABLE {TABLE} (\
+                ts TIMESTAMP, id LONG, price DOUBLE, sym SYMBOL, note VARCHAR\
+            ) TIMESTAMP(ts) PARTITION BY HOUR WAL DEDUP UPSERT KEYS(ts)"
+        ),
+    )?;
+    Ok(())
+}
+
+fn wait_for_count(base: &str, expected: u64) -> Result<u64, Box<dyn Error>> {
+    let url = format!("{base}/exec");
+    let sql = format!("SELECT count() FROM {TABLE}");
+    let deadline = Instant::now() + Duration::from_secs(300);
+    let mut last = 0u64;
+    while Instant::now() < deadline {
+        let mut resp = ureq::get(&url).query("query", &sql).call()?;
+        let body: String = resp.body_mut().read_to_string()?;
+        if let Some(idx) = body.rfind("\"dataset\":[[") {
+            let tail = &body[idx + "\"dataset\":[[".len()..];
+            if let Some(end) = tail.find(']')
+                && let Ok(n) = tail[..end].parse::<u64>()
+            {
+                last = n;
+                if n >= expected {
+                    return Ok(n);
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+    Ok(last)
+}
+
+fn populate(
+    host: &str,
+    port: u16,
+    base: &str,
+    df: &DataFrame,
+    rows: u64,
+) -> Result<u64, Box<dyn Error>> {
+    eprintln!("[qwp_egress_polars] creating DEDUP table + ingesting {rows} S1 rows ...");
+    create_table(base)?;
+    let conf = format!("qwpws::addr={host}:{port};pool_size=1;pool_max=1;pool_reap=manual;");
+    let db = QuestDb::connect(&conf)?;
+    let ts_col = ColumnName::new("ts")?;
+    let opts = PolarsIngestOptions::new()
+        .max_rows(10_000)
+        .timestamp_column(ts_col);
+    {
+        let mut sender = db.borrow_sender()?;
+        sender.flush_polars_dataframe(TABLE, df, &opts)?;
+    }
+    eprintln!("[qwp_egress_polars] waiting for WAL apply (count() == {rows}) ...");
+    wait_for_count(base, rows)
+}
+
+// ---------------------------------------------------------------------------
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let rows: usize = env_usize("ROWS", 10_000_000);
+    let sym_card: usize = env_usize("QUESTDB_COLUMN_BENCH_SYM_CARD", 8);
+    let varchar_len: usize = env_usize("QUESTDB_COLUMN_BENCH_VARCHAR_LEN", 16);
+    let iterations: usize = env_usize("ITERATIONS", 5);
+    let warmups: usize = env_usize("WARMUPS", 2);
+    let run_mode = std::env::var("RUN_MODE").unwrap_or_else(|_| "full".into());
+    let host = std::env::var("QDB_HOST").unwrap_or_else(|_| "127.0.0.1".into());
+    let port: u16 = env_usize("QDB_PORT", 9000) as u16;
+    let skip_populate = std::env::var("SKIP_POPULATE").is_ok();
+    let base = format!("http://{host}:{port}");
+
+    eprintln!(
+        "[qwp_egress_polars] schema={SCHEMA} rows={rows} sym_card={sym_card} \
+         varchar_len={varchar_len} iterations={iterations} warmups={warmups}"
+    );
+
+    // --- Populate (unless re-using an existing table). ---
+    if !skip_populate {
+        let df = build_s1_dataframe(rows, sym_card, varchar_len)?;
+        let count = populate(&host, port, &base, &df, rows as u64)?;
+        if count != rows as u64 {
+            return Err(format!(
+                "DEDUP gate failed: count() == {count}, expected {rows} (inflated={})",
+                count > rows as u64
+            )
+            .into());
+        }
+        eprintln!("[qwp_egress_polars] DEDUP gate OK: count() == {count}");
+    } else {
+        eprintln!("[qwp_egress_polars] SKIP_POPULATE set — reading existing {TABLE}");
+    }
+
+    let mut report = Report::new(SCHEMA, rows, COLUMNS, "egress", "rust-polars", &run_mode);
+    report.warmups = warmups;
+    report.env = Env::collect(&[]);
+    report.row_count_check = Some(bench_json::RowCountCheck {
+        expected: rows as u64,
+        actual: rows as u64,
+        ok: true,
+        inflated: false,
+    });
+
+    // --- next_polars correctness probe. ---
+    eprintln!("[qwp_egress_polars] exercising next_polars ...");
+    let (np_rows, np_batches) = exercise_next_polars(&host, port)?;
+    assert_rows(np_rows, rows as u64)?;
+    eprintln!("[qwp_egress_polars] next_polars: {np_rows} rows across {np_batches} batch(es)");
+
+    // --- fetch_all_polars first (it discovers the on-wire byte count). ---
+    eprintln!("[qwp_egress_polars] measuring fetch_all_polars ...");
+    let ((fa_wall, fa_cpu), wire_bytes) =
+        measure_fetch_all_polars(&host, port, rows as u64, iterations, warmups)?;
+    report.wire_bytes = wire_bytes;
+    eprintln!("[qwp_egress_polars] on-wire bytes/query = {wire_bytes}");
+
+    // --- decode-only floor. ---
+    eprintln!("[qwp_egress_polars] measuring decode-only floor ...");
+    let (dec_wall, dec_cpu) = measure_decode_only(&host, port, rows as u64, iterations, warmups)?;
+    report.add_path(
+        "decode-only",
+        PathSummary::new(
+            &dec_wall,
+            &dec_cpu,
+            rows,
+            COLUMNS,
+            "floor",
+            warmups > 0,
+            Some(wire_bytes),
+        ),
+    );
+
+    report.add_path(
+        "fetch-all-polars",
+        PathSummary::new(
+            &fa_wall,
+            &fa_cpu,
+            rows,
+            COLUMNS,
+            "e2e",
+            warmups > 0,
+            Some(wire_bytes),
+        ),
+    );
+
+    // --- iter_polars (streaming materialise). ---
+    eprintln!("[qwp_egress_polars] measuring iter_polars ...");
+    let (it_wall, it_cpu) = measure_iter_polars(&host, port, rows as u64, iterations, warmups)?;
+    report.add_path(
+        "iter-polars",
+        PathSummary::new(
+            &it_wall,
+            &it_cpu,
+            rows,
+            COLUMNS,
+            "e2e",
+            warmups > 0,
+            Some(wire_bytes),
+        ),
+    );
+
+    report.real_conf = Some(format!("ws::addr={host}:{port};compression=raw;"));
+    report.http_base = Some(base);
+    report.compute_egress_headline();
+    println!("{}", report.into_json());
+    Ok(())
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}

--- a/questdb-rs/examples/qwp_ingress_polars.rs
+++ b/questdb-rs/examples/qwp_ingress_polars.rs
@@ -1,0 +1,453 @@
+//! Step 3 (QWP_DATAFRAME_BENCH_PLAN.md §6) — Rust **Polars ingress**
+//! parity for the S1 narrow schema.
+//!
+//! Measures `BorrowedSender::flush_polars_dataframe()` end-to-end on the
+//! shared S1 schema (the same 5 columns the pandas harness ingests), and
+//! separately the column-sender **encode floor**
+//! (`bench_encode_chunk_into`, the same path `benches/column_sender.rs`
+//! reports) on identical data, so the DataFrame→batches overhead is
+//! isolated. Emits the plan §3.2 JSON metric contract with
+//! `client="rust-polars"`, `direction="ingress"`, matching the field
+//! names the Python harness (`benchmark_pandas_columnar.py`) emits, so a
+//! Step 4 aggregator consumes Python + Rust JSON uniformly.
+//!
+//! S1 schema (5 cols): `ts` TIMESTAMP (designated), `id` LONG, `price`
+//! DOUBLE, `sym` SYMBOL (Polars Categorical, card 8), `note` VARCHAR
+//! (Utf8, len ~16). Table DDL:
+//! `TIMESTAMP(ts) PARTITION BY HOUR WAL DEDUP UPSERT KEYS(ts)`.
+//!
+//! Run against a QWP-schema-0x3 QuestDB with QWP/WS + HTTP on :9000:
+//!
+//! ```bash
+//! cargo +nightly run --release --example qwp_ingress_polars \
+//!     --features polars,sync-sender-qwp-ws,sync-sender-http
+//! ```
+//!
+//! (The crate's `polars` dep currently needs a nightly toolchain; the
+//! `polars` feature already pulls in `sync-sender-qwp-ws` + `sync-reader-ws`.)
+//!
+//! Env knobs (parity with the Rust column-sender suite / Python harness):
+//!   ROWS=10000000            headline row count (default 10M)
+//!   QUESTDB_COLUMN_BENCH_SYM_CARD=8        SYMBOL cardinality
+//!   QUESTDB_COLUMN_BENCH_VARCHAR_LEN=16    VARCHAR byte length
+//!   ITERATIONS=5  WARMUPS=2  MAX_BATCH_ROWS=10000  RUN_MODE=full
+//!   QDB_HOST=127.0.0.1  QDB_PORT=9000
+//!   SKIP_E2E=1               floor only (no server needed)
+
+use std::error::Error;
+use std::time::{Duration, Instant};
+
+use polars::prelude::{
+    CategoricalPhysical, Categories, DataFrame, DataType as PlDataType, IntoColumn, NamedFrom,
+    PlSmallStr, Series, TimeUnit,
+};
+use questdb::ingress::ColumnName;
+use questdb::ingress::column_sender::_bench_internals::{
+    BenchEncoderState, bench_encode_chunk_into,
+};
+use questdb::ingress::column_sender::{Chunk, QuestDb};
+use questdb::ingress::polars::PolarsIngestOptions;
+
+mod bench_json;
+use bench_json::{Env, PathSummary, Report};
+
+const TABLE: &str = "bench_s1_narrow";
+const SCHEMA: &str = "s1-narrow";
+const COLUMNS: usize = 5;
+/// µs spacing for the designated timestamp: QuestDB TIMESTAMP is
+/// µs-resolution, so ns-spaced rows collapse and DEDUP folds them
+/// (plan §3.4). 1 µs apart keeps every row distinct and unique.
+const TS_STEP_NANOS: i64 = 1_000;
+const TS_BASE_NANOS: i64 = 1_704_067_200_000_000_000;
+
+/// The S1 data, generated once as plain Rust vectors. Both the encode
+/// floor (via [`Chunk`]) and the polars e2e path (via [`DataFrame`])
+/// are built from the *same* buffers so the only delta is the
+/// DataFrame→Arrow→batch machinery.
+struct S1Data {
+    rows: usize,
+    ts_nanos: Vec<i64>,
+    id: Vec<i64>,
+    price: Vec<f64>,
+    /// SYMBOL codes into `sym_dict` (one per row).
+    sym_codes: Vec<i32>,
+    sym_offsets: Vec<i32>,
+    sym_bytes: Vec<u8>,
+    /// Per-row VARCHAR string values, plus the compact offset/byte form
+    /// the column sender wants.
+    note_values: Vec<String>,
+    note_offsets: Vec<i32>,
+    note_bytes: Vec<u8>,
+}
+
+fn build_s1(rows: usize, sym_card: usize, varchar_len: usize) -> S1Data {
+    let ts_nanos: Vec<i64> = (0..rows as i64)
+        .map(|i| TS_BASE_NANOS + i * TS_STEP_NANOS)
+        .collect();
+    let id: Vec<i64> = (0..rows as i64).collect();
+    let price: Vec<f64> = (0..rows).map(|i| i as f64 * 0.25).collect();
+
+    // SYMBOL dict: `sym_0000`..`sym_{card-1}`; codes cycle the dict.
+    let mut sym_offsets = Vec::with_capacity(sym_card + 1);
+    let mut sym_bytes = Vec::new();
+    sym_offsets.push(0i32);
+    for i in 0..sym_card {
+        sym_bytes.extend_from_slice(format!("sym_{i:04}").as_bytes());
+        sym_offsets.push(sym_bytes.len() as i32);
+    }
+    let sym_codes: Vec<i32> = (0..rows).map(|i| (i % sym_card) as i32).collect();
+
+    // VARCHAR notes: fixed ~varchar_len strings from a small rotating
+    // template pool (cardinality low so cost tracks length, not
+    // distinctness — mirrors the pandas `make_s1_narrow`).
+    let template_count = rows.clamp(1, 1024);
+    let templates: Vec<String> = (0..template_count)
+        .map(|i| {
+            let base = format!("note_{i:03}_").repeat(varchar_len);
+            base.chars().take(varchar_len).collect()
+        })
+        .collect();
+    let mut note_values = Vec::with_capacity(rows);
+    let mut note_offsets = Vec::with_capacity(rows + 1);
+    let mut note_bytes = Vec::new();
+    note_offsets.push(0i32);
+    for i in 0..rows {
+        let s = &templates[i % templates.len()];
+        note_values.push(s.clone());
+        note_bytes.extend_from_slice(s.as_bytes());
+        note_offsets.push(note_bytes.len() as i32);
+    }
+
+    S1Data {
+        rows,
+        ts_nanos,
+        id,
+        price,
+        sym_codes,
+        sym_offsets,
+        sym_bytes,
+        note_values,
+        note_offsets,
+        note_bytes,
+    }
+}
+
+/// Build the S1 polars [`DataFrame`] from the shared data. `sym` is a
+/// Polars `Categorical` (card 8) and `ts` a `Datetime(ns)`, matching the
+/// plan's S1 dtype table.
+fn build_s1_dataframe(data: &S1Data) -> Result<DataFrame, Box<dyn Error>> {
+    let ts = Series::new(PlSmallStr::from("ts"), &data.ts_nanos)
+        .cast(&PlDataType::Datetime(TimeUnit::Nanoseconds, None))?;
+    let id = Series::new(PlSmallStr::from("id"), &data.id);
+    let price = Series::new(PlSmallStr::from("price"), &data.price);
+
+    // Reconstruct per-row symbol strings, then cast to Categorical.
+    let sym_strings: Vec<&str> = data
+        .sym_codes
+        .iter()
+        .map(|&c| {
+            let start = data.sym_offsets[c as usize] as usize;
+            let end = data.sym_offsets[c as usize + 1] as usize;
+            std::str::from_utf8(&data.sym_bytes[start..end]).unwrap()
+        })
+        .collect();
+    let cats = Categories::new(
+        PlSmallStr::from("sym"),
+        PlSmallStr::from("bench"),
+        CategoricalPhysical::U32,
+    );
+    let mapping = cats.mapping();
+    let sym = Series::new(PlSmallStr::from("sym"), sym_strings)
+        .cast(&PlDataType::Categorical(cats, mapping))?;
+
+    let note_refs: Vec<&str> = data.note_values.iter().map(String::as_str).collect();
+    let note = Series::new(PlSmallStr::from("note"), note_refs);
+
+    Ok(DataFrame::new(
+        data.rows,
+        vec![
+            ts.into_column(),
+            id.into_column(),
+            price.into_column(),
+            sym.into_column(),
+            note.into_column(),
+        ],
+    )?)
+}
+
+/// Build the matching column-sender [`Chunk`] for the encode floor. Uses
+/// the same column set + designated timestamp as the e2e path, all
+/// borrowing the shared buffers (no copy of row data).
+fn build_s1_chunk<'a>(data: &'a S1Data) -> Result<Chunk<'a>, Box<dyn Error>> {
+    let mut chunk = Chunk::new(TABLE);
+    chunk.column_i64("id", &data.id, None)?;
+    chunk.column_f64("price", &data.price, None)?;
+    chunk.symbol_dict_i32(
+        "sym",
+        &data.sym_codes,
+        &data.sym_offsets,
+        &data.sym_bytes,
+        None,
+    )?;
+    chunk.column_varchar("note", &data.note_offsets, &data.note_bytes, None)?;
+    chunk.designated_timestamp_nanos(&data.ts_nanos)?;
+    Ok(chunk)
+}
+
+/// Wire size of one encoded S1 chunk — the `mib_per_s` denominator. This
+/// is the columnar QWP payload the sender pushes per frame for this
+/// schema; deterministic for a given chunk, so one encode suffices.
+fn encoded_wire_bytes(data: &S1Data) -> Result<u64, Box<dyn Error>> {
+    let chunk = build_s1_chunk(data)?;
+    let mut state = BenchEncoderState::new();
+    let mut out = Vec::with_capacity(64 * 1024);
+    bench_encode_chunk_into(&mut out, &chunk, &mut state)?;
+    Ok(out.len() as u64)
+}
+
+// ---------------------------------------------------------------------------
+// Timing
+// ---------------------------------------------------------------------------
+
+/// Wall + process-CPU nanoseconds for one invocation of `f`. Takes
+/// `&mut` so the same per-iteration closure can be re-driven in a loop.
+fn timed<T>(f: &mut impl FnMut() -> T) -> (u64, u64, T) {
+    let cpu0 = bench_json::process_cpu_ns();
+    let t0 = Instant::now();
+    let out = f();
+    let wall = t0.elapsed().as_nanos() as u64;
+    let cpu = bench_json::process_cpu_ns().saturating_sub(cpu0);
+    (wall, cpu, out)
+}
+
+/// Encode floor: time `bench_encode_chunk_into` on the prebuilt S1
+/// chunk. Reuses the encoder state across iterations (a warm
+/// connection's steady state), exactly as `benches/column_sender.rs`'s
+/// `encode_only` arm does.
+fn measure_encode_floor(
+    data: &S1Data,
+    iterations: usize,
+    warmups: usize,
+) -> Result<(Vec<u64>, Vec<u64>), Box<dyn Error>> {
+    let chunk = build_s1_chunk(data)?;
+    let mut state = BenchEncoderState::new();
+    let mut out = Vec::with_capacity(64 * 1024);
+    let mut run = || -> Result<(), Box<dyn Error>> {
+        out.clear();
+        bench_encode_chunk_into(&mut out, &chunk, &mut state)?;
+        std::hint::black_box(&out);
+        Ok(())
+    };
+    for _ in 0..warmups {
+        run()?;
+    }
+    let mut wall = Vec::with_capacity(iterations);
+    let mut cpu = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let (w, c, r) = timed(&mut run);
+        r?;
+        wall.push(w);
+        cpu.push(c);
+    }
+    Ok((wall, cpu))
+}
+
+/// e2e: time `flush_polars_dataframe()` against the real server. Each
+/// iteration re-flushes the whole frame (DEDUP UPSERT KEYS(ts) folds the
+/// repeats, so `count() == rows` holds regardless of iteration count).
+fn measure_e2e(
+    db: &QuestDb,
+    df: &DataFrame,
+    opts: &PolarsIngestOptions<'_>,
+    iterations: usize,
+    warmups: usize,
+) -> Result<(Vec<u64>, Vec<u64>), Box<dyn Error>> {
+    let mut run = || -> Result<(), Box<dyn Error>> {
+        let mut sender = db.borrow_sender()?;
+        sender.flush_polars_dataframe(TABLE, df, opts)?;
+        Ok(())
+    };
+    for _ in 0..warmups {
+        run()?;
+    }
+    let mut wall = Vec::with_capacity(iterations);
+    let mut cpu = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let (w, c, r) = timed(&mut run);
+        r?;
+        wall.push(w);
+        cpu.push(c);
+    }
+    Ok((wall, cpu))
+}
+
+// ---------------------------------------------------------------------------
+// HTTP/SQL helpers (DEDUP table + WAL-aware count gate, plan §3.4)
+// ---------------------------------------------------------------------------
+
+fn http_base(host: &str, port: u16) -> String {
+    format!("http://{host}:{port}")
+}
+
+fn exec_sql(base: &str, sql: &str) -> Result<(), Box<dyn Error>> {
+    let url = format!("{base}/exec");
+    let resp = ureq::get(&url).query("query", sql).call()?;
+    if resp.status() != 200 {
+        return Err(format!("/exec {sql} -> HTTP {}", resp.status()).into());
+    }
+    Ok(())
+}
+
+fn create_table(base: &str) -> Result<(), Box<dyn Error>> {
+    exec_sql(base, &format!("DROP TABLE IF EXISTS {TABLE}"))?;
+    exec_sql(
+        base,
+        &format!(
+            "CREATE TABLE {TABLE} (\
+                ts TIMESTAMP, id LONG, price DOUBLE, sym SYMBOL, note VARCHAR\
+            ) TIMESTAMP(ts) PARTITION BY HOUR WAL DEDUP UPSERT KEYS(ts)"
+        ),
+    )?;
+    Ok(())
+}
+
+/// Poll `SELECT count()` until it reaches `expected` (WAL tables apply
+/// asynchronously). Returns the final observed count. A value above
+/// `expected` signals at-least-once DEDUP inflation (a failure).
+fn wait_for_count(base: &str, expected: u64) -> Result<u64, Box<dyn Error>> {
+    let url = format!("{base}/exec");
+    let sql = format!("SELECT count() FROM {TABLE}");
+    let deadline = Instant::now() + Duration::from_secs(300);
+    let mut last = 0u64;
+    while Instant::now() < deadline {
+        let mut resp = ureq::get(&url).query("query", &sql).call()?;
+        let body: String = resp.body_mut().read_to_string()?;
+        if let Some(idx) = body.rfind("\"dataset\":[[") {
+            let tail = &body[idx + "\"dataset\":[[".len()..];
+            if let Some(end) = tail.find(']')
+                && let Ok(n) = tail[..end].parse::<u64>()
+            {
+                last = n;
+                if n >= expected {
+                    return Ok(n);
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+    Ok(last)
+}
+
+// ---------------------------------------------------------------------------
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let rows: usize = env_usize("ROWS", 10_000_000);
+    let sym_card: usize = env_usize("QUESTDB_COLUMN_BENCH_SYM_CARD", 8);
+    let varchar_len: usize = env_usize("QUESTDB_COLUMN_BENCH_VARCHAR_LEN", 16);
+    let iterations: usize = env_usize("ITERATIONS", 5);
+    let warmups: usize = env_usize("WARMUPS", 2);
+    let max_batch_rows: usize = env_usize("MAX_BATCH_ROWS", 10_000);
+    let run_mode = std::env::var("RUN_MODE").unwrap_or_else(|_| "full".into());
+    let host = std::env::var("QDB_HOST").unwrap_or_else(|_| "127.0.0.1".into());
+    let port: u16 = env_usize("QDB_PORT", 9000) as u16;
+    let skip_e2e = std::env::var("SKIP_E2E").is_ok();
+
+    eprintln!(
+        "[qwp_ingress_polars] schema={SCHEMA} rows={rows} sym_card={sym_card} \
+         varchar_len={varchar_len} iterations={iterations} warmups={warmups} \
+         max_batch_rows={max_batch_rows}"
+    );
+
+    let data = build_s1(rows, sym_card, varchar_len);
+    let wire_bytes = encoded_wire_bytes(&data)?;
+    eprintln!("[qwp_ingress_polars] encoded S1 wire bytes/flush = {wire_bytes}");
+
+    let mut report = Report::new(SCHEMA, rows, COLUMNS, "ingress", "rust-polars", &run_mode);
+    report.warmups = warmups;
+    report.wire_bytes = wire_bytes;
+    report.env = Env::collect(&[]);
+
+    // --- Encode floor (no network). ---
+    eprintln!("[qwp_ingress_polars] measuring encode floor ...");
+    let (floor_wall, floor_cpu) = measure_encode_floor(&data, iterations, warmups)?;
+    report.add_path(
+        "encode-floor",
+        PathSummary::new(
+            &floor_wall,
+            &floor_cpu,
+            rows,
+            COLUMNS,
+            "floor",
+            warmups > 0,
+            Some(wire_bytes),
+        ),
+    );
+
+    // --- e2e flush_polars_dataframe (real server). ---
+    if !skip_e2e {
+        let base = http_base(&host, port);
+        eprintln!("[qwp_ingress_polars] creating DEDUP table on {base} ...");
+        create_table(&base)?;
+
+        let df = build_s1_dataframe(&data)?;
+        eprintln!(
+            "[qwp_ingress_polars] DataFrame shape={:?} schema={:?}",
+            df.shape(),
+            df.schema()
+        );
+
+        let conf = format!("qwpws::addr={host}:{port};pool_size=1;pool_max=1;pool_reap=manual;");
+        let db = QuestDb::connect(&conf)?;
+        let ts_col = ColumnName::new("ts")?;
+        let opts = PolarsIngestOptions::new()
+            .max_rows(max_batch_rows)
+            .timestamp_column(ts_col);
+
+        eprintln!("[qwp_ingress_polars] measuring flush_polars_dataframe e2e ...");
+        let (e2e_wall, e2e_cpu) = measure_e2e(&db, &df, &opts, iterations, warmups)?;
+        report.add_path(
+            "flush-polars-dataframe",
+            PathSummary::new(
+                &e2e_wall,
+                &e2e_cpu,
+                rows,
+                COLUMNS,
+                "e2e",
+                warmups > 0,
+                Some(wire_bytes),
+            ),
+        );
+
+        // DEDUP gate: count() must equal rows exactly (plan §3.4).
+        eprintln!("[qwp_ingress_polars] waiting for WAL apply (count() == {rows}) ...");
+        let count = wait_for_count(&base, rows as u64)?;
+        report.row_count_check = Some(bench_json::RowCountCheck {
+            expected: rows as u64,
+            actual: count,
+            ok: count == rows as u64,
+            inflated: count > rows as u64,
+        });
+        if count != rows as u64 {
+            eprintln!(
+                "[qwp_ingress_polars] WARNING: count() == {count}, expected {rows} \
+                 (inflated={})",
+                count > rows as u64
+            );
+        }
+        report.real_conf = Some(conf);
+        report.http_base = Some(base);
+    } else {
+        eprintln!("[qwp_ingress_polars] SKIP_E2E set — floor only");
+    }
+
+    report.compute_ingress_headline();
+    println!("{}", report.into_json());
+    Ok(())
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}

--- a/questdb-rs/src/egress/arrow/polars.rs
+++ b/questdb-rs/src/egress/arrow/polars.rs
@@ -316,4 +316,36 @@ mod tests {
         assert_eq!(df.height(), 0);
         assert_eq!(df.width(), 1);
     }
+
+    /// Every QuestDB table carries a designated TIMESTAMP, which the
+    /// egress decoder maps to the tz-aware Arrow `Timestamp(Microsecond,
+    /// Some("UTC"))`. Materialising that into a polars `DataFrame`
+    /// requires the `dtype-datetime` + `timezones` polars features; this
+    /// test guards that feature set (without them `Series::from_arrow`
+    /// fails at runtime, which `fetch_all_polars` on any real result set
+    /// would hit). See the `polars` feature in `Cargo.toml`.
+    #[test]
+    fn record_batch_to_dataframe_preserves_tz_timestamp() {
+        use arrow_array::TimestampMicrosecondArray;
+        let ts: ArrayRef = Arc::new(
+            TimestampMicrosecondArray::from(vec![1_700_000_000_000_000i64, 1_700_000_000_000_001])
+                .with_timezone("UTC"),
+        );
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "ts",
+            ts.data_type().clone(),
+            false,
+        )]));
+        let rb = RecordBatch::try_new(schema, vec![ts]).unwrap();
+        let df = record_batch_to_dataframe(rb).unwrap();
+        assert_eq!(df.height(), 2);
+        assert_eq!(df.width(), 1);
+        // The column must round-trip as a polars Datetime, not error out.
+        let series = df.columns()[0].as_materialized_series();
+        assert!(
+            matches!(series.dtype(), polars::prelude::DataType::Datetime(_, _)),
+            "expected polars Datetime, got {:?}",
+            series.dtype()
+        );
+    }
 }

--- a/questdb-rs/src/egress/mod.rs
+++ b/questdb-rs/src/egress/mod.rs
@@ -111,4 +111,38 @@ pub mod _bench_internals {
     pub use crate::egress::schema::Schema;
     pub use crate::egress::symbol_dict::SymbolDict;
     pub use bytes::Bytes;
+
+    /// Assemble an already-decoded [`DecodedBatch`] into an
+    /// `arrow_array::RecordBatch`, mirroring the in-crate
+    /// `Cursor::next_arrow_batch` assembly path (`batch_arrow_schema` +
+    /// `batch_to_record_batch`) so a server-free decode→assemble
+    /// benchmark can isolate the column-build cost on top of the raw
+    /// decode. The egress `schema` and `dict` are the ones
+    /// [`decode_result_batch`] populated for the same payload.
+    #[cfg(feature = "arrow")]
+    pub fn bench_batch_to_record_batch(
+        schema: &Schema,
+        batch: DecodedBatch,
+        dict: &SymbolDict,
+    ) -> crate::egress::error::Result<arrow_array::RecordBatch> {
+        use std::sync::Arc;
+        let arrow_schema = Arc::new(crate::egress::arrow::batch_arrow_schema(schema, &batch)?);
+        crate::egress::arrow::batch_to_record_batch(arrow_schema, schema, batch, dict)
+    }
+
+    /// Full decode→assemble→polars path for the `→ polars DataFrame`
+    /// decoder bench arm: assemble the decoded batch into a
+    /// `RecordBatch` (see [`bench_batch_to_record_batch`]) and hand it
+    /// to polars via the Arrow C Data Interface
+    /// (`record_batch_to_dataframe`). This is the honest
+    /// `decode_plus_assemble`-to-DataFrame microbench with no network.
+    #[cfg(feature = "polars")]
+    pub fn bench_batch_to_polars(
+        schema: &Schema,
+        batch: DecodedBatch,
+        dict: &SymbolDict,
+    ) -> crate::egress::error::Result<polars::frame::DataFrame> {
+        let rb = bench_batch_to_record_batch(schema, batch, dict)?;
+        crate::egress::arrow::polars::record_batch_to_dataframe(rb)
+    }
 }


### PR DESCRIPTION
## What

Adds the QWP DataFrame benchmark plan and the Rust (Polars) side of it.

**Plan** — `doc/QWP_DATAFRAME_BENCH_PLAN.md`: a narrow-v1 benchmark plan for the QWP DataFrame paths (pandas in py-questdb-client, Polars here), both ingress and egress. Realises `COLUMN_SENDER_PLAN.md` WS-6/WS-7; methodology from `COLUMN_SENDER_PERF.md`. One shared `S1` schema + JSON metric contract so Python and Rust numbers are comparable.

**Step 3 — Rust Polars S1 parity** (`15023af`):
- `questdb-rs/examples/qwp_ingress_polars.rs` — `flush_polars_dataframe()` e2e + encode floor on S1, DEDUP `count()` gate, JSON contract (`client=rust-polars`).
- `questdb-rs/examples/qwp_egress_polars.rs` — `fetch_all_polars` (headline) + decode-only floor + `iter_polars`/`next_polars`, honest `decode_plus_assemble`.
- `benches/decoder.rs` — server-free S1 `→ polars` arms (existing 15-col arm unchanged).
- `examples/bench_json/` — shared JSON-contract emitter matching the Python field names.

## Product fix (not just bench code)
The `polars` feature only enabled `dtype-categorical`, so egress `Series::from_arrow` could not build a Series from the tz-aware `Timestamp(µs, UTC)` the decoder emits for **every** table's designated TIMESTAMP — `fetch_all_polars` would fail at runtime on any real result. Added `dtype-datetime`/`dtype-date`/`timezones` + a regression test. `Cargo.lock` unchanged; `--locked` build verified.

## Numbers (S1, 10M rows, single-stream, Apple-Silicon loopback; QuestDB 9.4.3 OSS @ 85aecd600b)
- Ingress: `flush_polars_dataframe` 15.6M rows/s @ 670 MiB/s; encode floor 447M rows/s; DEDUP `count()==10M`.
- Egress: `fetch_all_polars` 37.6M rows/s; decode-only floor 68.4M rows/s; `iter_polars` 36.6M.

## Verified
`cargo fmt` clean; `cargo clippy --tests --examples` clean for new code; 22 polars lib tests pass; stable default build + existing non-polars benches unaffected.

## Notes
- The polars examples require the **nightly** toolchain (pinned polars 0.54.4 needs `strict_overflow_ops`).
- Live verification used a QWP-schema-0x3 QuestDB; the older public build lacks it.

Base branch is `jh_conn_pool_refactor` (the QWP feature branch this was built on), per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVkG2Hrju3VngFZgcVGRzZ
