### PR TITLE
chore:  java-parity pool startup, eager by default, lazy_connect opt-in

### DIFF
--- a/cpp_test/smoke_reader.c
+++ b/cpp_test/smoke_reader.c
@@ -87,12 +87,18 @@ static int closed_port_phase(void)
  * <questdb/egress/qwp_reader.h> and the client-wide `questdb_error` type.
  *
  * Targets the same guaranteed-closed 127.0.0.1:1 port via a `ws::`
- * connect string. The pool is lazy: `questdb_db_connect` opens no
- * socket, so the connect itself succeeds and the connect failure surfaces
+ * connect string with `lazy_connect=true`, so `questdb_db_connect` opens
+ * no socket, the connect itself succeeds, and the connect failure surfaces
  * on the first `questdb_db_borrow_reader` — reported as a `questdb_error*`.
  * Also exercises the NULL-idempotent `questdb_db_close` path.
  */
-static int pool_reader_only_phase(void)
+/*
+ * Eager-default pool phase (always runs): the inverse of the lazy phase
+ * below. Without `lazy_connect=true`, `questdb_db_connect` pre-opens the
+ * warm minimums and must fail fast against the guaranteed-closed port,
+ * returning NULL with a populated `questdb_error*`.
+ */
+static int pool_eager_connect_fails_phase(void)
 {
     static const char conf[] = "ws::addr=127.0.0.1:1;";
 
@@ -100,9 +106,38 @@ static int pool_reader_only_phase(void)
     struct questdb_db* db =
         questdb_db_connect(conf, strlen(conf), &err);
 
+    if (db != NULL)
+    {
+        fprintf(
+            stderr,
+            "smoke pool: eager questdb_db_connect unexpectedly succeeded "
+            "against a closed port\n");
+        questdb_db_close(db);
+        return 1;
+    }
+    if (err == NULL)
+    {
+        fprintf(
+            stderr,
+            "smoke pool: eager connect failed without populating "
+            "err_out\n");
+        return 1;
+    }
+    questdb_error_free(err);
+    return 0;
+}
+
+static int pool_reader_only_phase(void)
+{
+    static const char conf[] = "ws::addr=127.0.0.1:1;lazy_connect=true;";
+
+    questdb_error* err = NULL;
+    struct questdb_db* db =
+        questdb_db_connect(conf, strlen(conf), &err);
+
     /*
-     * Lazy pool: connect opens nothing, so it succeeds even against a
-     * guaranteed-closed port.
+     * lazy_connect pool: connect opens nothing, so it succeeds even
+     * against a guaranteed-closed port.
      */
     if (db == NULL)
     {
@@ -353,6 +388,10 @@ cleanup:
 int main(void)
 {
     int rc = closed_port_phase();
+    if (rc != 0)
+        return rc;
+
+    rc = pool_eager_connect_fails_phase();
     if (rc != 0)
         return rc;
 

--- a/cpp_test/test_arrow_c.c
+++ b/cpp_test/test_arrow_c.c
@@ -1049,7 +1049,7 @@ static qwp_sender* mock_borrow_sender_frames(
     char conf[256];
     snprintf(
         conf, sizeof(conf),
-        "ws::addr=%s;sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;",
+        "ws::addr=%s;lazy_connect=true;sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;",
         addr);
     line_sender_error* err = NULL;
     questdb_db* db = questdb_db_connect(conf, strlen(conf), &err);

--- a/cpp_test/test_arrow_ingress.cpp
+++ b/cpp_test/test_arrow_ingress.cpp
@@ -168,7 +168,7 @@ struct MockConn
         : server(std::vector<qm::Script>{std::move(script)})
     {
         const std::string conf = "ws::addr=" + server.addr() +
-            ";sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;";
+            ";lazy_connect=true;sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;";
         line_sender_error* err = nullptr;
         db = questdb_db_connect(conf.c_str(), conf.size(), &err);
         REQUIRE(db != nullptr);
@@ -267,7 +267,7 @@ TEST_CASE("borrowed_sender exposes Arrow FSN helper")
         qm::Script{qm::ActionAwaitClientFrame{0x51}}});
     questdb::pool db{
         "ws::addr=" + server.addr() +
-        ";sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;"};
+        ";lazy_connect=true;sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;"};
     auto conn = db.borrow_sender();
 
     auto col = pack_le<int64_t>({10, 20, 30});
@@ -321,7 +321,7 @@ TEST_CASE("borrowed_sender exposes Arrow ACKing helpers")
         qm::ActionSendRaw{qm::ingress_ok_frame(1)}}});
     questdb::pool db{
         "ws::addr=" + server.addr() +
-        ";sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;"};
+        ";lazy_connect=true;sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;"};
     auto conn = db.borrow_sender();
 
     auto col = pack_le<int64_t>({10, 20, 30});

--- a/cpp_test/test_column_sender.cpp
+++ b/cpp_test/test_column_sender.cpp
@@ -58,7 +58,7 @@ std::unique_ptr<qm::MockServer> spawn_acking_mock(int slot_count)
 std::string conf_for(const std::string& addr, const std::string& extras = {})
 {
     return "ws::addr=" + addr +
-           ";sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;" +
+           ";lazy_connect=true;sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;" +
            extras;
 }
 

--- a/cpp_test/test_reader_mock.cpp
+++ b/cpp_test/test_reader_mock.cpp
@@ -4492,9 +4492,10 @@ TEST_CASE("mock: column::visit dispatches DOUBLE_ARRAY to array_view<double>")
 // hands out query readers as well as senders; a borrowed reader returns to
 // the pool on destruction unless `drop_on_return()` was called.
 //
-// The pool is lazy: construction opens no connections (mirroring the Rust
-// `reader_pool_*` tests, which assert `server.accepted() == 0` right after
-// `connect`), so reader borrows consume scripts from index 0. The reader
+// The pool sets `lazy_connect=true` so construction opens no connections
+// (mirroring the Rust `reader_pool_*` tests, which assert
+// `server.accepted() == 0` right after `connect`) and reader borrows consume
+// scripts from index 0. The reader
 // connection sends SERVER_INFO at connect, then parks on the query request
 // that never arrives.
 // ---------------------------------------------------------------------------
@@ -4511,7 +4512,8 @@ qm::Script reader_park_script(uint8_t role = qm::ROLE_PRIMARY)
 
 std::string pool_conf(const std::string& addr)
 {
-    return "ws::addr=" + addr + ";sender_pool_min=1;pool_reap=manual;";
+    return "ws::addr=" + addr +
+           ";lazy_connect=true;sender_pool_min=1;pool_reap=manual;";
 }
 } // namespace
 

--- a/examples/qwp_ingress_c.c
+++ b/examples/qwp_ingress_c.c
@@ -119,7 +119,9 @@ int main(void)
     char base[256], conf[256];
     snprintf(base, sizeof(base), "http://%s:%zu", host, port);
     snprintf(conf, sizeof(conf),
-             "ws::addr=%s:%zu;sender_pool_min=1;sender_pool_max=1;pool_reap=manual;",
+             "ws::addr=%s:%zu;sender_pool_min=1;sender_pool_max=1;pool_reap=manual;"
+             /* ingestion-only: skip the eager reader pre-open */
+             "query_pool_min=0;",
              host, port);
 
     long long count = -1;

--- a/include/questdb/client.h
+++ b/include/questdb/client.h
@@ -67,19 +67,29 @@ typedef struct questdb_db questdb_db;
  * ------------------------------------------------------------------------- */
 
 /**
- * Open a connection pool. This call performs no blocking network I/O. In
- * disk-backed store-and-forward mode it may pre-open parked recovery senders;
- * their initial connect and replay run in the background. Otherwise, the first
- * borrow opens a sender, so auth / TLS / connect errors usually surface from
- * the borrow, not from here. `sender_pool_min` (default 1) is the warm
- * minimum the reaper keeps once connections have been opened.
+ * Open a connection pool. By default this connects eagerly: it pre-opens the
+ * warm minimums (`sender_pool_min` senders, `query_pool_min` readers),
+ * honoring `initial_connect_retry` for the senders (readers always connect
+ * fail-fast), so auth / TLS / connect errors surface from this call.
+ * With `lazy_connect=true` it performs no blocking network
+ * I/O: senders buffer locally and connect in the background, readers
+ * (`query_pool_min` defaults to 0) connect on first borrow, and errors
+ * surface there instead. In disk-backed store-and-forward mode either
+ * variant may pre-open parked recovery senders; their initial connect and
+ * replay run in the background. `sender_pool_min` (default 1) is the warm
+ * minimum the reaper keeps.
  *
  * `conf` is a `ws::` / `wss::` connect string. Pool-specific keys (aligned
  * with the Java client's `QuestDBBuilder`):
- *   `sender_pool_min`      (default 1)    warm/min sender connections;
+ *   `sender_pool_min`      (default 1)    warm/min sender connections,
+ *                                         pre-opened at connect unless
+ *                                         `lazy_connect=true`;
  *   `sender_pool_max`      (default 4)    cap on the ingestion and direct
  *                                         pools, each capped independently;
- *   `query_pool_min`       (default 1)    warm/min reader connections;
+ *   `query_pool_min`       (default 1; 0 when lazy)
+ *                                         warm/min reader connections,
+ *                                         pre-opened at connect unless
+ *                                         `lazy_connect=true`;
  *   `query_pool_max`       (default 4)    cap on the reader pool;
  *   `acquire_timeout_ms`   (default 5000) how long a borrow at cap waits for
  *                                         a return before failing; 0 fails
@@ -88,7 +98,13 @@ typedef struct questdb_db questdb_db;
  *                                         reap above-minimum idle
  *                                         connections;
  *   `pool_reap`            (`auto`|`manual`, default `auto`)
- *                                         background reaper opt-in.
+ *                                         background reaper opt-in;
+ *   `lazy_connect`         (default false)
+ *                                         tolerate a down server at startup:
+ *                                         connect opens nothing, senders
+ *                                         buffer and connect in the
+ *                                         background, readers connect on
+ *                                         first borrow.
  *
  * Disk-backed store-and-forward is opt-in: `sf_dir` selects disk-backed queues
  * for the public ingestion pool. `sender_id` names the slot *base* (default

--- a/include/questdb/client.hpp
+++ b/include/questdb/client.hpp
@@ -71,10 +71,15 @@ namespace questdb
  * Those `<sender_id>-ingest-*` directories under `sf_dir` belong to the pool namespace;
  * use a unique `sender_id` for each pool sharing an `sf_dir`.
  *
- * Construction performs no blocking network I/O. In disk-backed
- * store-and-forward mode it may pre-open parked recovery senders whose initial
- * connect and replay run in the background; otherwise senders are opened on
- * first borrow.
+ * Construction connects eagerly by default: it pre-opens the warm minimums
+ * (`sender_pool_min` senders, `query_pool_min` readers), honoring
+ * `initial_connect_retry` for the senders (readers always connect
+ * fail-fast), so connect errors throw from the constructor.
+ * With `lazy_connect=true` it performs no blocking network I/O: senders
+ * buffer locally and connect in the background, and readers connect on
+ * first borrow. In disk-backed store-and-forward mode either variant may
+ * pre-open parked recovery senders whose initial connect and replay run in
+ * the background.
  *
  * Borrow/return operations are thread-safe while this owner remains alive.
  * Destruction is the final owner release: do not destroy the pool while
@@ -143,8 +148,9 @@ public:
      * Borrow a query reader from the pool, mirroring Rust
      * `QuestDb::borrow_reader`. Readers are pooled on a separate,
      * independently-capped free list with its own `query_pool_min` /
-     * `query_pool_max` budget; the reader pool is lazy (a
-     * connection opens on first borrow). The returned `reader` is
+     * `query_pool_max` budget; `query_pool_min` readers are pre-opened at
+     * construction (none under `lazy_connect=true`, where a connection
+     * opens on first borrow). The returned `reader` is
      * equivalent to a standalone one and returns itself to the pool on
      * destruction — unless `reader::drop_on_return()` was called, in which
      * case it is dropped. If the pool has already been closed by the time the

--- a/questdb-rs-ffi/src/column_sender.rs
+++ b/questdb-rs-ffi/src/column_sender.rs
@@ -855,10 +855,13 @@ unsafe fn typed_bytes_slice<'a>(
 // Pool
 // ===========================================================================
 
-/// Open a connection pool. The pool is lazy: this call parses and validates
-/// the connect string but opens no connections; the first borrow opens one,
-/// so server/auth/TLS errors surface from the borrow, not from here. `conf`
-/// is a UTF-8 string of `conf_len` bytes.
+/// Open a connection pool. By default this connects eagerly: it pre-opens
+/// the warm minimums (`sender_pool_min` senders, `query_pool_min` readers),
+/// honoring `initial_connect_retry` for the senders (readers always connect
+/// fail-fast), so server/auth/TLS errors surface from this call. With
+/// `lazy_connect=true` it opens no connections; senders buffer locally and
+/// connect in the background, readers connect on first borrow, and errors
+/// surface there instead. `conf` is a UTF-8 string of `conf_len` bytes.
 ///
 /// Returns NULL on failure. When `err_out != NULL`, the error is placed
 /// in `*err_out` and ownership transfers to the caller (release with
@@ -5079,7 +5082,8 @@ mod tests {
             listener.local_addr().expect("local_addr").port()
         };
         let conf = format!(
-            "ws::addr=127.0.0.1:{port};auth_timeout=2000;reconnect_max_duration_millis=1000;"
+            "ws::addr=127.0.0.1:{port};auth_timeout=2000;reconnect_max_duration_millis=1000;\
+             lazy_connect=true;"
         );
         let mut err: *mut line_sender_error = std::ptr::null_mut();
         let db =

--- a/questdb-rs-ffi/src/egress.rs
+++ b/questdb-rs-ffi/src/egress.rs
@@ -3549,10 +3549,11 @@ use crate::column_sender::questdb_db;
 /// Reader connections are pooled separately from writer connections
 /// with their own `query_pool_min` / `query_pool_max` budget
 /// (senders use `sender_pool_min` / `sender_pool_max`; both pools
-/// share `acquire_timeout_ms` and `idle_timeout_ms`). The reader pool is lazy: a
-/// connection is opened on first borrow, not at `questdb_db_connect`
-/// time, so callers that never use egress don't pay any handshake
-/// cost.
+/// share `acquire_timeout_ms` and `idle_timeout_ms`). `query_pool_min`
+/// readers are pre-opened at `questdb_db_connect` time by default; with
+/// `lazy_connect=true` the reader pool is lazy (`query_pool_min` defaults
+/// to 0, a connection opens on first borrow), so callers that never use
+/// egress pay no handshake cost.
 ///
 /// The returned `qwp_reader*` is equivalent to one constructed via
 /// `qwp_reader_from_conf`: cursor lifecycle, stat getters, and

--- a/questdb-rs-ffi/src/lib.rs
+++ b/questdb-rs-ffi/src/lib.rs
@@ -5402,8 +5402,11 @@ mod tests {
         }
 
         fn conf(&self) -> String {
+            // lazy_connect: these tests exercise the store-and-forward borrow
+            // model (buffer locally, background connect), not eager startup.
             format!(
-                "ws::addr=127.0.0.1:{};sender_pool_min=1;sender_pool_max=2;close_flush_timeout_millis=50;",
+                "ws::addr=127.0.0.1:{};sender_pool_min=1;sender_pool_max=2;\
+                 close_flush_timeout_millis=50;lazy_connect=true;",
                 self.port
             )
         }

--- a/questdb-rs/examples/qwp_ingress_polars.rs
+++ b/questdb-rs/examples/qwp_ingress_polars.rs
@@ -505,8 +505,11 @@ fn main() -> Result<(), Box<dyn Error>> {
             df.schema()
         );
 
-        let conf =
-            format!("ws::addr={host}:{port};sender_pool_min=1;sender_pool_max=1;pool_reap=manual;");
+        let conf = format!(
+            // ingestion-only: skip the eager reader pre-open
+            "ws::addr={host}:{port};sender_pool_min=1;sender_pool_max=1;\
+             pool_reap=manual;query_pool_min=0;"
+        );
         let dbs: Vec<QuestDb> = (0..senders_n)
             .map(|_| QuestDb::connect(&conf))
             .collect::<Result<_, _>>()?;

--- a/questdb-rs/src/db.rs
+++ b/questdb-rs/src/db.rs
@@ -637,7 +637,7 @@ fn preopen_recovery_sender(
         }
     };
 
-    match connect_sfa_pool_with_recovery_candidates(inner, Some(index), recovery_candidates) {
+    match connect_sfa_pool_with_recovery_candidates(inner, Some(index), recovery_candidates, true) {
         Ok(sender) => {
             let slot_index = slot.slot_index;
             {
@@ -701,7 +701,12 @@ impl QuestDb {
     /// senders whose initial connect and replay run in the background. The
     /// store-and-forward ingestion pool creates a local producer on first borrow
     /// and starts its initial connect in the background, so the borrower can
-    /// buffer immediately even while the server is absent. Direct senders and
+    /// buffer immediately even while the server is absent. An explicit
+    /// `initial_connect_retry` mode changes that for borrows: `off` connects
+    /// synchronously at borrow time and fails fast, `sync` retries within the
+    /// reconnect budget before the borrow returns. The `sync` promoted from
+    /// merely setting a `reconnect_*` key does not apply to pool borrows, and
+    /// recovery pre-opens always connect in the background. Direct senders and
     /// readers still open their transport on first borrow. `sender_pool_min` /
     /// `query_pool_min` are the warm minimums the reaper keeps once entries
     /// have been opened.
@@ -899,6 +904,12 @@ impl QuestDb {
     /// releases its lock; failing that, wait up to `acquire_timeout_ms` for a
     /// return (`acquire_timeout_ms=0` fails fast); failing that, return
     /// `InvalidApiCall`.
+    ///
+    /// A borrow that opens a new connection starts it in the background by
+    /// default, so it succeeds even while the server is away. An explicit
+    /// `initial_connect_retry` mode overrides that: `off` connects
+    /// synchronously and fails fast, `sync` retries within the reconnect
+    /// budget before returning; see [`Self::connect`].
     pub fn borrow_sender(&self) -> Result<BorrowedSender<'_>> {
         let cs = self.pick_sender()?;
         Ok(BorrowedSender(SenderHandle::new(self, cs)))
@@ -2647,13 +2658,14 @@ fn pick_direct_sender(inner: &Arc<DbInner>) -> Result<PooledSender<DirectSenderC
 
 fn connect_sfa_pool(inner: &Arc<DbInner>, slot_index: Option<usize>) -> Result<PooledSenderCore> {
     let recovery_candidates = managed_slot_recovery_candidates(inner);
-    connect_sfa_pool_with_recovery_candidates(inner, slot_index, &recovery_candidates)
+    connect_sfa_pool_with_recovery_candidates(inner, slot_index, &recovery_candidates, false)
 }
 
 fn connect_sfa_pool_with_recovery_candidates(
     inner: &Arc<DbInner>,
     slot_index: Option<usize>,
     recovery_candidates: &[PathBuf],
+    force_async_initial_connect: bool,
 ) -> Result<PooledSenderCore> {
     let sender_id = slot_index.map(|index| managed_slot_id(&inner.slot_base_id, index));
     let state = inner
@@ -2664,6 +2676,7 @@ fn connect_sfa_pool_with_recovery_candidates(
             recovery_candidates,
             Arc::clone(&inner.conn_events),
             Arc::clone(&inner.rejections),
+            force_async_initial_connect,
         )
         .map_err(|err| {
             crate::Error::new(

--- a/questdb-rs/src/db.rs
+++ b/questdb-rs/src/db.rs
@@ -25,13 +25,19 @@
 //! QWP ingestion connection pool.
 //!
 //! `QuestDb` is a thread-safe pool of store-and-forward producer handles to a
-//! single QuestDB QWP/WebSocket endpoint. The pool is lazy: `connect` performs
-//! no blocking network I/O. In disk-backed store-and-forward mode it may
-//! pre-open parked recovery senders whose initial connect and replay run in the
-//! background. Borrowing [`QuestDb::borrow_sender`] creates a local
-//! store-and-forward producer immediately and lets its background runner connect
-//! later, so callers can buffer while the server is absent. Direct ingestion
-//! senders and readers still open their transport on first borrow.
+//! single QuestDB QWP/WebSocket endpoint. By default (Java parity) `connect`
+//! is eager: it pre-opens the warm minimums (`sender_pool_min`,
+//! `query_pool_min`), honoring `initial_connect_retry` for the ingest
+//! senders (readers always connect fail-fast), so a down server fails the
+//! constructor fast. With `lazy_connect=true` the pool tolerates a down
+//! server at startup: `connect` performs no blocking network I/O,
+//! `query_pool_min` defaults to 0, and borrowing
+//! [`QuestDb::borrow_sender`] creates a local store-and-forward producer
+//! immediately whose background runner connects later, so callers can buffer
+//! while the server is absent. In disk-backed store-and-forward mode either
+//! variant may pre-open parked recovery senders whose initial connect and
+//! replay run in the background. Direct ingestion senders open their
+//! transport on first borrow.
 //! The pools auto-grow up to their configured caps (`sender_pool_max` /
 //! `query_pool_max`) on demand and (under `pool_reap=auto`)
 //! run a background thread that closes above-minimum idle entries after
@@ -256,6 +262,11 @@ struct DbInner {
     /// Warm minimum the reaper preserves in the store-and-forward
     /// ingestion pool.
     sender_pool_min: usize,
+    /// `lazy_connect=true`: tolerate a down server at startup. No warm-minimum
+    /// pre-connect, and ingest borrows force the background initial connect.
+    /// Off by default (Java parity): `connect()` pre-opens the warm minimums
+    /// and borrows honor `initial_connect_retry`.
+    lazy_connect: bool,
     /// Hard cap on the store-and-forward ingestion pool and on the direct
     /// column-sender pool (both are ingestion-side connections).
     sender_pool_max: usize,
@@ -670,13 +681,14 @@ impl QuestDb {
     ///
     /// | Key                  | Default | Meaning                                                          |
     /// |----------------------|---------|------------------------------------------------------------------|
-    /// | `sender_pool_min`    | 1       | Warm minimum of the ingestion pool once opened. |
+    /// | `sender_pool_min`    | 1       | Warm minimum of the ingestion pool, pre-opened at connect unless `lazy_connect=true`. |
     /// | `sender_pool_max`    | 4       | Hard cap on the ingestion pool; the direct column-sender pool used by DataFrame ingestion is capped separately at the same value. |
-    /// | `query_pool_min`     | 1       | Warm minimum of the reader pool once opened. |
+    /// | `query_pool_min`     | 1 (0 when lazy) | Warm minimum of the reader pool, pre-opened at connect unless `lazy_connect=true`. |
     /// | `query_pool_max`     | 4       | Hard cap on the reader pool. |
     /// | `acquire_timeout_ms` | 5000    | How long an at-cap borrow waits for a return before failing; `0` fails immediately. |
     /// | `idle_timeout_ms`    | 60000   | Above-minimum idle connections are closed after this long. |
     /// | `pool_reap`          | `auto`  | `auto` runs a background reaper; `manual` requires `reap_idle`. |
+    /// | `lazy_connect`       | `false` | Tolerate a down server at startup: connect opens nothing, senders buffer and connect in the background, readers connect on first borrow. |
     ///
     /// Key names and defaults match the Java client's `QuestDBBuilder`; the
     /// Java-only lifecycle keys (`max_lifetime_ms`, `housekeeper_interval_ms`,
@@ -696,20 +708,32 @@ impl QuestDb {
     /// (non-SF) connection — used by DataFrame ingestion — see
     /// [`Self::borrow_direct_column_sender`].
     ///
-    /// Pools are **lazy**: `connect` performs no blocking network I/O. In
-    /// disk-backed store-and-forward mode, it may pre-open parked recovery
-    /// senders whose initial connect and replay run in the background. The
-    /// store-and-forward ingestion pool creates a local producer on first borrow
-    /// and starts its initial connect in the background, so the borrower can
-    /// buffer immediately even while the server is absent. An explicit
-    /// `initial_connect_retry` mode changes that for borrows: `off` connects
-    /// synchronously at borrow time and fails fast, `sync` retries within the
-    /// reconnect budget before the borrow returns. The `sync` promoted from
-    /// merely setting a `reconnect_*` key does not apply to pool borrows, and
-    /// recovery pre-opens always connect in the background. Direct senders and
-    /// readers still open their transport on first borrow. `sender_pool_min` /
-    /// `query_pool_min` are the warm minimums the reaper keeps once entries
-    /// have been opened.
+    /// Startup matches the Java client. By default `connect` is **eager**:
+    /// it pre-opens `sender_pool_min` ingest senders — honoring an
+    /// EXPLICITLY set `initial_connect_retry`: `off` (the default) fails
+    /// fast, `sync` retries within the reconnect budget, `async` connects in
+    /// the background — and `query_pool_min` readers, which have no retry
+    /// mode and always connect synchronously, failing fast. The `sync`
+    /// promoted from merely setting a `reconnect_*` key never drives pool
+    /// startup or borrows (a mid-stream failover budget must not become a
+    /// blocking `connect()`), and explicit `sync` conflicts with a positive
+    /// `query_pool_min` — set `query_pool_min=0` or use `lazy_connect=true`.
+    /// Bare `initial_connect_retry=async` is likewise not a non-blocking
+    /// startup while `query_pool_min > 0`; `lazy_connect=true` is. Growth
+    /// borrows beyond the minimum honor the same rules.
+    ///
+    /// With `lazy_connect=true` the pool tolerates a down server at startup:
+    /// `connect` performs no blocking network I/O, `query_pool_min` defaults
+    /// to 0 (readers connect lazily on first use), and every ingest borrow
+    /// creates its local store-and-forward producer immediately and connects
+    /// in the background, so the borrower can buffer while the server is
+    /// absent. An explicit blocking `initial_connect_retry` alongside
+    /// `lazy_connect=true` is rejected as a configuration conflict. In
+    /// disk-backed store-and-forward mode, either variant may pre-open parked
+    /// recovery senders whose initial connect and replay run in the
+    /// background. Direct senders open their transport on first borrow.
+    /// `sender_pool_min` / `query_pool_min` are the warm minimums the reaper
+    /// keeps.
     ///
     /// # Store-and-forward durability
     ///
@@ -833,6 +857,7 @@ impl QuestDb {
             buffer_max_name_len,
             health: Mutex::new(health),
             sender_pool_min: pool_cfg.sender_pool_min,
+            lazy_connect: pool_cfg.lazy_connect,
             sender_pool_max: pool_cfg.sender_pool_max,
             #[cfg(feature = "_egress")]
             query_pool_min: pool_cfg.query_pool_min,
@@ -863,8 +888,6 @@ impl QuestDb {
             conn_events: Arc::new(conn_events),
         });
 
-        preopen_recovery_senders(&inner);
-
         let reaper = match pool_cfg.pool_reap {
             PoolReap::Auto => Some(spawn_reaper(Arc::clone(&inner)).map_err(|err| {
                 inner.shutdown.store(true, Ordering::SeqCst);
@@ -876,7 +899,22 @@ impl QuestDb {
             PoolReap::Manual => None,
         };
 
-        Ok(Self { inner, reaper })
+        let db = Self { inner, reaper };
+        // Prewarm BEFORE recovery pre-open, matching the Java client's order.
+        // Prewarm adopts dirty disk slots itself through the borrow path's
+        // recovery candidates, so its foreground connect genuinely probes the
+        // server; recovery must not run first or its background-connecting
+        // (forced-async) senders would sit in the free list and satisfy the
+        // warm minimum without any connect, silently voiding the eager
+        // fail-fast contract whenever a previous run left queued data behind.
+        // On error the drop of `db` closes whatever was opened.
+        if !db.inner.lazy_connect {
+            prewarm_min_connections(&db)?;
+        }
+        // Recovery pre-open then re-adopts any dirty slots prewarm did not
+        // claim; their initial connect and replay run in the background.
+        preopen_recovery_senders(&db.inner);
+        Ok(db)
     }
 
     /// Create a caller-owned QWP/WebSocket row buffer using this pool's
@@ -905,11 +943,12 @@ impl QuestDb {
     /// return (`acquire_timeout_ms=0` fails fast); failing that, return
     /// `InvalidApiCall`.
     ///
-    /// A borrow that opens a new connection starts it in the background by
-    /// default, so it succeeds even while the server is away. An explicit
-    /// `initial_connect_retry` mode overrides that: `off` connects
-    /// synchronously and fails fast, `sync` retries within the reconnect
-    /// budget before returning; see [`Self::connect`].
+    /// A borrow that opens a new connection honors `initial_connect_retry`:
+    /// `off` (the default) connects synchronously and fails fast, `sync`
+    /// retries within the reconnect budget before returning. Under
+    /// `lazy_connect=true` the connection starts in the background instead,
+    /// so the borrow succeeds even while the server is away; see
+    /// [`Self::connect`].
     pub fn borrow_sender(&self) -> Result<BorrowedSender<'_>> {
         let cs = self.pick_sender()?;
         Ok(BorrowedSender(SenderHandle::new(self, cs)))
@@ -2656,9 +2695,64 @@ fn pick_direct_sender(inner: &Arc<DbInner>) -> Result<PooledSender<DirectSenderC
     )
 }
 
+/// Java-parity eager startup: open ingest senders until the pool holds
+/// `sender_pool_min` and readers until it holds `query_pool_min`, honoring
+/// an explicitly set `initial_connect_retry`. Runs BEFORE recovery pre-open,
+/// so every warm sender performs a real foreground connect — adopting dirty
+/// disk slots (and replaying them) along the way via the borrow path's
+/// recovery candidates. All warm borrows are held at once so each opens a
+/// distinct connection, then returned to the free lists; on the first
+/// failure the already-opened connections are returned and the error
+/// propagates to `connect()`.
+fn prewarm_min_connections(db: &QuestDb) -> Result<()> {
+    let inner = &db.inner;
+    let mut warm = Vec::new();
+    let mut outcome: Result<()> = Ok(());
+    for _ in 0..inner.sender_pool_min {
+        match pick_sfa_sender(inner) {
+            Ok(sender) => warm.push(sender),
+            Err(err) => {
+                outcome = Err(err);
+                break;
+            }
+        }
+    }
+    for picked in warm {
+        return_sfa_to_pool(inner, picked.sender, picked.slot_index);
+    }
+    outcome?;
+    #[cfg(feature = "_egress")]
+    {
+        let mut warm = Vec::new();
+        let mut outcome: Result<()> = Ok(());
+        for _ in 0..inner.query_pool_min {
+            match db.pick_reader() {
+                Ok(reader) => warm.push(reader),
+                Err(err) => {
+                    outcome = Err(err);
+                    break;
+                }
+            }
+        }
+        for reader in warm {
+            return_reader_to_pool(inner, reader, false);
+        }
+        outcome?;
+    }
+    Ok(())
+}
+
 fn connect_sfa_pool(inner: &Arc<DbInner>, slot_index: Option<usize>) -> Result<PooledSenderCore> {
     let recovery_candidates = managed_slot_recovery_candidates(inner);
-    connect_sfa_pool_with_recovery_candidates(inner, slot_index, &recovery_candidates, false)
+    // A lazy pool forces the background initial connect so borrows keep
+    // working while the server is away; a non-lazy pool honors
+    // `initial_connect_retry` as configured.
+    connect_sfa_pool_with_recovery_candidates(
+        inner,
+        slot_index,
+        &recovery_candidates,
+        inner.lazy_connect,
+    )
 }
 
 fn connect_sfa_pool_with_recovery_candidates(
@@ -3116,9 +3210,9 @@ fn reap_idle_direct_senders(inner: &DbInner) -> usize {
 
 #[cfg(feature = "_egress")]
 fn reap_idle_readers(inner: &DbInner) -> usize {
-    // The reader pool is lazy-init (no pre-population at connect);
-    // `query_pool_min` acts purely as the reaper's floor once readers
-    // have been opened.
+    // `query_pool_min` readers are pre-opened at connect by default
+    // (none under lazy_connect, where the pool fills on first borrow);
+    // either way `query_pool_min` is the reaper's floor here.
     let to_drop: Vec<Reader> = {
         let mut state = lock_reader_state(&inner.reader_state);
         let mut to_drop = Vec::new();

--- a/questdb-rs/src/db.rs
+++ b/questdb-rs/src/db.rs
@@ -262,11 +262,6 @@ struct DbInner {
     /// Warm minimum the reaper preserves in the store-and-forward
     /// ingestion pool.
     sender_pool_min: usize,
-    /// `lazy_connect=true`: tolerate a down server at startup. No warm-minimum
-    /// pre-connect, and ingest borrows force the background initial connect.
-    /// Off by default (Java parity): `connect()` pre-opens the warm minimums
-    /// and borrows honor `initial_connect_retry`.
-    lazy_connect: bool,
     /// Hard cap on the store-and-forward ingestion pool and on the direct
     /// column-sender pool (both are ingestion-side connections).
     sender_pool_max: usize,
@@ -709,18 +704,16 @@ impl QuestDb {
     /// [`Self::borrow_direct_column_sender`].
     ///
     /// Startup matches the Java client. By default `connect` is **eager**:
-    /// it pre-opens `sender_pool_min` ingest senders — honoring an
-    /// EXPLICITLY set `initial_connect_retry`: `off` (the default) fails
+    /// it pre-opens `sender_pool_min` ingest senders — honoring only an
+    /// explicitly set `initial_connect_retry`: `off` (the default) fails
     /// fast, `sync` retries within the reconnect budget, `async` connects in
     /// the background — and `query_pool_min` readers, which have no retry
-    /// mode and always connect synchronously, failing fast. The `sync`
-    /// promoted from merely setting a `reconnect_*` key never drives pool
-    /// startup or borrows (a mid-stream failover budget must not become a
-    /// blocking `connect()`), and explicit `sync` conflicts with a positive
-    /// `query_pool_min` — set `query_pool_min=0` or use `lazy_connect=true`.
-    /// Bare `initial_connect_retry=async` is likewise not a non-blocking
-    /// startup while `query_pool_min > 0`; `lazy_connect=true` is. Growth
-    /// borrows beyond the minimum honor the same rules.
+    /// mode and always connect synchronously, failing fast; `sync` governs
+    /// only the ingest side. Reconnect-to-sync promotion applies only to
+    /// standalone [`SenderBuilder::build`]; pools honor only an explicitly
+    /// set mode. Bare `initial_connect_retry=async` is likewise not a
+    /// non-blocking startup while `query_pool_min > 0`; `lazy_connect=true`
+    /// is. Growth borrows beyond the minimum honor the same rules.
     ///
     /// With `lazy_connect=true` the pool tolerates a down server at startup:
     /// `connect` performs no blocking network I/O, `query_pool_min` defaults
@@ -832,7 +825,12 @@ impl QuestDb {
         let sf_disk = parsed.sf_disk;
         let pool_cfg = parsed.pool;
 
-        let builder = SenderBuilder::from_conf(conf)?;
+        let mut builder = SenderBuilder::from_conf(conf)?;
+        if pool_cfg.lazy_connect {
+            // Java's lazy_connect injects an async initial connect into the
+            // ingest config once; every pooled sender then inherits it.
+            builder.force_async_initial_connect();
+        }
         let buffer_max_name_len = builder.configured_max_name_len();
         let connector = builder.build_qwp_ws_connector()?;
         let health = QwpWsHostHealthTracker::new(connector.endpoint_count());
@@ -857,7 +855,6 @@ impl QuestDb {
             buffer_max_name_len,
             health: Mutex::new(health),
             sender_pool_min: pool_cfg.sender_pool_min,
-            lazy_connect: pool_cfg.lazy_connect,
             sender_pool_max: pool_cfg.sender_pool_max,
             #[cfg(feature = "_egress")]
             query_pool_min: pool_cfg.query_pool_min,
@@ -908,7 +905,7 @@ impl QuestDb {
         // warm minimum without any connect, silently voiding the eager
         // fail-fast contract whenever a previous run left queued data behind.
         // On error the drop of `db` closes whatever was opened.
-        if !db.inner.lazy_connect {
+        if !pool_cfg.lazy_connect {
             prewarm_min_connections(&db)?;
         }
         // Recovery pre-open then re-adopts any dirty slots prewarm did not
@@ -2744,15 +2741,8 @@ fn prewarm_min_connections(db: &QuestDb) -> Result<()> {
 
 fn connect_sfa_pool(inner: &Arc<DbInner>, slot_index: Option<usize>) -> Result<PooledSenderCore> {
     let recovery_candidates = managed_slot_recovery_candidates(inner);
-    // A lazy pool forces the background initial connect so borrows keep
-    // working while the server is away; a non-lazy pool honors
-    // `initial_connect_retry` as configured.
-    connect_sfa_pool_with_recovery_candidates(
-        inner,
-        slot_index,
-        &recovery_candidates,
-        inner.lazy_connect,
-    )
+    // The connector already carries the pool's resolved initial-connect mode.
+    connect_sfa_pool_with_recovery_candidates(inner, slot_index, &recovery_candidates, false)
 }
 
 fn connect_sfa_pool_with_recovery_candidates(

--- a/questdb-rs/src/db.rs
+++ b/questdb-rs/src/db.rs
@@ -282,6 +282,12 @@ struct DbInner {
     /// Managed ingestion slot range excluded from orphan scans so sibling
     /// senders do not adopt each other's live pool slots.
     managed_slot_exclusion: Option<QwpWsManagedSlotExclusion>,
+    /// Same-base managed slots left outside this pool's live index range by a
+    /// larger previous run. Snapshotted once before the pool is published and
+    /// reused by every sender build, so borrow-triggered growth never rescans
+    /// `sf_dir`. The pool namespace is exclusive: a same-base slot created
+    /// after connect is recovered by the next pool instance.
+    out_of_range_recovery_candidates: Vec<PathBuf>,
     idle_timeout: Duration,
     /// Pool-wide connection lifecycle event source (dispatcher + attempt
     /// counter + success-classification state). Fixed at connect — with a
@@ -535,24 +541,6 @@ fn parse_managed_slot_id(base: &str, name: &str) -> Option<usize> {
     managed_slot_exclusion(base, usize::MAX).parse_index(name)
 }
 
-fn managed_slot_recovery_candidates(inner: &DbInner) -> Vec<PathBuf> {
-    if !inner.sf_disk {
-        return Vec::new();
-    }
-    let Some(sf_dir) = inner.connector.sf_dir() else {
-        return Vec::new();
-    };
-    managed_slot_recovery_candidates_from(sf_dir, &inner.slot_base_id, inner.sender_pool_max)
-}
-
-fn managed_slot_recovery_candidates_from(
-    sf_dir: &Path,
-    base: &str,
-    pool_max: usize,
-) -> Vec<PathBuf> {
-    managed_slot_recovery_scan_from(sf_dir, base, pool_max).out_of_range
-}
-
 fn managed_slot_recovery_scan_from(
     sf_dir: &Path,
     base: &str,
@@ -585,9 +573,8 @@ fn managed_slot_recovery_scan_from(
                 path: slot_path,
             });
         } else {
-            // This scan runs for every managed sender build, so the warning may
-            // repeat for the same directory until one drainer drains it. A
-            // DbInner-level dedupe set is a follow-up, not part of this fix.
+            // The pool-lifetime snapshot emits this warning once per candidate
+            // instead of repeating it on every borrow-triggered sender build.
             log::warn!(
                 "adopting out-of-range store-and-forward slot `{}`; \
                  `<sender_id>-ingest-*` directories under \
@@ -608,18 +595,20 @@ fn managed_slot_recovery_scan_from(
 /// Recovery senders count toward the ingestion pool total like ordinary parked
 /// senders. They are reaped only after their queues are delivered and idle past
 /// the timeout, and drain on pool close via `drain_sfa_senders_bounded`. Each
-/// pre-opened sender also enrolls out-of-range managed slots in its
-/// orphan-drainer set, so those slots may begin replay at connect as well.
-fn preopen_recovery_senders(inner: &Arc<DbInner>) {
-    if !inner.sf_disk {
-        return;
-    }
-    let Some(sf_dir) = inner.connector.sf_dir() else {
-        return;
-    };
-    let scan = managed_slot_recovery_scan_from(sf_dir, &inner.slot_base_id, inner.sender_pool_max);
-    for candidate in scan.in_range {
-        preopen_recovery_sender(inner, candidate.index, &candidate.path, &scan.out_of_range);
+/// pre-opened sender also enrolls the pool's snapshotted out-of-range managed
+/// slots in its orphan-drainer set, so those slots may begin replay at connect
+/// as well.
+fn preopen_recovery_senders(
+    inner: &Arc<DbInner>,
+    in_range_candidates: &[ManagedSlotRecoveryCandidate],
+) {
+    for candidate in in_range_candidates {
+        preopen_recovery_sender(
+            inner,
+            candidate.index,
+            &candidate.path,
+            &inner.out_of_range_recovery_candidates,
+        );
     }
 }
 
@@ -843,6 +832,25 @@ impl QuestDb {
         } else {
             None
         };
+        // Snapshot managed recovery before any sender is built. In-range
+        // entries are retained locally for connect-time pre-open; out-of-range
+        // entries live on DbInner and are reused by prewarm and later growth.
+        // This matches Java SenderPool's cached out-of-range worklist and keeps
+        // the borrow path free of top-level sf_dir scans.
+        let recovery_scan = if sf_disk {
+            connector
+                .sf_dir()
+                .map(|sf_dir| {
+                    managed_slot_recovery_scan_from(sf_dir, &slot_base_id, pool_cfg.sender_pool_max)
+                })
+                .unwrap_or_default()
+        } else {
+            ManagedSlotRecoveryScan::default()
+        };
+        let ManagedSlotRecoveryScan {
+            in_range: in_range_recovery_candidates,
+            out_of_range: out_of_range_recovery_candidates,
+        } = recovery_scan;
 
         // Start empty; connect-time recovery may pre-open dirty disk-SF slots
         // after `inner` exists, otherwise the pools open on first borrow.
@@ -864,6 +872,7 @@ impl QuestDb {
             sf_disk,
             slot_base_id,
             managed_slot_exclusion,
+            out_of_range_recovery_candidates,
             idle_timeout: pool_cfg.idle_timeout,
             state: Mutex::new(if sf_disk {
                 PoolState::with_disk_slots(pool_cfg.sender_pool_max)
@@ -898,19 +907,20 @@ impl QuestDb {
 
         let db = Self { inner, reaper };
         // Prewarm BEFORE recovery pre-open, matching the Java client's order.
-        // Prewarm adopts dirty disk slots itself through the borrow path's
-        // recovery candidates, so its foreground connect genuinely probes the
-        // server; recovery must not run first or its background-connecting
-        // (forced-async) senders would sit in the free list and satisfy the
-        // warm minimum without any connect, silently voiding the eager
-        // fail-fast contract whenever a previous run left queued data behind.
-        // On error the drop of `db` closes whatever was opened.
+        // Prewarm adopts each dirty in-range slot through its deterministic
+        // managed id and enrolls the snapshotted out-of-range candidates, so
+        // its foreground connect genuinely probes the server; recovery must
+        // not run first or its background-connecting (forced-async) senders
+        // would sit in the free list and satisfy the warm minimum without any
+        // connect, silently voiding the eager fail-fast contract whenever a
+        // previous run left queued data behind. On error the drop of `db`
+        // closes whatever was opened.
         if !pool_cfg.lazy_connect {
             prewarm_min_connections(&db)?;
         }
         // Recovery pre-open then re-adopts any dirty slots prewarm did not
         // claim; their initial connect and replay run in the background.
-        preopen_recovery_senders(&db.inner);
+        preopen_recovery_senders(&db.inner, &in_range_recovery_candidates);
         Ok(db)
     }
 
@@ -2740,9 +2750,13 @@ fn prewarm_min_connections(db: &QuestDb) -> Result<()> {
 }
 
 fn connect_sfa_pool(inner: &Arc<DbInner>, slot_index: Option<usize>) -> Result<PooledSenderCore> {
-    let recovery_candidates = managed_slot_recovery_candidates(inner);
     // The connector already carries the pool's resolved initial-connect mode.
-    connect_sfa_pool_with_recovery_candidates(inner, slot_index, &recovery_candidates, false)
+    connect_sfa_pool_with_recovery_candidates(
+        inner,
+        slot_index,
+        &inner.out_of_range_recovery_candidates,
+        false,
+    )
 }
 
 fn connect_sfa_pool_with_recovery_candidates(
@@ -3276,7 +3290,7 @@ mod tests {
 
     use tempfile::TempDir;
 
-    use super::{SlotReservations, managed_slot_recovery_candidates_from};
+    use super::{SlotReservations, managed_slot_recovery_scan_from};
 
     fn dirty_slot(root: &std::path::Path, name: &str) {
         let slot = root.join(name);
@@ -3293,7 +3307,7 @@ mod tests {
         dirty_slot(temp.path(), &format!("default-{}-2", "col"));
         dirty_slot(temp.path(), &format!("default-{}-2", "row"));
 
-        let mut actual = managed_slot_recovery_candidates_from(temp.path(), "default", 2);
+        let mut actual = managed_slot_recovery_scan_from(temp.path(), "default", 2).out_of_range;
         actual.sort();
 
         assert_eq!(actual, vec![temp.path().join("default-ingest-2")]);

--- a/questdb-rs/src/db/conf.rs
+++ b/questdb-rs/src/db/conf.rs
@@ -285,25 +285,6 @@ pub(crate) fn parse(conf: &str) -> Result<ParsedConf> {
             ));
         }
         pool.query_pool_min = 0;
-    } else if pool.query_pool_min > 0
-        && initial_connect_retry
-            .as_deref()
-            .is_some_and(crate::ingress::initial_connect_retry_value_is_sync)
-    {
-        // Same cross-surface consistency rule as the lazy conflicts above:
-        // explicit sync means "retry my startup connects", but readers have
-        // no retry mode, so a reader pre-open would still fail fast and make
-        // the sync promise a half-truth. Refuse the combination with a
-        // remedy instead.
-        return Err(error::fmt!(
-            ConfigError,
-            "conflicting configuration: initial_connect_retry=sync retries the \
-             eager ingest pre-opens, but readers have no retry mode and \
-             query_pool_min={} would still fail fast at startup. Resolve by \
-             setting query_pool_min=0 (readers then connect on first use) or \
-             using lazy_connect=true.",
-            pool.query_pool_min
-        ));
     }
 
     if pool.sender_pool_min > pool.sender_pool_max {

--- a/questdb-rs/src/db/conf.rs
+++ b/questdb-rs/src/db/conf.rs
@@ -26,8 +26,8 @@
 //!
 //! Extracts pool-specific keys (`sender_pool_min`, `sender_pool_max`,
 //! `query_pool_min`, `query_pool_max`, `acquire_timeout_ms`,
-//! `idle_timeout_ms`, `pool_reap` — names and defaults matching the Java
-//! client's `QuestDBBuilder`), detects explicit disk-backed
+//! `idle_timeout_ms`, `pool_reap`, `lazy_connect` — names and defaults
+//! matching the Java client's `QuestDBBuilder`), detects explicit disk-backed
 //! store-and-forward opt-in (`sf_dir`), enforces a QWP/WebSocket schema, and
 //! produces a sanitized conf string that the underlying
 //! [`crate::ingress::SenderBuilder`] can consume to build connections.
@@ -73,6 +73,12 @@ pub(crate) struct PoolConfig {
     pub(crate) acquire_timeout: Duration,
     pub(crate) idle_timeout: Duration,
     pub(crate) pool_reap: PoolReap,
+    /// `lazy_connect=true` tolerates a down server at startup, matching the
+    /// Java client: no warm-minimum pre-connect, ingest borrows connect in
+    /// the background, and `query_pool_min` defaults to 0. Off by default:
+    /// `connect()` pre-opens the warm minimums and fails fast, honoring
+    /// `initial_connect_retry`.
+    pub(crate) lazy_connect: bool,
 }
 
 impl Default for PoolConfig {
@@ -85,6 +91,7 @@ impl Default for PoolConfig {
             acquire_timeout: DEFAULT_ACQUIRE_TIMEOUT,
             idle_timeout: DEFAULT_IDLE_TIMEOUT,
             pool_reap: PoolReap::Auto,
+            lazy_connect: false,
         }
     }
 }
@@ -124,6 +131,8 @@ pub(crate) fn parse(conf: &str) -> Result<ParsedConf> {
 
     let mut pool = PoolConfig::default();
     let mut sf_dir_specified = false;
+    let mut query_pool_min_specified = false;
+    let mut initial_connect_retry: Option<String> = None;
 
     walk_params(params, |key, value| {
         // `sf_dir` selects disk-backed store-and-forward slots;
@@ -161,6 +170,7 @@ pub(crate) fn parse(conf: &str) -> Result<ParsedConf> {
             }
             "query_pool_min" => {
                 pool.query_pool_min = parse_pool_usize(key, value)?;
+                query_pool_min_specified = true;
             }
             "query_pool_max" => {
                 let value = parse_pool_usize(key, value)?;
@@ -191,6 +201,31 @@ pub(crate) fn parse(conf: &str) -> Result<ParsedConf> {
                     }
                 };
             }
+            "lazy_connect" => {
+                // Java conf strings write true/false; accept on/off too,
+                // case-insensitively, matching initial_connect_retry's
+                // grammar. Deliberately NOT widened into parse_on_off:
+                // request_durable_ack must keep the builder's strict on/off
+                // grammar or the pool would accept values the builder then
+                // rejects.
+                pool.lazy_connect = match value.to_ascii_lowercase().as_str() {
+                    "on" | "true" => true,
+                    "off" | "false" => false,
+                    other => {
+                        return Err(error::fmt!(
+                            ConfigError,
+                            "Invalid value for \"lazy_connect\" (expected \
+                             'true' or 'false'): {:?}",
+                            other
+                        ));
+                    }
+                };
+            }
+            "initial_connect_retry" => {
+                // Parsed by the SenderBuilder; recorded here only for the
+                // lazy_connect conflict check below.
+                initial_connect_retry = Some(value.to_owned());
+            }
             "pool_size" | "pool_max" | "pool_idle_timeout_ms" => {
                 return Err(error::fmt!(
                     ConfigError,
@@ -213,6 +248,63 @@ pub(crate) fn parse(conf: &str) -> Result<ParsedConf> {
         }
         Ok(())
     })?;
+
+    // lazy_connect needs BOTH sides to start non-blocking, matching the Java
+    // client: an explicit knob that forces a blocking / fail-fast startup is
+    // a configuration conflict, rejected with a remedy rather than silently
+    // overridden.
+    if pool.lazy_connect {
+        // Conflict only for modes the ingress parser recognizes as blocking;
+        // an unrecognized value falls through to the SenderBuilder's
+        // invalid-value error instead of a misleading conflict message.
+        // Reusing the parser keeps this check from drifting when a mode is
+        // added there.
+        let blocking_mode = initial_connect_retry
+            .as_deref()
+            .filter(|mode| crate::ingress::initial_connect_retry_value_is_blocking(mode));
+        if let Some(mode) = blocking_mode {
+            return Err(error::fmt!(
+                ConfigError,
+                "conflicting configuration: lazy_connect=true needs a non-blocking \
+                 startup, but initial_connect_retry={} makes the initial connect \
+                 block / fail-fast. Resolve by removing initial_connect_retry \
+                 (lazy_connect implies initial_connect_retry=async) or setting \
+                 initial_connect_retry=async.",
+                mode
+            ));
+        }
+        if query_pool_min_specified && pool.query_pool_min > 0 {
+            return Err(error::fmt!(
+                ConfigError,
+                "conflicting configuration: lazy_connect=true needs query_pool_min=0 \
+                 (the read pool connects lazily on first use and must not fail-fast \
+                 at startup), but query_pool_min={} was set. Resolve by removing \
+                 query_pool_min (lazy_connect defaults it to 0) or setting \
+                 query_pool_min=0.",
+                pool.query_pool_min
+            ));
+        }
+        pool.query_pool_min = 0;
+    } else if pool.query_pool_min > 0
+        && initial_connect_retry
+            .as_deref()
+            .is_some_and(crate::ingress::initial_connect_retry_value_is_sync)
+    {
+        // Same cross-surface consistency rule as the lazy conflicts above:
+        // explicit sync means "retry my startup connects", but readers have
+        // no retry mode, so a reader pre-open would still fail fast and make
+        // the sync promise a half-truth. Refuse the combination with a
+        // remedy instead.
+        return Err(error::fmt!(
+            ConfigError,
+            "conflicting configuration: initial_connect_retry=sync retries the \
+             eager ingest pre-opens, but readers have no retry mode and \
+             query_pool_min={} would still fail fast at startup. Resolve by \
+             setting query_pool_min=0 (readers then connect on first use) or \
+             using lazy_connect=true.",
+            pool.query_pool_min
+        ));
+    }
 
     if pool.sender_pool_min > pool.sender_pool_max {
         return Err(error::fmt!(

--- a/questdb-rs/src/egress/config.rs
+++ b/questdb-rs/src/egress/config.rs
@@ -587,6 +587,7 @@ pub(crate) const INGRESS_ONLY_CONFIG_KEYS: &[&str] = &[
     "query_pool_max",
     "acquire_timeout_ms",
     "idle_timeout_ms",
+    "lazy_connect",
     "pool_reap",
 ];
 

--- a/questdb-rs/src/egress/reader.rs
+++ b/questdb-rs/src/egress/reader.rs
@@ -1368,6 +1368,12 @@ impl FailoverBudget {
         }
     }
 
+    fn advance_backoff(&mut self, max_backoff_ms: u64) {
+        if self.next_backoff_ms > 0 {
+            self.next_backoff_ms = self.next_backoff_ms.saturating_mul(2).min(max_backoff_ms);
+        }
+    }
+
     fn before_reconnect_round(
         &mut self,
         cfg: &ReaderConfig,
@@ -1392,12 +1398,7 @@ impl FailoverBudget {
             None => Duration::from_millis(jittered_ms),
         };
         std::thread::sleep(sleep_dur);
-        if self.next_backoff_ms > 0 {
-            self.next_backoff_ms = self
-                .next_backoff_ms
-                .saturating_mul(2)
-                .min(cfg.failover_backoff_max_ms);
-        }
+        self.advance_backoff(cfg.failover_backoff_max_ms);
         self.reconnect_rounds_remaining = self.reconnect_rounds_remaining.saturating_sub(1);
         Ok(())
     }
@@ -3507,6 +3508,33 @@ mod tests {
                 code
             );
         }
+    }
+
+    /// Pin the exponential base schedule without measuring wall-clock
+    /// time. Socket setup and scheduler delays are unrelated to the
+    /// configured backoff, so elapsed-time integration assertions can
+    /// fail even when this progression is correct.
+    #[test]
+    fn failover_budget_backoff_base_grows_and_caps() {
+        let mut budget = FailoverBudget {
+            reconnect_rounds_remaining: 9,
+            next_backoff_ms: 10,
+            deadline: None,
+        };
+        let observed: [u64; 9] = std::array::from_fn(|_| {
+            let base = budget.next_backoff_ms;
+            budget.advance_backoff(20);
+            base
+        });
+        assert_eq!(observed, [10, 20, 20, 20, 20, 20, 20, 20, 20]);
+
+        let mut disabled = FailoverBudget {
+            reconnect_rounds_remaining: 1,
+            next_backoff_ms: 0,
+            deadline: None,
+        };
+        disabled.advance_backoff(20);
+        assert_eq!(disabled.next_backoff_ms, 0);
     }
 
     /// `base = 0` MUST return 0 without touching the splitmix state.

--- a/questdb-rs/src/egress/reader.rs
+++ b/questdb-rs/src/egress/reader.rs
@@ -3537,6 +3537,49 @@ mod tests {
         assert_eq!(disabled.next_backoff_ms, 0);
     }
 
+    /// Exercise the production call path without using elapsed time as
+    /// an oracle. The configured bases keep the real sleeps at 0–1 ms;
+    /// scheduler oversleep can delay the test but cannot change its
+    /// state assertions.
+    #[test]
+    fn before_reconnect_round_applies_configured_backoff_cap() {
+        let cfg = ReaderConfig::from_conf(concat!(
+            "ws::addr=localhost:9000;",
+            "failover_max_attempts=4;",
+            "failover_backoff_initial_ms=1;",
+            "failover_backoff_max_ms=2"
+        ))
+        .unwrap();
+        let mut budget = FailoverBudget::new(&cfg);
+        let mut rng = FailoverRng { state: 0 };
+
+        let observed: [u64; 3] = std::array::from_fn(|_| {
+            budget.before_reconnect_round(&cfg, &mut rng).unwrap();
+            budget.next_backoff_ms
+        });
+        assert_eq!(observed, [2, 2, 2]);
+        assert_eq!(budget.reconnect_rounds_remaining, 0);
+        assert_eq!(
+            budget.before_reconnect_round(&cfg, &mut rng),
+            Err(FailoverBudgetStop::AttemptsExhausted)
+        );
+
+        let disabled_cfg = ReaderConfig::from_conf(concat!(
+            "ws::addr=localhost:9000;",
+            "failover_max_attempts=2;",
+            "failover_backoff_initial_ms=0;",
+            "failover_backoff_max_ms=2"
+        ))
+        .unwrap();
+        let mut disabled = FailoverBudget::new(&disabled_cfg);
+        let mut disabled_rng = FailoverRng { state: 0 };
+        disabled
+            .before_reconnect_round(&disabled_cfg, &mut disabled_rng)
+            .unwrap();
+        assert_eq!(disabled.next_backoff_ms, 0);
+        assert_eq!(disabled.reconnect_rounds_remaining, 0);
+    }
+
     /// `base = 0` MUST return 0 without touching the splitmix state.
     /// A backoff of zero is the documented "sleep is a no-op" sentinel
     /// and the caller passes it whenever `failover_backoff_initial_ms`

--- a/questdb-rs/src/ingress.rs
+++ b/questdb-rs/src/ingress.rs
@@ -636,18 +636,11 @@ impl QwpWsConnector {
         force_async_initial_connect: bool,
     ) -> Result<sender::qwp_ws::SyncQwpWsHandlerState> {
         let mut qwp_ws = self.qwp_ws.clone();
-        // Recovery pre-opens and lazy_connect pools force the background
-        // initial connect; a non-lazy pool honors an EXPLICITLY set
-        // `initial_connect_retry` (default off: connect at borrow / prewarm
-        // and fail fast). The `sync` promoted from `reconnect_*` keys is
-        // demoted back to the default here: that promotion exists to give the
-        // standalone sender's blocking connect a retry budget, and honoring
-        // it in the pool would turn a mid-stream failover knob into a
-        // multi-minute blocking `connect()`.
+        // Reconnect-to-sync promotion applies only to standalone
+        // `SenderBuilder::build()`; pools honor only an explicitly set mode.
+        // Recovery pre-opens still override that mode for this one connect.
         if force_async_initial_connect {
             qwp_ws.force_async_initial_connect();
-        } else {
-            qwp_ws.demote_promoted_initial_connect_retry();
         }
         // The pool's shared sources exist (handlers already attached, or
         // permanently defaulted) before connect-time recovery senders are
@@ -1368,11 +1361,6 @@ impl SenderBuilder {
             };
         }
 
-        #[cfg(feature = "_sender-qwp-ws")]
-        if let Some(qwp_ws) = builder.qwp_ws.as_mut() {
-            qwp_ws.apply_reconnect_implies_initial_retry();
-        }
-
         Ok(builder)
     }
 
@@ -2013,7 +2001,6 @@ impl SenderBuilder {
                 "The \"initial_connect_retry\" setting is only supported for QWP/WebSocket."
             ));
         };
-        qwp_ws.demote_promoted_initial_connect_retry();
         qwp_ws
             .initial_connect_retry
             .set_specified("initial_connect_retry", mode)?;
@@ -2027,8 +2014,8 @@ impl SenderBuilder {
     /// eager warm-minimum pre-open and every pool borrow that opens a new
     /// connection honor it, defaulting to fail-fast `off`. A `lazy_connect`
     /// pool always connects in the background and rejects an explicit
-    /// blocking mode. An explicit call here replaces the `sync` that setting
-    /// any `reconnect_*` key promotes.
+    /// blocking mode. Reconnect-to-sync promotion applies only to standalone
+    /// [`SenderBuilder::build`]; pools honor only an explicitly set mode.
     pub fn initial_connect_retry(mut self, value: bool) -> Result<Self> {
         let Some(qwp_ws) = &mut self.qwp_ws else {
             return Err(error::fmt!(
@@ -2036,7 +2023,6 @@ impl SenderBuilder {
                 "The \"initial_connect_retry\" setting is only supported for QWP/WebSocket."
             ));
         };
-        qwp_ws.demote_promoted_initial_connect_retry();
         qwp_ws.initial_connect_retry.set_specified(
             "initial_connect_retry",
             if value {
@@ -2776,12 +2762,14 @@ impl SenderBuilder {
                         "QWP/WebSocket configuration is missing."
                     ));
                 };
-                // Builder API callers reach build() without going through
-                // from_conf, so apply the reconnect-implies-initial-retry
-                // auto-on here too. Cheap clone; a no-op when the caller
-                // already specified initial_connect_retry.
+                // Resolve reconnect-implies-initial-retry only for this
+                // standalone build. The builder retains the user's explicit
+                // choice (or lack of one), so pool connector builds never see
+                // this effective mode.
+                let actual_initial_connect_retry = qwp_ws.resolve_initial_connect_retry();
                 let mut qwp_ws = qwp_ws.clone();
-                qwp_ws.apply_reconnect_implies_initial_retry();
+                qwp_ws.initial_connect_retry =
+                    ConfigSetting::Specified(actual_initial_connect_retry);
                 let qwp_ws = &qwp_ws;
                 reject_unsupported_qwp_ws_sf_config(qwp_ws)?;
                 let basic_auth = qwp_ws_auth_header(&auth)?;
@@ -2889,7 +2877,7 @@ impl SenderBuilder {
     /// Resolve the QWP/WebSocket connect ingredients used by
     /// [`Self::build_qwp_ws_connector`]: validate the protocol / buffer / TLS
     /// settings, build the TLS config and auth header, and clone the
-    /// (reconnect-promoted, SF-vetted) `QwpWsConfig`.
+    /// SF-vetted `QwpWsConfig`.
     #[cfg(feature = "sync-sender-qwp-ws")]
     fn resolve_qwp_ws_ingredients(
         &self,
@@ -2952,8 +2940,7 @@ impl SenderBuilder {
 
         let auth = self.build_auth()?;
         let auth_header = qwp_ws_auth_header(&auth)?;
-        let mut qwp_ws = qwp_ws.clone();
-        qwp_ws.apply_reconnect_implies_initial_retry();
+        let qwp_ws = qwp_ws.clone();
         reject_unsupported_qwp_ws_sf_config(&qwp_ws)?;
         if *qwp_ws.progress == QwpWsProgress::Manual
             && *qwp_ws.initial_connect_retry == conf::QwpWsInitialConnectMode::Async
@@ -2966,6 +2953,14 @@ impl SenderBuilder {
 
         let use_tls = matches!(self.protocol, Protocol::Wss);
         Ok((use_tls, tls_settings, qwp_ws, auth_header))
+    }
+
+    /// Force the pool connector's baked-in initial connect mode to background.
+    #[cfg(feature = "sync-sender-qwp-ws")]
+    pub(crate) fn force_async_initial_connect(&mut self) {
+        if let Some(qwp_ws) = self.qwp_ws.as_mut() {
+            qwp_ws.force_async_initial_connect();
+        }
     }
 
     /// Build a reusable [`QwpWsConnector`] capturing the full configured
@@ -3058,18 +3053,6 @@ pub(crate) fn initial_connect_retry_value_is_blocking(str_value: &str) -> bool {
     matches!(
         parse_initial_connect_retry_value(str_value),
         Ok(mode) if mode != conf::QwpWsInitialConnectMode::Async
-    )
-}
-
-/// `true` when the ingress parser recognizes `str_value` as the synchronous
-/// retry mode (`sync` / `on` / `true`). Used by the pool's eager-startup
-/// conflict check; derived from the parser for the same no-drift reason as
-/// [`initial_connect_retry_value_is_blocking`].
-#[cfg(feature = "_sender-qwp-ws")]
-pub(crate) fn initial_connect_retry_value_is_sync(str_value: &str) -> bool {
-    matches!(
-        parse_initial_connect_retry_value(str_value),
-        Ok(conf::QwpWsInitialConnectMode::Sync)
     )
 }
 

--- a/questdb-rs/src/ingress.rs
+++ b/questdb-rs/src/ingress.rs
@@ -633,9 +633,17 @@ impl QwpWsConnector {
         extra_orphan_slots: &[PathBuf],
         conn_events: std::sync::Arc<conn_events::ConnectionEventSource>,
         rejection_sink: std::sync::Arc<rejection_events::RejectionEventSource>,
+        force_async_initial_connect: bool,
     ) -> Result<sender::qwp_ws::SyncQwpWsHandlerState> {
         let mut qwp_ws = self.qwp_ws.clone();
-        qwp_ws.force_async_initial_connect();
+        // Recovery pre-opens force the background initial connect so
+        // `QuestDb::connect` stays non-blocking; borrows honor an explicit
+        // `initial_connect_retry` mode and default to background otherwise.
+        if force_async_initial_connect {
+            qwp_ws.force_async_initial_connect();
+        } else {
+            qwp_ws.default_async_initial_connect();
+        }
         // The pool's shared sources exist (handlers already attached, or
         // permanently defaulted) before connect-time recovery senders are
         // pre-opened, so every runner narrates through them from its first
@@ -1999,6 +2007,7 @@ impl SenderBuilder {
                 "The \"initial_connect_retry\" setting is only supported for QWP/WebSocket."
             ));
         };
+        qwp_ws.demote_promoted_initial_connect_retry();
         qwp_ws
             .initial_connect_retry
             .set_specified("initial_connect_retry", mode)?;
@@ -2007,6 +2016,12 @@ impl SenderBuilder {
 
     #[cfg(feature = "_sender-qwp-ws")]
     /// Retry the initial connection using the reconnect policy. Default false.
+    ///
+    /// The mode also governs pool borrows ([`crate::QuestDb::borrow_sender`]):
+    /// a borrow that opens a new connection honors an explicit `off`/`sync`
+    /// and defaults to the background initial connect otherwise. An explicit
+    /// call here replaces the `sync` that setting any `reconnect_*` key
+    /// promotes; that promoted mode never applies to pool borrows.
     pub fn initial_connect_retry(mut self, value: bool) -> Result<Self> {
         let Some(qwp_ws) = &mut self.qwp_ws else {
             return Err(error::fmt!(
@@ -2014,6 +2029,7 @@ impl SenderBuilder {
                 "The \"initial_connect_retry\" setting is only supported for QWP/WebSocket."
             ));
         };
+        qwp_ws.demote_promoted_initial_connect_retry();
         qwp_ws.initial_connect_retry.set_specified(
             "initial_connect_retry",
             if value {

--- a/questdb-rs/src/ingress.rs
+++ b/questdb-rs/src/ingress.rs
@@ -636,13 +636,18 @@ impl QwpWsConnector {
         force_async_initial_connect: bool,
     ) -> Result<sender::qwp_ws::SyncQwpWsHandlerState> {
         let mut qwp_ws = self.qwp_ws.clone();
-        // Recovery pre-opens force the background initial connect so
-        // `QuestDb::connect` stays non-blocking; borrows honor an explicit
-        // `initial_connect_retry` mode and default to background otherwise.
+        // Recovery pre-opens and lazy_connect pools force the background
+        // initial connect; a non-lazy pool honors an EXPLICITLY set
+        // `initial_connect_retry` (default off: connect at borrow / prewarm
+        // and fail fast). The `sync` promoted from `reconnect_*` keys is
+        // demoted back to the default here: that promotion exists to give the
+        // standalone sender's blocking connect a retry budget, and honoring
+        // it in the pool would turn a mid-stream failover knob into a
+        // multi-minute blocking `connect()`.
         if force_async_initial_connect {
             qwp_ws.force_async_initial_connect();
         } else {
-            qwp_ws.default_async_initial_connect();
+            qwp_ws.demote_promoted_initial_connect_retry();
         }
         // The pool's shared sources exist (handlers already attached, or
         // permanently defaulted) before connect-time recovery senders are
@@ -1115,6 +1120,7 @@ impl SenderBuilder {
             "path",
             "acquire_timeout_ms",
             "idle_timeout_ms",
+            "lazy_connect",
             "pool_reap",
             "query_pool_max",
             "query_pool_min",
@@ -2017,11 +2023,12 @@ impl SenderBuilder {
     #[cfg(feature = "_sender-qwp-ws")]
     /// Retry the initial connection using the reconnect policy. Default false.
     ///
-    /// The mode also governs pool borrows ([`crate::QuestDb::borrow_sender`]):
-    /// a borrow that opens a new connection honors an explicit `off`/`sync`
-    /// and defaults to the background initial connect otherwise. An explicit
-    /// call here replaces the `sync` that setting any `reconnect_*` key
-    /// promotes; that promoted mode never applies to pool borrows.
+    /// The mode also governs the pool ([`crate::QuestDb::connect`]): the
+    /// eager warm-minimum pre-open and every pool borrow that opens a new
+    /// connection honor it, defaulting to fail-fast `off`. A `lazy_connect`
+    /// pool always connects in the background and rejects an explicit
+    /// blocking mode. An explicit call here replaces the `sync` that setting
+    /// any `reconnect_*` key promotes.
     pub fn initial_connect_retry(mut self, value: bool) -> Result<Self> {
         let Some(qwp_ws) = &mut self.qwp_ws else {
             return Err(error::fmt!(
@@ -3040,6 +3047,30 @@ where
             "Could not parse {param_name:?} to number: {e:?}"
         )
     })
+}
+
+/// `true` when the ingress parser recognizes `str_value` as an
+/// `initial_connect_retry` mode that blocks or fails fast at startup.
+/// The pool's `lazy_connect` conflict check derives from the parser so the
+/// two cannot drift when a mode is added.
+#[cfg(feature = "_sender-qwp-ws")]
+pub(crate) fn initial_connect_retry_value_is_blocking(str_value: &str) -> bool {
+    matches!(
+        parse_initial_connect_retry_value(str_value),
+        Ok(mode) if mode != conf::QwpWsInitialConnectMode::Async
+    )
+}
+
+/// `true` when the ingress parser recognizes `str_value` as the synchronous
+/// retry mode (`sync` / `on` / `true`). Used by the pool's eager-startup
+/// conflict check; derived from the parser for the same no-drift reason as
+/// [`initial_connect_retry_value_is_blocking`].
+#[cfg(feature = "_sender-qwp-ws")]
+pub(crate) fn initial_connect_retry_value_is_sync(str_value: &str) -> bool {
+    matches!(
+        parse_initial_connect_retry_value(str_value),
+        Ok(conf::QwpWsInitialConnectMode::Sync)
+    )
 }
 
 #[cfg(feature = "_sender-qwp-ws")]

--- a/questdb-rs/src/ingress/conf.rs
+++ b/questdb-rs/src/ingress/conf.rs
@@ -281,8 +281,9 @@ pub(crate) struct QwpWsConfig {
     /// round, matching Java's startup behavior.
     pub(crate) initial_connect_retry: ConfigSetting<QwpWsInitialConnectMode>,
     /// `true` when `initial_connect_retry` was promoted from a `reconnect_*`
-    /// key rather than chosen by the user; pool borrows ignore the promoted
-    /// mode (see `default_async_initial_connect`).
+    /// key rather than chosen by the user. An explicit builder-setter call
+    /// replaces a promoted mode instead of conflicting with it (see
+    /// `demote_promoted_initial_connect_retry`).
     pub(crate) initial_connect_retry_promoted: bool,
     /// Bounded wait used by Sender::close_drain().
     pub(crate) close_flush_timeout: ConfigSetting<std::time::Duration>,
@@ -433,18 +434,6 @@ impl QwpWsConfig {
         if self.initial_connect_retry_promoted {
             self.initial_connect_retry = ConfigSetting::new_default(QwpWsInitialConnectMode::Off);
             self.initial_connect_retry_promoted = false;
-        }
-    }
-
-    /// Pool-borrow variant of `force_async_initial_connect`: default the
-    /// initial connect to the background runner so a borrow can buffer while
-    /// the server is away, but let a mode the user chose explicitly win. The
-    /// `Sync` promoted from `reconnect_*` keys does not count as explicit —
-    /// the pool's background runner already applies the reconnect budget to
-    /// its initial connect, which is what that promotion exists to ensure.
-    pub(crate) fn default_async_initial_connect(&mut self) {
-        if !self.initial_connect_retry.is_specified() || self.initial_connect_retry_promoted {
-            self.force_async_initial_connect();
         }
     }
 }

--- a/questdb-rs/src/ingress/conf.rs
+++ b/questdb-rs/src/ingress/conf.rs
@@ -280,11 +280,6 @@ pub(crate) struct QwpWsConfig {
     /// Initial-connect retry mode. Default is fail-fast after one endpoint
     /// round, matching Java's startup behavior.
     pub(crate) initial_connect_retry: ConfigSetting<QwpWsInitialConnectMode>,
-    /// `true` when `initial_connect_retry` was promoted from a `reconnect_*`
-    /// key rather than chosen by the user. An explicit builder-setter call
-    /// replaces a promoted mode instead of conflicting with it (see
-    /// `demote_promoted_initial_connect_retry`).
-    pub(crate) initial_connect_retry_promoted: bool,
     /// Bounded wait used by Sender::close_drain().
     pub(crate) close_flush_timeout: ConfigSetting<std::time::Duration>,
     pub(crate) sf_dir: ConfigSetting<Option<PathBuf>>,
@@ -352,7 +347,6 @@ impl Default for QwpWsConfig {
             ),
             reconnect_max_backoff: ConfigSetting::new_default(std::time::Duration::from_secs(5)),
             initial_connect_retry: ConfigSetting::new_default(QwpWsInitialConnectMode::Off),
-            initial_connect_retry_promoted: false,
             close_flush_timeout: ConfigSetting::new_default(QWP_WS_DEFAULT_CLOSE_DRAIN_TIMEOUT),
             sf_dir: ConfigSetting::new_default(None),
             sender_id: ConfigSetting::new_default(QWP_WS_DEFAULT_SENDER_ID.to_owned()),
@@ -401,20 +395,20 @@ impl QwpWsConfig {
     /// a longer reconnect budget expecting it to also bound the first
     /// connect silently gets no retry at all.
     ///
-    /// Promote `initial_connect_retry` to `Sync` whenever the user
-    /// explicitly set any `reconnect_*` key and did not explicitly choose
-    /// an `initial_connect_retry` mode themselves. Explicit
-    /// `initial_connect_retry=off` is preserved.
-    pub(crate) fn apply_reconnect_implies_initial_retry(&mut self) {
+    /// Resolve the standalone sender's effective initial-connect mode.
+    /// Explicit `initial_connect_retry` wins; otherwise any explicitly set
+    /// `reconnect_*` key implies `Sync`, and the remaining default is `Off`.
+    pub(crate) fn resolve_initial_connect_retry(&self) -> QwpWsInitialConnectMode {
         if self.initial_connect_retry.is_specified() {
-            return;
+            return *self.initial_connect_retry;
         }
         let any_reconnect_specified = self.reconnect_max_duration.is_specified()
             || self.reconnect_initial_backoff.is_specified()
             || self.reconnect_max_backoff.is_specified();
         if any_reconnect_specified {
-            self.initial_connect_retry = ConfigSetting::Specified(QwpWsInitialConnectMode::Sync);
-            self.initial_connect_retry_promoted = true;
+            QwpWsInitialConnectMode::Sync
+        } else {
+            QwpWsInitialConnectMode::Off
         }
     }
 
@@ -422,19 +416,6 @@ impl QwpWsConfig {
     /// server is reachable; the background runner owns the initial connect.
     pub(crate) fn force_async_initial_connect(&mut self) {
         self.initial_connect_retry = ConfigSetting::Specified(QwpWsInitialConnectMode::Async);
-        self.initial_connect_retry_promoted = false;
-    }
-
-    /// A promoted `initial_connect_retry` is a default in disguise: before an
-    /// explicit setter call, demote it back to `Defaulted` so `set_specified`
-    /// accepts the caller's value whatever it is — including `Off`, which
-    /// would otherwise hit the already-specified conflict arm for a mode the
-    /// user never chose. A no-op unless the current mode was promoted.
-    pub(crate) fn demote_promoted_initial_connect_retry(&mut self) {
-        if self.initial_connect_retry_promoted {
-            self.initial_connect_retry = ConfigSetting::new_default(QwpWsInitialConnectMode::Off);
-            self.initial_connect_retry_promoted = false;
-        }
     }
 }
 

--- a/questdb-rs/src/ingress/conf.rs
+++ b/questdb-rs/src/ingress/conf.rs
@@ -280,6 +280,10 @@ pub(crate) struct QwpWsConfig {
     /// Initial-connect retry mode. Default is fail-fast after one endpoint
     /// round, matching Java's startup behavior.
     pub(crate) initial_connect_retry: ConfigSetting<QwpWsInitialConnectMode>,
+    /// `true` when `initial_connect_retry` was promoted from a `reconnect_*`
+    /// key rather than chosen by the user; pool borrows ignore the promoted
+    /// mode (see `default_async_initial_connect`).
+    pub(crate) initial_connect_retry_promoted: bool,
     /// Bounded wait used by Sender::close_drain().
     pub(crate) close_flush_timeout: ConfigSetting<std::time::Duration>,
     pub(crate) sf_dir: ConfigSetting<Option<PathBuf>>,
@@ -347,6 +351,7 @@ impl Default for QwpWsConfig {
             ),
             reconnect_max_backoff: ConfigSetting::new_default(std::time::Duration::from_secs(5)),
             initial_connect_retry: ConfigSetting::new_default(QwpWsInitialConnectMode::Off),
+            initial_connect_retry_promoted: false,
             close_flush_timeout: ConfigSetting::new_default(QWP_WS_DEFAULT_CLOSE_DRAIN_TIMEOUT),
             sf_dir: ConfigSetting::new_default(None),
             sender_id: ConfigSetting::new_default(QWP_WS_DEFAULT_SENDER_ID.to_owned()),
@@ -408,6 +413,7 @@ impl QwpWsConfig {
             || self.reconnect_max_backoff.is_specified();
         if any_reconnect_specified {
             self.initial_connect_retry = ConfigSetting::Specified(QwpWsInitialConnectMode::Sync);
+            self.initial_connect_retry_promoted = true;
         }
     }
 
@@ -415,6 +421,31 @@ impl QwpWsConfig {
     /// server is reachable; the background runner owns the initial connect.
     pub(crate) fn force_async_initial_connect(&mut self) {
         self.initial_connect_retry = ConfigSetting::Specified(QwpWsInitialConnectMode::Async);
+        self.initial_connect_retry_promoted = false;
+    }
+
+    /// A promoted `initial_connect_retry` is a default in disguise: before an
+    /// explicit setter call, demote it back to `Defaulted` so `set_specified`
+    /// accepts the caller's value whatever it is — including `Off`, which
+    /// would otherwise hit the already-specified conflict arm for a mode the
+    /// user never chose. A no-op unless the current mode was promoted.
+    pub(crate) fn demote_promoted_initial_connect_retry(&mut self) {
+        if self.initial_connect_retry_promoted {
+            self.initial_connect_retry = ConfigSetting::new_default(QwpWsInitialConnectMode::Off);
+            self.initial_connect_retry_promoted = false;
+        }
+    }
+
+    /// Pool-borrow variant of `force_async_initial_connect`: default the
+    /// initial connect to the background runner so a borrow can buffer while
+    /// the server is away, but let a mode the user chose explicitly win. The
+    /// `Sync` promoted from `reconnect_*` keys does not count as explicit —
+    /// the pool's background runner already applies the reconnect budget to
+    /// its initial connect, which is what that promotion exists to ensure.
+    pub(crate) fn default_async_initial_connect(&mut self) {
+        if !self.initial_connect_retry.is_specified() || self.initial_connect_retry_promoted {
+            self.force_async_initial_connect();
+        }
     }
 }
 

--- a/questdb-rs/src/ingress/sender/qwp_ws.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws.rs
@@ -3136,9 +3136,10 @@ pub(crate) fn connect_qwp_ws_background_state(
         // catch-up frame on reconnect); file mode iff the persisted side-file
         // opened (its recovered entries seed the encoder dict + driver mirror so
         // ids continue above them). This branch runs for the standalone
-        // ingress sender and for pool borrows with an explicit non-async
-        // `initial_connect_retry`; the encoder is live only for the
-        // standalone sender and stays dormant for the pooled core.
+        // ingress sender and for pool borrows whose initial connect is not
+        // forced async — any non-lazy pool, including the default Off mode;
+        // the encoder is live only for the standalone sender and stays
+        // dormant for the pooled core.
         // Encoder and mirror enable together to stay in lockstep.
         let delta_dict_enabled = parts.delta_dict_enabled;
         parts.encoder.set_delta_dict_enabled(delta_dict_enabled);

--- a/questdb-rs/src/ingress/sender/qwp_ws.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws.rs
@@ -3135,9 +3135,10 @@ pub(crate) fn connect_qwp_ws_background_state(
         // replayed and the I/O thread re-registers the whole dictionary via a
         // catch-up frame on reconnect); file mode iff the persisted side-file
         // opened (its recovered entries seed the encoder dict + driver mirror so
-        // ids continue above them). This branch runs only for the standalone
-        // ingress sender -- the pooled core forces async connect -- so the
-        // encoder is live here.
+        // ids continue above them). This branch runs for the standalone
+        // ingress sender and for pool borrows with an explicit non-async
+        // `initial_connect_retry`; the encoder is live only for the
+        // standalone sender and stays dormant for the pooled core.
         // Encoder and mirror enable together to stay in lockstep.
         let delta_dict_enabled = parts.delta_dict_enabled;
         parts.encoder.set_delta_dict_enabled(delta_dict_enabled);

--- a/questdb-rs/src/ingress/sender/qwp_ws.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws.rs
@@ -63,7 +63,7 @@ use super::qwp_ws_orphan::{
 };
 use super::qwp_ws_ownership::QwpWsSenderError;
 use super::qwp_ws_publisher::{QwpWsReplayEncoder, qwp_ws_encoded_message_size_error};
-use super::qwp_ws_queue::OutboundFrame;
+use super::qwp_ws_queue::{OutboundFrame, SentFrame};
 use super::qwp_ws_sfa_queue::{
     SfaMemoryQueueOptions, SfaProducer, SfaProgressView, SfaQueueError, segment_payload_capacity,
     two_frame_segment_payload_capacity,
@@ -337,6 +337,7 @@ struct QwpWsPendingConnect {
 
 #[derive(Debug, Clone, Copy)]
 enum RunnerColdEffect {
+    Sent { frame: SentFrame, replayed: bool },
     Event(DriverEvent),
     CompletedThrough { fsn: u64, wire_seq: u64 },
 }
@@ -1020,12 +1021,9 @@ where
         let (frame, send_result) = self.send_core.send_frame(outbound);
         match send_result {
             Ok(send_result) => match self.send_core.finish_send_result_hot(frame, send_result) {
-                Ok(QwpWsHotSendProgress::NoResponse { frame }) => {
+                Ok(QwpWsHotSendProgress::NoResponse { frame, replayed }) => {
                     self.cold_effects
-                        .push_back(RunnerColdEffect::Event(DriverEvent::Sent {
-                            fsn: frame.fsn,
-                            wire_seq: frame.wire_seq,
-                        }));
+                        .push_back(RunnerColdEffect::Sent { frame, replayed });
                     if self.flush_cold_effects(shared) == RunnerStep::Stop {
                         return RunnerStep::Stop;
                     }
@@ -1033,20 +1031,22 @@ where
                     self.backpressure.notify_all();
                     step
                 }
-                Ok(QwpWsHotSendProgress::Response { frame, response }) => {
+                Ok(QwpWsHotSendProgress::Response {
+                    frame,
+                    replayed,
+                    response,
+                }) => {
                     self.cold_effects
-                        .push_back(RunnerColdEffect::Event(DriverEvent::Sent {
-                            fsn: frame.fsn,
-                            wire_seq: frame.wire_seq,
-                        }));
+                        .push_back(RunnerColdEffect::Sent { frame, replayed });
                     self.finish_response(shared, stop, response)
                 }
-                Ok(QwpWsHotSendProgress::TransportFailure { frame, failure }) => {
+                Ok(QwpWsHotSendProgress::TransportFailure {
+                    frame,
+                    replayed,
+                    failure,
+                }) => {
                     self.cold_effects
-                        .push_back(RunnerColdEffect::Event(DriverEvent::Sent {
-                            fsn: frame.fsn,
-                            wire_seq: frame.wire_seq,
-                        }));
+                        .push_back(RunnerColdEffect::Sent { frame, replayed });
                     if self.flush_cold_effects(shared) == RunnerStep::Stop {
                         return RunnerStep::Stop;
                     }
@@ -1484,6 +1484,9 @@ where
     {
         while let Some(effect) = self.cold_effects.pop_front() {
             match effect {
+                RunnerColdEffect::Sent { frame, replayed } => {
+                    store.record_sent_event(frame, replayed);
+                }
                 RunnerColdEffect::Event(event) => store.record_driver_event(event),
                 RunnerColdEffect::CompletedThrough { fsn, wire_seq } => {
                     store.record_completed_through_event(fsn, wire_seq);
@@ -5368,6 +5371,17 @@ mod tests {
         reconnect_started_rx
             .recv_timeout(Duration::from_secs(5))
             .unwrap();
+
+        // The sent event is flushed before reconnect I/O starts. Pin the
+        // background-runner counter path while reconnect is deliberately
+        // blocked so no replay can race this assertion.
+        {
+            let store = runner.lock_shared().unwrap();
+            let counters = store.counters();
+            assert_eq!(counters.total_frames_sent, 1);
+            assert_eq!(counters.total_frames_replayed, 0);
+        }
+
         release_reconnect_tx.send(()).unwrap();
 
         let events = {

--- a/questdb-rs/src/ingress/sender/qwp_ws_driver.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws_driver.rs
@@ -200,13 +200,16 @@ pub(crate) enum QwpWsSendProgress {
 pub(crate) enum QwpWsHotSendProgress {
     NoResponse {
         frame: SentFrame,
+        replayed: bool,
     },
     Response {
         frame: SentFrame,
+        replayed: bool,
         response: TransportResponse,
     },
     TransportFailure {
         frame: SentFrame,
+        replayed: bool,
         failure: TransportFailure,
     },
 }
@@ -409,6 +412,7 @@ impl PublicationLifecycle {
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct QwpWsCounters {
     pub total_frames_sent: u64,
+    pub total_frames_replayed: u64,
     pub total_acks: u64,
     pub total_reconnect_attempts: u64,
     pub total_reconnects_succeeded: u64,
@@ -419,6 +423,7 @@ impl From<QwpWsCounters> for super::qwp_ws_ownership::QwpWsTotals {
     fn from(counters: QwpWsCounters) -> Self {
         Self {
             frames_sent: counters.total_frames_sent,
+            frames_replayed: counters.total_frames_replayed,
             acks: counters.total_acks,
             reconnect_attempts: counters.total_reconnect_attempts,
             reconnects_succeeded: counters.total_reconnects_succeeded,
@@ -504,13 +509,16 @@ impl<Q: PublicationLog> QwpWsPublicationStore<Q> {
         send_cursor: &mut SendCursor,
         frame: SentFrame,
     ) -> Result<(), DriverError> {
-        send_cursor.commit_sent(frame)?;
-        self.record_sent_event(frame);
+        let replayed = send_cursor.commit_sent(frame)?;
+        self.record_sent_event(frame, replayed);
         Ok(())
     }
 
-    pub(crate) fn record_sent_event(&mut self, frame: SentFrame) {
+    pub(crate) fn record_sent_event(&mut self, frame: SentFrame, replayed: bool) {
         self.counters.total_frames_sent += 1;
+        if replayed {
+            self.counters.total_frames_replayed += 1;
+        }
         self.push_event(DriverEvent::Sent {
             fsn: frame.fsn,
             wire_seq: frame.wire_seq,
@@ -1455,17 +1463,25 @@ impl<T: QwpWsCoreTransport> QwpWsSendCore<T> {
         send_result: TransportSendResult,
     ) -> Result<QwpWsSendProgress, DriverError> {
         match self.finish_send_result_hot(frame, send_result)? {
-            QwpWsHotSendProgress::NoResponse { frame } => {
-                store.record_sent_event(frame);
+            QwpWsHotSendProgress::NoResponse { frame, replayed } => {
+                store.record_sent_event(frame, replayed);
                 Ok(QwpWsSendProgress::Outcome(DriveOutcome::Sent(frame)))
             }
-            QwpWsHotSendProgress::Response { frame, response } => {
-                store.record_sent_event(frame);
+            QwpWsHotSendProgress::Response {
+                frame,
+                replayed,
+                response,
+            } => {
+                store.record_sent_event(frame, replayed);
                 self.apply_response(store, response, false)
                     .map(QwpWsSendProgress::Outcome)
             }
-            QwpWsHotSendProgress::TransportFailure { frame, failure } => {
-                store.record_sent_event(frame);
+            QwpWsHotSendProgress::TransportFailure {
+                frame,
+                replayed,
+                failure,
+            } => {
+                store.record_sent_event(frame, replayed);
                 Ok(QwpWsSendProgress::TransportFailure(failure))
             }
         }
@@ -1476,15 +1492,21 @@ impl<T: QwpWsCoreTransport> QwpWsSendCore<T> {
         frame: SentFrame,
         send_result: TransportSendResult,
     ) -> Result<QwpWsHotSendProgress, DriverError> {
-        self.send_cursor.commit_sent(frame)?;
+        let replayed = self.send_cursor.commit_sent(frame)?;
         match send_result {
-            TransportSendResult::NoResponse => Ok(QwpWsHotSendProgress::NoResponse { frame }),
-            TransportSendResult::Response(response) => {
-                Ok(QwpWsHotSendProgress::Response { frame, response })
+            TransportSendResult::NoResponse => {
+                Ok(QwpWsHotSendProgress::NoResponse { frame, replayed })
             }
-            TransportSendResult::Failure(failure) => {
-                Ok(QwpWsHotSendProgress::TransportFailure { frame, failure })
-            }
+            TransportSendResult::Response(response) => Ok(QwpWsHotSendProgress::Response {
+                frame,
+                replayed,
+                response,
+            }),
+            TransportSendResult::Failure(failure) => Ok(QwpWsHotSendProgress::TransportFailure {
+                frame,
+                replayed,
+                failure,
+            }),
         }
     }
 
@@ -2669,6 +2691,10 @@ pub(crate) struct SendCursor {
     max_in_flight: usize,
     fsn_at_zero: Option<u64>,
     next_fsn: Option<u64>,
+    /// Inclusive publication boundary captured at the last successful
+    /// reconnect. Frames through this FSN are replayed; frames published after
+    /// the reconnect are ordinary sends. `None` on the initial connection.
+    replay_target_fsn: Option<u64>,
     next_wire_seq: u64,
     /// Number of out-of-band symbol-dict catch-up frames prepended on the
     /// current connection. They occupy wire seqs `[0, catch_up_offset)`; real
@@ -2687,6 +2713,7 @@ impl SendCursor {
             max_in_flight,
             fsn_at_zero: None,
             next_fsn: None,
+            replay_target_fsn: None,
             next_wire_seq: 0,
             catch_up_offset: 0,
             last_sent_wire_seq: None,
@@ -2722,7 +2749,9 @@ impl SendCursor {
         Ok(Some((fsn, self.next_wire_seq)))
     }
 
-    fn commit_sent(&mut self, frame: SentFrame) -> Result<(), DriverError> {
+    /// Commits a successfully handed-off frame and reports whether it belongs
+    /// to the replay window armed by [`Self::restart`].
+    fn commit_sent(&mut self, frame: SentFrame) -> Result<bool, DriverError> {
         if self.in_flight.len() >= self.max_in_flight {
             return Err(DriverError::Queue(QueueError::MaxInFlightReached {
                 max_in_flight: self.max_in_flight,
@@ -2734,6 +2763,9 @@ impl SendCursor {
                 wire_seq: frame.wire_seq,
             }));
         }
+        let replayed = self
+            .replay_target_fsn
+            .is_some_and(|target_fsn| frame.fsn <= target_fsn);
 
         self.next_fsn = Some(
             frame
@@ -2747,7 +2779,13 @@ impl SendCursor {
             .ok_or(DriverError::Queue(QueueError::SequenceOverflow))?;
         self.last_sent_wire_seq = Some(frame.wire_seq);
         self.in_flight.push_back(frame);
-        Ok(())
+        if self
+            .replay_target_fsn
+            .is_some_and(|target_fsn| frame.fsn >= target_fsn)
+        {
+            self.replay_target_fsn = None;
+        }
+        Ok(replayed)
     }
 
     fn reject_fsn_for_wire_seq(&self, wire_seq: u64) -> Result<Option<(u64, u64)>, DriverError> {
@@ -2801,6 +2839,12 @@ impl SendCursor {
         self.in_flight.clear();
         self.fsn_at_zero = log.oldest_unresolved_fsn();
         self.next_fsn = self.fsn_at_zero;
+        self.replay_target_fsn = match (self.fsn_at_zero, log.published_fsn()) {
+            (Some(oldest_unresolved), Some(published)) if oldest_unresolved <= published => {
+                Some(published)
+            }
+            _ => None,
+        };
         self.next_wire_seq = 0;
         self.catch_up_offset = 0;
         self.last_sent_wire_seq = None;
@@ -4128,6 +4172,68 @@ mod tests {
         assert_eq!(payloads.len(), 2, "catch-up frame precedes the replay");
         assert_catch_up_frame(&payloads[0], &[b"a", b"b"]);
         assert_eq!(payloads[1], frame, "the stored frame replays verbatim");
+
+        let counters = driver.counters();
+        assert_eq!(counters.total_frames_sent, 1);
+        assert_eq!(
+            counters.total_frames_replayed, 0,
+            "initial recovery sends are not post-reconnect replays"
+        );
+    }
+
+    #[test]
+    fn replay_totals_use_the_reconnect_time_publication_boundary() {
+        let mut driver = driver(FakeOrderedServer::no_response());
+
+        // Frame 0 is sent on the initial connection. Frame 1 is published but
+        // still unsent when the reconnect succeeds. Both are inside the
+        // reconnect-time publication snapshot, but only their post-reconnect
+        // sends count as replay.
+        driver.try_submit(b"sent-before-reconnect").unwrap();
+        driver.drive_send_once().unwrap();
+        driver.try_submit(b"published-before-reconnect").unwrap();
+
+        let counters = driver.counters();
+        assert_eq!(counters.total_frames_sent, 1);
+        assert_eq!(counters.total_frames_replayed, 0);
+
+        assert_eq!(
+            driver
+                .send_core
+                .finish_reconnect_success(&mut driver.store, ReconnectReason::Disconnect),
+            DriveOutcome::Reconnected {
+                reason: ReconnectReason::Disconnect
+            }
+        );
+        driver.drive_send_once().unwrap();
+        driver.drive_send_once().unwrap();
+
+        // Frame 2 is published after the reconnect snapshot. Its first send is
+        // not replay even though older frames on this connection were.
+        driver.try_submit(b"published-after-reconnect").unwrap();
+        driver.drive_send_once().unwrap();
+
+        let counters = driver.counters();
+        assert_eq!(counters.total_frames_sent, 4);
+        assert_eq!(counters.total_frames_replayed, 2);
+
+        // With no ACKs, the next reconnect snapshots all three frames. Sending
+        // them again is three more actual replay attempts.
+        assert_eq!(
+            driver
+                .send_core
+                .finish_reconnect_success(&mut driver.store, ReconnectReason::Disconnect),
+            DriveOutcome::Reconnected {
+                reason: ReconnectReason::Disconnect
+            }
+        );
+        driver.drive_send_once().unwrap();
+        driver.drive_send_once().unwrap();
+        driver.drive_send_once().unwrap();
+
+        let counters = driver.counters();
+        assert_eq!(counters.total_frames_sent, 7);
+        assert_eq!(counters.total_frames_replayed, 5);
     }
 
     #[test]

--- a/questdb-rs/src/ingress/sender/qwp_ws_ownership.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws_ownership.rs
@@ -154,6 +154,11 @@ pub struct QwpWsTotals {
     /// Frames handed to the transport for writing, regardless of whether the
     /// server has acknowledged them.
     pub frames_sent: u64,
+    /// Frames handed to the transport while catching up through the
+    /// publication boundary captured at a successful reconnect. Initial
+    /// publication, including recovered store-and-forward frames sent on the
+    /// first connection, is not counted as replay.
+    pub frames_replayed: u64,
     /// Server responses interpreted as ACKs: ordinary OK, DurableOk, and
     /// stand-alone DurableAck position notifications.
     pub acks: u64,

--- a/questdb-rs/src/ingress/tests.rs
+++ b/questdb-rs/src/ingress/tests.rs
@@ -1592,6 +1592,72 @@ fn qwpws_apply_reconnect_implies_initial_retry_is_idempotent() {
 
 #[cfg(feature = "sync-sender-qwp-ws")]
 #[test]
+fn qwpws_promoted_sync_defaults_back_to_async_for_pool_borrows() {
+    // Pool borrows ignore the promoted mode: the background runner already
+    // applies the reconnect budget to its initial connect.
+    let builder =
+        SenderBuilder::from_conf("ws::addr=localhost:9000;reconnect_max_duration_millis=120000;")
+            .unwrap();
+    let mut qwp_ws = builder.qwp_ws.as_ref().unwrap().clone();
+    qwp_ws.default_async_initial_connect();
+    assert_specified_eq(
+        &qwp_ws.initial_connect_retry,
+        conf::QwpWsInitialConnectMode::Async,
+    );
+}
+
+#[cfg(feature = "sync-sender-qwp-ws")]
+#[test]
+fn qwpws_explicit_sync_after_promotion_stays_explicit_for_pool_borrows() {
+    // from_conf promotes Sync from the reconnect key; the explicit builder
+    // call demotes the promoted mode back to a default and re-specifies the
+    // same value. The choice is explicit now, so the pool-borrow defaulting
+    // must keep Sync instead of treating it as promoted and reverting to the
+    // background connect.
+    let builder =
+        SenderBuilder::from_conf("ws::addr=localhost:9000;reconnect_max_duration_millis=120000;")
+            .unwrap()
+            .initial_connect_retry(true)
+            .unwrap();
+    let mut qwp_ws = builder.qwp_ws.as_ref().unwrap().clone();
+    qwp_ws.default_async_initial_connect();
+    assert_specified_eq(
+        &qwp_ws.initial_connect_retry,
+        conf::QwpWsInitialConnectMode::Sync,
+    );
+}
+
+#[cfg(feature = "sync-sender-qwp-ws")]
+#[test]
+fn qwpws_explicit_off_after_promotion_overrides_promoted_sync() {
+    // The promoted Sync is a default in disguise: an explicit Off must
+    // replace it instead of dying in set_specified's conflict arm for a
+    // mode the user never chose, and the build-time promotion re-run must
+    // not resurrect Sync over it.
+    let builder =
+        SenderBuilder::from_conf("ws::addr=localhost:9000;reconnect_max_duration_millis=120000;")
+            .unwrap()
+            .initial_connect_retry(false)
+            .expect("explicit off must override the promoted sync");
+    let mut qwp_ws = builder.qwp_ws.as_ref().unwrap().clone();
+    assert_specified_eq(
+        &qwp_ws.initial_connect_retry,
+        conf::QwpWsInitialConnectMode::Off,
+    );
+    qwp_ws.apply_reconnect_implies_initial_retry();
+    assert_specified_eq(
+        &qwp_ws.initial_connect_retry,
+        conf::QwpWsInitialConnectMode::Off,
+    );
+    qwp_ws.default_async_initial_connect();
+    assert_specified_eq(
+        &qwp_ws.initial_connect_retry,
+        conf::QwpWsInitialConnectMode::Off,
+    );
+}
+
+#[cfg(feature = "sync-sender-qwp-ws")]
+#[test]
 fn qwpws_apply_reconnect_implies_initial_retry_no_op_without_reconnect_keys() {
     // Defaults only: no reconnect_* key was specified, so the promotion
     // is a no-op and `initial_connect_retry` stays `Defaulted(Off)`.

--- a/questdb-rs/src/ingress/tests.rs
+++ b/questdb-rs/src/ingress/tests.rs
@@ -1592,35 +1592,17 @@ fn qwpws_apply_reconnect_implies_initial_retry_is_idempotent() {
 
 #[cfg(feature = "sync-sender-qwp-ws")]
 #[test]
-fn qwpws_promoted_sync_defaults_back_to_async_for_pool_borrows() {
-    // Pool borrows ignore the promoted mode: the background runner already
-    // applies the reconnect budget to its initial connect.
-    let builder =
-        SenderBuilder::from_conf("ws::addr=localhost:9000;reconnect_max_duration_millis=120000;")
-            .unwrap();
-    let mut qwp_ws = builder.qwp_ws.as_ref().unwrap().clone();
-    qwp_ws.default_async_initial_connect();
-    assert_specified_eq(
-        &qwp_ws.initial_connect_retry,
-        conf::QwpWsInitialConnectMode::Async,
-    );
-}
-
-#[cfg(feature = "sync-sender-qwp-ws")]
-#[test]
-fn qwpws_explicit_sync_after_promotion_stays_explicit_for_pool_borrows() {
+fn qwpws_explicit_sync_after_promotion_stays_explicit() {
     // from_conf promotes Sync from the reconnect key; the explicit builder
     // call demotes the promoted mode back to a default and re-specifies the
-    // same value. The choice is explicit now, so the pool-borrow defaulting
-    // must keep Sync instead of treating it as promoted and reverting to the
-    // background connect.
+    // same value instead of erroring, leaving an explicit (unpromoted) Sync.
     let builder =
         SenderBuilder::from_conf("ws::addr=localhost:9000;reconnect_max_duration_millis=120000;")
             .unwrap()
             .initial_connect_retry(true)
             .unwrap();
-    let mut qwp_ws = builder.qwp_ws.as_ref().unwrap().clone();
-    qwp_ws.default_async_initial_connect();
+    let qwp_ws = builder.qwp_ws.as_ref().unwrap();
+    assert!(!qwp_ws.initial_connect_retry_promoted);
     assert_specified_eq(
         &qwp_ws.initial_connect_retry,
         conf::QwpWsInitialConnectMode::Sync,
@@ -1645,11 +1627,6 @@ fn qwpws_explicit_off_after_promotion_overrides_promoted_sync() {
         conf::QwpWsInitialConnectMode::Off,
     );
     qwp_ws.apply_reconnect_implies_initial_retry();
-    assert_specified_eq(
-        &qwp_ws.initial_connect_retry,
-        conf::QwpWsInitialConnectMode::Off,
-    );
-    qwp_ws.default_async_initial_connect();
     assert_specified_eq(
         &qwp_ws.initial_connect_retry,
         conf::QwpWsInitialConnectMode::Off,

--- a/questdb-rs/src/ingress/tests.rs
+++ b/questdb-rs/src/ingress/tests.rs
@@ -1391,10 +1391,11 @@ fn auto_flush_interval_unsupported() {
 // silently ignored on the *initial* connect because `initial_connect_retry`
 // defaulted to `off`. A user setting `reconnect_max_duration_millis=120000`
 // expecting it to cover startup races against an unhealthy server got one
-// shot at the WS upgrade and no retry. `apply_reconnect_implies_initial_retry`
-// (called from `from_conf` and `build`) closes this footgun by promoting
-// `initial_connect_retry` to `Sync` whenever any `reconnect_*` key is
-// explicitly set and the user has not picked a mode themselves.
+// shot at the WS upgrade and no retry. `SenderBuilder::build()` closes this
+// footgun by resolving an effective `Sync` mode whenever any `reconnect_*`
+// key is explicitly set and the user has not picked a mode themselves.
+// Parsing retains that distinction so pool connector builds see only explicit
+// `initial_connect_retry` choices.
 
 #[cfg(feature = "sync-sender-qwp-ws")]
 #[test]
@@ -1404,6 +1405,10 @@ fn qwpws_defaults_leave_initial_connect_retry_off() {
     assert_defaulted_eq(
         &qwp_ws.initial_connect_retry,
         conf::QwpWsInitialConnectMode::Off,
+    );
+    assert_eq!(
+        qwp_ws.resolve_initial_connect_retry(),
+        conf::QwpWsInitialConnectMode::Off
     );
 }
 
@@ -1439,8 +1444,12 @@ fn qwpws_reconnect_max_duration_implies_initial_connect_retry_sync() {
         SenderBuilder::from_conf("ws::addr=localhost:9000;reconnect_max_duration_millis=120000;")
             .unwrap();
     let qwp_ws = builder.qwp_ws.as_ref().unwrap();
-    assert_specified_eq(
+    assert_defaulted_eq(
         &qwp_ws.initial_connect_retry,
+        conf::QwpWsInitialConnectMode::Off,
+    );
+    assert_eq!(
+        qwp_ws.resolve_initial_connect_retry(),
         conf::QwpWsInitialConnectMode::Sync,
     );
     assert_specified_eq(&qwp_ws.reconnect_max_duration, Duration::from_secs(120));
@@ -1453,8 +1462,8 @@ fn qwpws_reconnect_initial_backoff_implies_initial_connect_retry_sync() {
         SenderBuilder::from_conf("ws::addr=localhost:9000;reconnect_initial_backoff_millis=250;")
             .unwrap();
     let qwp_ws = builder.qwp_ws.as_ref().unwrap();
-    assert_specified_eq(
-        &qwp_ws.initial_connect_retry,
+    assert_eq!(
+        qwp_ws.resolve_initial_connect_retry(),
         conf::QwpWsInitialConnectMode::Sync,
     );
 }
@@ -1466,8 +1475,8 @@ fn qwpws_reconnect_max_backoff_implies_initial_connect_retry_sync() {
         SenderBuilder::from_conf("ws::addr=localhost:9000;reconnect_max_backoff_millis=10000;")
             .unwrap();
     let qwp_ws = builder.qwp_ws.as_ref().unwrap();
-    assert_specified_eq(
-        &qwp_ws.initial_connect_retry,
+    assert_eq!(
+        qwp_ws.resolve_initial_connect_retry(),
         conf::QwpWsInitialConnectMode::Sync,
     );
 }
@@ -1486,6 +1495,10 @@ fn qwpws_explicit_initial_connect_retry_off_is_preserved() {
         &qwp_ws.initial_connect_retry,
         conf::QwpWsInitialConnectMode::Off,
     );
+    assert_eq!(
+        qwp_ws.resolve_initial_connect_retry(),
+        conf::QwpWsInitialConnectMode::Off,
+    );
 }
 
 #[cfg(feature = "sync-sender-qwp-ws")]
@@ -1500,15 +1513,19 @@ fn qwpws_explicit_initial_connect_retry_async_is_preserved() {
         &qwp_ws.initial_connect_retry,
         conf::QwpWsInitialConnectMode::Async,
     );
+    assert_eq!(
+        qwp_ws.resolve_initial_connect_retry(),
+        conf::QwpWsInitialConnectMode::Async,
+    );
 }
 
 #[cfg(feature = "sync-sender-qwp-ws")]
 #[test]
 fn qwpws_explicit_off_before_reconnect_key_is_preserved() {
     // Reversed key order from `qwpws_explicit_initial_connect_retry_off_is_preserved`:
-    // the override is set first, then the reconnect budget. The promotion
-    // runs after the parse loop, so the explicit `off` must still win
-    // regardless of where it appeared in the conf string.
+    // the override is set first, then the reconnect budget. Build-time
+    // resolution must preserve the explicit `off` regardless of where it
+    // appeared in the conf string.
     let builder = SenderBuilder::from_conf(
         "ws::addr=localhost:9000;initial_connect_retry=off;reconnect_max_duration_millis=120000;",
     )
@@ -1516,6 +1533,10 @@ fn qwpws_explicit_off_before_reconnect_key_is_preserved() {
     let qwp_ws = builder.qwp_ws.as_ref().unwrap();
     assert_specified_eq(
         &qwp_ws.initial_connect_retry,
+        conf::QwpWsInitialConnectMode::Off,
+    );
+    assert_eq!(
+        qwp_ws.resolve_initial_connect_retry(),
         conf::QwpWsInitialConnectMode::Off,
     );
 }
@@ -1533,8 +1554,8 @@ fn qwpws_multiple_reconnect_keys_promote_once() {
     )
     .unwrap();
     let qwp_ws = builder.qwp_ws.as_ref().unwrap();
-    assert_specified_eq(
-        &qwp_ws.initial_connect_retry,
+    assert_eq!(
+        qwp_ws.resolve_initial_connect_retry(),
         conf::QwpWsInitialConnectMode::Sync,
     );
     assert_specified_eq(&qwp_ws.reconnect_max_duration, Duration::from_secs(120));
@@ -1548,44 +1569,19 @@ fn qwpws_multiple_reconnect_keys_promote_once() {
 #[cfg(feature = "sync-sender-qwp-ws")]
 #[test]
 fn qwpws_reconnect_implies_initial_retry_via_builder_api() {
-    // The builder API reaches `build()` without going through `from_conf`,
-    // so the promotion must also fire from there. We can't observe
-    // `build()`'s local QwpWsConfig clone directly, but the helper that
-    // implements the invariant is `pub(crate)`, so exercise it on the
-    // same `QwpWsConfig` the builder would feed in.
+    // The builder API reaches `build()` without going through `from_conf`;
+    // its unresolved config must carry enough state for the same build-time
+    // effective-mode calculation.
     let builder = SenderBuilder::new(Protocol::Ws, "localhost", 9000)
         .reconnect_max_duration(Duration::from_secs(120))
         .unwrap();
-    let mut qwp_ws = builder.qwp_ws.as_ref().unwrap().clone();
-    // Before the promotion runs (mirrors the builder-state-at-build-time):
+    let qwp_ws = builder.qwp_ws.as_ref().unwrap();
     assert_defaulted_eq(
         &qwp_ws.initial_connect_retry,
         conf::QwpWsInitialConnectMode::Off,
     );
-    qwp_ws.apply_reconnect_implies_initial_retry();
-    assert_specified_eq(
-        &qwp_ws.initial_connect_retry,
-        conf::QwpWsInitialConnectMode::Sync,
-    );
-}
-
-#[cfg(feature = "sync-sender-qwp-ws")]
-#[test]
-fn qwpws_apply_reconnect_implies_initial_retry_is_idempotent() {
-    // `from_conf` already runs the promotion at parse time; `build()`
-    // then runs it again on a clone. The second run must be a no-op
-    // when the first has already settled the value.
-    let builder =
-        SenderBuilder::from_conf("ws::addr=localhost:9000;reconnect_max_duration_millis=120000;")
-            .unwrap();
-    let mut qwp_ws = builder.qwp_ws.as_ref().unwrap().clone();
-    assert_specified_eq(
-        &qwp_ws.initial_connect_retry,
-        conf::QwpWsInitialConnectMode::Sync,
-    );
-    qwp_ws.apply_reconnect_implies_initial_retry();
-    assert_specified_eq(
-        &qwp_ws.initial_connect_retry,
+    assert_eq!(
+        qwp_ws.resolve_initial_connect_retry(),
         conf::QwpWsInitialConnectMode::Sync,
     );
 }
@@ -1593,18 +1589,20 @@ fn qwpws_apply_reconnect_implies_initial_retry_is_idempotent() {
 #[cfg(feature = "sync-sender-qwp-ws")]
 #[test]
 fn qwpws_explicit_sync_after_promotion_stays_explicit() {
-    // from_conf promotes Sync from the reconnect key; the explicit builder
-    // call demotes the promoted mode back to a default and re-specifies the
-    // same value instead of erroring, leaving an explicit (unpromoted) Sync.
+    // `from_conf` leaves the reconnect-implied mode unresolved, so the
+    // explicit builder call cannot collide with a value the user never chose.
     let builder =
         SenderBuilder::from_conf("ws::addr=localhost:9000;reconnect_max_duration_millis=120000;")
             .unwrap()
             .initial_connect_retry(true)
             .unwrap();
     let qwp_ws = builder.qwp_ws.as_ref().unwrap();
-    assert!(!qwp_ws.initial_connect_retry_promoted);
     assert_specified_eq(
         &qwp_ws.initial_connect_retry,
+        conf::QwpWsInitialConnectMode::Sync,
+    );
+    assert_eq!(
+        qwp_ws.resolve_initial_connect_retry(),
         conf::QwpWsInitialConnectMode::Sync,
     );
 }
@@ -1612,36 +1610,34 @@ fn qwpws_explicit_sync_after_promotion_stays_explicit() {
 #[cfg(feature = "sync-sender-qwp-ws")]
 #[test]
 fn qwpws_explicit_off_after_promotion_overrides_promoted_sync() {
-    // The promoted Sync is a default in disguise: an explicit Off must
-    // replace it instead of dying in set_specified's conflict arm for a
-    // mode the user never chose, and the build-time promotion re-run must
-    // not resurrect Sync over it.
+    // The reconnect-implied Sync is resolved only at build time, so an
+    // explicit Off setter succeeds and wins unconditionally.
     let builder =
         SenderBuilder::from_conf("ws::addr=localhost:9000;reconnect_max_duration_millis=120000;")
             .unwrap()
             .initial_connect_retry(false)
-            .expect("explicit off must override the promoted sync");
-    let mut qwp_ws = builder.qwp_ws.as_ref().unwrap().clone();
+            .expect("explicit off must not collide with a build-time default");
+    let qwp_ws = builder.qwp_ws.as_ref().unwrap();
     assert_specified_eq(
         &qwp_ws.initial_connect_retry,
         conf::QwpWsInitialConnectMode::Off,
     );
-    qwp_ws.apply_reconnect_implies_initial_retry();
-    assert_specified_eq(
-        &qwp_ws.initial_connect_retry,
+    assert_eq!(
+        qwp_ws.resolve_initial_connect_retry(),
         conf::QwpWsInitialConnectMode::Off,
     );
 }
 
 #[cfg(feature = "sync-sender-qwp-ws")]
 #[test]
-fn qwpws_apply_reconnect_implies_initial_retry_no_op_without_reconnect_keys() {
-    // Defaults only: no reconnect_* key was specified, so the promotion
-    // is a no-op and `initial_connect_retry` stays `Defaulted(Off)`.
-    let mut qwp_ws = conf::QwpWsConfig::default();
-    qwp_ws.apply_reconnect_implies_initial_retry();
+fn qwpws_resolves_initial_connect_retry_off_without_reconnect_keys() {
+    let qwp_ws = conf::QwpWsConfig::default();
     assert_defaulted_eq(
         &qwp_ws.initial_connect_retry,
+        conf::QwpWsInitialConnectMode::Off,
+    );
+    assert_eq!(
+        qwp_ws.resolve_initial_connect_retry(),
         conf::QwpWsInitialConnectMode::Off,
     );
 }

--- a/questdb-rs/src/tests/qwp_sender_pool.rs
+++ b/questdb-rs/src/tests/qwp_sender_pool.rs
@@ -855,6 +855,91 @@ fn at_cap_borrow_fails_fast_with_zero_acquire_timeout() {
 }
 
 #[test]
+fn borrow_honors_explicit_initial_connect_retry_off() {
+    let conf = conf_for_endpoints(
+        &[unused_local_port()],
+        "initial_connect_retry=off;sender_pool_max=1;acquire_timeout_ms=0;",
+    );
+    let db = QuestDb::connect(&conf).unwrap();
+    let start = std::time::Instant::now();
+    db.borrow_sender()
+        .expect_err("initial_connect_retry=off must connect at borrow and fail fast");
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(2),
+        "off is one connection round, not a retry budget"
+    );
+
+    // The failed eager connect must roll back its pool slot: with
+    // sender_pool_max=1 and fail-fast acquisition, a leaked slot would turn
+    // the second borrow into a pool-exhausted InvalidApiCall instead of
+    // another connect failure.
+    let second = db
+        .borrow_sender()
+        .expect_err("second borrow retries the connect");
+    assert_ne!(
+        second.code(),
+        ErrorCode::InvalidApiCall,
+        "a failed sync borrow must not leak its pool slot: {}",
+        second.msg()
+    );
+}
+
+#[test]
+fn borrow_honors_explicit_initial_connect_retry_sync() {
+    let (server, frames) = MockServer::spawn_acking_capturing(1);
+    let conf = conf_for_endpoints(&[server.port()], "initial_connect_retry=sync;");
+    let db = QuestDb::connect(&conf).unwrap();
+    let mut sender = db.borrow_sender().expect("sync initial connect");
+    assert_eq!(
+        server.accepted(),
+        1,
+        "sync mode must have connected before the borrow returned"
+    );
+
+    // The sync mode routes the pooled core through the eager-connect branch
+    // of connect_qwp_ws_background_state, previously reachable only by the
+    // standalone sender. Prove data (including a symbol, so the delta-dict
+    // wiring of that branch is exercised) flows end to end on it.
+    let mut buf = sender.new_buffer();
+    buf.table("sync_trades")
+        .unwrap()
+        .symbol("symbol", "ETH-USDT")
+        .unwrap()
+        .column_f64("price", 2615.54)
+        .unwrap()
+        .at(TimestampNanos::now())
+        .unwrap();
+    sender
+        .flush_buffer_and_wait(&mut buf, AckLevel::Ok)
+        .expect("flush over the sync-connected pooled core");
+    let payload = frames
+        .recv_timeout(Duration::from_secs(5))
+        .expect("server must receive the frame");
+    assert_eq!(frame_table_name(&payload), "sync_trades");
+    assert_eq!(frame_row_count(&payload), 1);
+    assert_eq!(
+        read_symbol_prefix(&payload),
+        (0, vec![b"ETH-USDT".to_vec()]),
+        "the eager-connect branch must seed the delta dict from zero and \
+         register the symbol exactly once"
+    );
+}
+
+#[test]
+fn borrow_ignores_reconnect_promoted_sync_and_buffers_offline() {
+    // `conf_for_endpoints` sets `reconnect_max_duration_millis`, which
+    // promotes `initial_connect_retry=sync` for the standalone sender. Pool
+    // borrows must ignore the promoted mode: the background runner already
+    // applies the reconnect budget to its initial connect, and a borrow must
+    // keep working while the server is away.
+    let conf = conf_for_endpoints(&[unused_local_port()], "");
+    let db = QuestDb::connect(&conf).unwrap();
+    let _sender = db
+        .borrow_sender()
+        .expect("default pool borrow buffers while the server is away");
+}
+
+#[test]
 fn disk_store_and_forward_ingress_pool_uses_distinct_slots_up_to_pool_max() {
     let server = MockServer::spawn(4);
     let dir = TempDir::new().unwrap();

--- a/questdb-rs/src/tests/qwp_sender_pool.rs
+++ b/questdb-rs/src/tests/qwp_sender_pool.rs
@@ -1054,22 +1054,22 @@ fn eager_connect_adopts_dirty_slot_and_replays_on_live_server() {
 }
 
 #[test]
-fn eager_sync_with_reader_prewarm_is_a_config_conflict() {
-    // Explicit sync retries ingest pre-opens, but readers have no retry
-    // mode; refusing the combination keeps "retry my startup" from being a
-    // half-truth.
-    let err = QuestDb::connect("ws::addr=localhost:9000;initial_connect_retry=sync;")
-        .expect_err("sync with the default reader prewarm must conflict");
-    assert_eq!(err.code(), ErrorCode::ConfigError);
-    assert!(err.msg().contains("query_pool_min"), "{}", err.msg());
-
-    // sync with a lazy read pool is accepted; nothing prewarms here.
-    QuestDb::connect(&format!(
-        "ws::addr=127.0.0.1:{};initial_connect_retry=sync;\
-         sender_pool_min=0;query_pool_min=0;",
-        unused_local_port()
-    ))
-    .expect("sync with query_pool_min=0 must be accepted");
+fn eager_connect_with_sync_mode_still_fails_fast_on_reader_prewarm() {
+    // Java permits this combination: sync governs ingest only, while readers
+    // always connect fail-fast. Skip ingest prewarm so the down reader is the
+    // observed failure; the long reconnect budget must not delay it.
+    let conf = eager_conf(
+        &[unused_local_port()],
+        "initial_connect_retry=sync;reconnect_max_duration_millis=6000;\
+         sender_pool_min=0;query_pool_min=1;",
+    );
+    let start = std::time::Instant::now();
+    let err = QuestDb::connect(&conf).expect_err("reader prewarm must fail fast");
+    assert_ne!(err.code(), ErrorCode::ConfigError, "{}", err.msg());
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(2),
+        "reader prewarm has no retry budget"
+    );
 }
 
 #[test]

--- a/questdb-rs/src/tests/qwp_sender_pool.rs
+++ b/questdb-rs/src/tests/qwp_sender_pool.rs
@@ -1739,6 +1739,85 @@ fn disk_store_and_forward_restart_replays_reminted_and_out_of_range_managed_slot
 }
 
 #[test]
+fn disk_store_and_forward_growth_uses_connect_time_recovery_snapshot() {
+    let dir = TempDir::new().unwrap();
+    let seed_port = unused_local_port();
+    let seed_conf = format!(
+        "ws::addr=127.0.0.1:{seed_port};lazy_connect=true;auth_timeout=200;\
+         reconnect_max_duration_millis=100;sf_dir={};sender_id=snapshot;\
+         sender_pool_min=0;query_pool_min=0;sender_pool_max=3;pool_reap=manual;\
+         close_flush_timeout_millis=0;",
+        dir.path().display()
+    );
+    {
+        let db = QuestDb::connect(&seed_conf).unwrap();
+        let _s0 = db.borrow_sender().expect("reserve seed slot 0");
+        let mut s1 = db.borrow_sender().expect("seed snapshot slot 1");
+        let mut s2 = db.borrow_sender().expect("seed late slot 2");
+
+        let snapshot_value = [101_i64];
+        let snapshot_ts = [101_i64];
+        let mut snapshot_chunk = one_i64_row("snapshot_candidate", &snapshot_value, &snapshot_ts);
+        s1.flush(&mut snapshot_chunk)
+            .expect("append snapshot candidate");
+
+        let late_value = [202_i64];
+        let late_ts = [202_i64];
+        let mut late_chunk = one_i64_row("late_candidate", &late_value, &late_ts);
+        s2.flush(&mut late_chunk).expect("append late candidate");
+    }
+
+    let snapshot_slot = dir.path().join("snapshot-ingest-1");
+    let late_slot = dir.path().join("snapshot-ingest-2");
+    let hidden_late_slot = dir.path().join("snapshot-late-hidden");
+    assert!(slot_has_sfa_file(&snapshot_slot));
+    assert!(slot_has_sfa_file(&late_slot));
+    fs::rename(&late_slot, &hidden_late_slot).expect("hide late slot before connect snapshot");
+
+    let (server, frames) = MockServer::spawn_acking_capturing(4);
+    let replay_conf = format!(
+        "ws::addr=127.0.0.1:{};lazy_connect=true;auth_timeout=2000;\
+         sf_dir={};sender_id=snapshot;sender_pool_min=0;query_pool_min=0;\
+         sender_pool_max=1;pool_reap=manual;max_background_drainers=1;\
+         close_flush_timeout_millis=0;",
+        server.port(),
+        dir.path().display()
+    );
+    let db = QuestDb::connect(&replay_conf).expect("snapshot recovery candidates");
+
+    // This valid out-of-range slot appears only after construction. The first
+    // borrow must reuse the connect-time candidate list rather than rescan
+    // sf_dir and silently expand the pool's recovery snapshot.
+    fs::rename(&hidden_late_slot, &late_slot).expect("publish late candidate after snapshot");
+    let _sender = db
+        .borrow_sender()
+        .expect("first borrow starts snapshotted recovery");
+
+    let replayed = frames
+        .recv_timeout(Duration::from_secs(5))
+        .expect("snapshotted candidate must replay");
+    assert_eq!(frame_table_name(&replayed), "snapshot_candidate");
+    assert!(
+        wait_until(Duration::from_secs(5), || !slot_has_sfa_file(
+            &snapshot_slot
+        )),
+        "the snapshotted candidate must drain completely"
+    );
+    match frames.recv_timeout(Duration::from_secs(5)) {
+        Err(mpsc::RecvTimeoutError::Timeout) => {}
+        Ok(frame) => panic!(
+            "borrow-time growth rescanned sf_dir and replayed late table `{}`",
+            frame_table_name(&frame)
+        ),
+        Err(err) => panic!("capture channel closed while checking snapshot boundary: {err}"),
+    }
+    assert!(
+        slot_has_sfa_file(&late_slot),
+        "a candidate published after construction must wait for the next pool snapshot"
+    );
+}
+
+#[test]
 fn disk_store_and_forward_restart_same_pool_max_replays_in_range_slots_without_borrow() {
     let dir = TempDir::new().unwrap();
     let seed_port = unused_local_port();

--- a/questdb-rs/src/tests/qwp_sender_pool.rs
+++ b/questdb-rs/src/tests/qwp_sender_pool.rs
@@ -650,7 +650,10 @@ fn eager_conf(ports: &[u16], extras: &str) -> String {
         .map(|p| format!("127.0.0.1:{p}"))
         .collect::<Vec<_>>()
         .join(",");
-    format!("ws::addr={addrs};auth_timeout=2000;{extras}")
+    // The fail-fast tests below measure the application-level retry policy,
+    // not the platform's default TCP dial timeout. Bound both stages so a
+    // closed port remains deterministic on Windows as well as Unix.
+    format!("ws::addr={addrs};auth_timeout=1000;connect_timeout=500;{extras}")
 }
 
 fn append_one_symbol_row<'a>(chunk: &mut Chunk<'a>, symbol: &'a [u8], timestamp: &'a [i64; 1]) {
@@ -982,6 +985,7 @@ fn eager_connect_fails_fast_despite_dirty_recovery_slots() {
     let dead_port = unused_local_port();
     let offline = format!(
         "ws::addr=127.0.0.1:{dead_port};lazy_connect=true;auth_timeout=200;\
+         connect_timeout=500;\
          sf_dir={};sender_id=eagerdirty;sender_pool_min=1;sender_pool_max=1;\
          pool_reap=manual;close_flush_timeout_millis=0;",
         dir.path().display()
@@ -1000,7 +1004,7 @@ fn eager_connect_fails_fast_despite_dirty_recovery_slots() {
     db1.close();
 
     let eager = format!(
-        "ws::addr=127.0.0.1:{dead_port};auth_timeout=200;\
+        "ws::addr=127.0.0.1:{dead_port};auth_timeout=200;connect_timeout=500;\
          sf_dir={};sender_id=eagerdirty;sender_pool_min=1;sender_pool_max=1;\
          query_pool_min=0;pool_reap=manual;close_flush_timeout_millis=0;",
         dir.path().display()

--- a/questdb-rs/src/tests/qwp_sender_pool.rs
+++ b/questdb-rs/src/tests/qwp_sender_pool.rs
@@ -936,6 +936,7 @@ fn eager_connect_prewarms_sender_pool_min_connections() {
     assert_eq!(server.accepted(), 2);
 }
 
+#[cfg(feature = "sync-reader-qwp-ws")]
 #[test]
 fn eager_connect_with_async_mode_still_fails_fast_on_reader_prewarm() {
     // initial_connect_retry is ingress-only: reader pre-opens always connect
@@ -1053,6 +1054,7 @@ fn eager_connect_adopts_dirty_slot_and_replays_on_live_server() {
     assert_eq!(frame_row_count(&replayed), 1);
 }
 
+#[cfg(feature = "sync-reader-qwp-ws")]
 #[test]
 fn eager_connect_with_sync_mode_still_fails_fast_on_reader_prewarm() {
     // Java permits this combination: sync governs ingest only, while readers

--- a/questdb-rs/src/tests/qwp_sender_pool.rs
+++ b/questdb-rs/src/tests/qwp_sender_pool.rs
@@ -622,19 +622,35 @@ fn read_then_close(stream: &mut std::net::TcpStream, stop: &AtomicBool, n: usize
 
 fn conf_for(port: u16, extras: &str) -> String {
     format!(
-        "ws::addr=127.0.0.1:{port};auth_timeout=2000;reconnect_max_duration_millis=1000;{extras}"
+        "ws::addr=127.0.0.1:{port};lazy_connect=true;auth_timeout=2000;reconnect_max_duration_millis=1000;{extras}"
     )
 }
 
 /// Build a conf string with a comma-joined endpoint list (`addr=h1,h2,...`),
 /// which enables endpoint rotation / failover in the pool's connect path.
+// `lazy_connect=true`: the pool suite exercises the store-and-forward
+// borrow model (buffer while the server is away, background connects, no
+// warm-minimum pre-connect at construction). Eager-startup behavior has
+// its own tests with explicit non-lazy conf strings.
 fn conf_for_endpoints(ports: &[u16], extras: &str) -> String {
     let addrs = ports
         .iter()
         .map(|p| format!("127.0.0.1:{p}"))
         .collect::<Vec<_>>()
         .join(",");
-    format!("ws::addr={addrs};auth_timeout=2000;reconnect_max_duration_millis=1000;{extras}")
+    format!(
+        "ws::addr={addrs};auth_timeout=2000;reconnect_max_duration_millis=1000;\
+         lazy_connect=true;{extras}"
+    )
+}
+
+fn eager_conf(ports: &[u16], extras: &str) -> String {
+    let addrs = ports
+        .iter()
+        .map(|p| format!("127.0.0.1:{p}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("ws::addr={addrs};auth_timeout=2000;{extras}")
 }
 
 fn append_one_symbol_row<'a>(chunk: &mut Chunk<'a>, symbol: &'a [u8], timestamp: &'a [i64; 1]) {
@@ -768,7 +784,7 @@ fn sorted_slot_names(sf_dir: &Path) -> Vec<String> {
 fn seed_async_qwp_ws_slot(sf_dir: &Path, sender_id: &str, value: i64) {
     let port = unused_local_port();
     let conf = format!(
-        "ws::addr=127.0.0.1:{port};initial_connect_retry=async;\
+        "ws::addr=127.0.0.1:{port};lazy_connect=true;initial_connect_retry=async;\
          sf_dir={};sender_id={sender_id};sf_max_segment_bytes=256;sf_max_total_bytes=1024;\
          close_flush_timeout_millis=0;",
         sf_dir.display()
@@ -855,15 +871,18 @@ fn at_cap_borrow_fails_fast_with_zero_acquire_timeout() {
 }
 
 #[test]
-fn borrow_honors_explicit_initial_connect_retry_off() {
-    let conf = conf_for_endpoints(
+fn eager_borrow_honors_default_initial_connect_retry_off() {
+    // Non-lazy pool, sender_pool_min=0 so connect() itself opens nothing:
+    // the borrow performs the initial connect, honoring the default
+    // fail-fast mode.
+    let conf = eager_conf(
         &[unused_local_port()],
-        "initial_connect_retry=off;sender_pool_max=1;acquire_timeout_ms=0;",
+        "sender_pool_min=0;query_pool_min=0;sender_pool_max=1;acquire_timeout_ms=0;",
     );
     let db = QuestDb::connect(&conf).unwrap();
     let start = std::time::Instant::now();
     db.borrow_sender()
-        .expect_err("initial_connect_retry=off must connect at borrow and fail fast");
+        .expect_err("the default off mode must connect at borrow and fail fast");
     assert!(
         start.elapsed() < std::time::Duration::from_secs(2),
         "off is one connection round, not a retry budget"
@@ -885,9 +904,227 @@ fn borrow_honors_explicit_initial_connect_retry_off() {
 }
 
 #[test]
-fn borrow_honors_explicit_initial_connect_retry_sync() {
+fn eager_connect_prewarms_and_fails_fast_offline() {
+    // Default (non-lazy) startup with the default warm minimum of one
+    // ingest sender: connect() itself performs the initial connect and
+    // fails fast against a dead endpoint, matching the Java client.
+    let conf = eager_conf(&[unused_local_port()], "query_pool_min=0;");
+    let start = std::time::Instant::now();
+    QuestDb::connect(&conf).expect_err("eager connect must fail against a dead endpoint");
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(2),
+        "default off mode must not consume a retry budget"
+    );
+}
+
+#[test]
+fn eager_connect_prewarms_sender_pool_min_connections() {
+    let server = MockServer::spawn(3);
+    let conf = eager_conf(
+        &[server.port()],
+        "sender_pool_min=2;query_pool_min=0;pool_reap=manual;",
+    );
+    let db = QuestDb::connect(&conf).unwrap();
+    assert_eq!(
+        server.accepted(),
+        2,
+        "connect() must pre-open the warm minimum of ingest senders"
+    );
+    // The prewarmed connections are parked in the free list: a borrow
+    // reuses one instead of opening a third connection.
+    let _sender = db.borrow_sender().expect("borrow pops a prewarmed sender");
+    assert_eq!(server.accepted(), 2);
+}
+
+#[test]
+fn eager_connect_with_async_mode_still_fails_fast_on_reader_prewarm() {
+    // initial_connect_retry is ingress-only: reader pre-opens always connect
+    // synchronously and fail fast. Bare async is therefore not a
+    // non-blocking startup while query_pool_min > 0; lazy_connect is.
+    let conf = eager_conf(
+        &[unused_local_port()],
+        "initial_connect_retry=async;sender_pool_min=0;query_pool_min=1;",
+    );
+    let start = std::time::Instant::now();
+    QuestDb::connect(&conf).expect_err("reader prewarm must fail fast");
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(2),
+        "reader prewarm has no retry budget"
+    );
+}
+
+#[test]
+fn reconnect_keys_do_not_stall_eager_connect() {
+    // reconnect_* keys promote initial_connect_retry=sync for the standalone
+    // sender. The pool must not let that promotion drive its eager startup:
+    // a mid-stream failover budget (default 300 s) must never become a
+    // blocking connect() stall. Only an explicitly set mode counts.
+    let conf = eager_conf(
+        &[unused_local_port()],
+        "reconnect_max_duration_millis=6000;query_pool_min=0;",
+    );
+    let start = std::time::Instant::now();
+    QuestDb::connect(&conf).expect_err("dead endpoint must fail the eager connect");
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(2),
+        "promoted sync must not turn connect() into a retry loop"
+    );
+}
+
+#[test]
+fn eager_connect_fails_fast_despite_dirty_recovery_slots() {
+    // Dirty disk slots must not satisfy the eager warm minimum: prewarm runs
+    // before recovery pre-open and adopts the dirty slot with a real
+    // foreground connect, so a dead server fails connect() deterministically
+    // whether or not a previous run left queued data behind.
+    let dir = TempDir::new().unwrap();
+    let dead_port = unused_local_port();
+    let offline = format!(
+        "ws::addr=127.0.0.1:{dead_port};lazy_connect=true;auth_timeout=200;\
+         sf_dir={};sender_id=eagerdirty;sender_pool_min=1;sender_pool_max=1;\
+         pool_reap=manual;close_flush_timeout_millis=0;",
+        dir.path().display()
+    );
+    let db1 = QuestDb::connect(&offline).unwrap();
+    let mut sender1 = db1.borrow_sender().expect("seed the dirty slot");
+    let mut buf = sender1.new_buffer();
+    buf.table("eager_dirty")
+        .unwrap()
+        .column_i64("v", 1)
+        .unwrap()
+        .at_now()
+        .unwrap();
+    sender1.flush_buffer(&mut buf).expect("publish to disk");
+    drop(sender1);
+    db1.close();
+
+    let eager = format!(
+        "ws::addr=127.0.0.1:{dead_port};auth_timeout=200;\
+         sf_dir={};sender_id=eagerdirty;sender_pool_min=1;sender_pool_max=1;\
+         query_pool_min=0;pool_reap=manual;close_flush_timeout_millis=0;",
+        dir.path().display()
+    );
+    let start = std::time::Instant::now();
+    QuestDb::connect(&eager).expect_err("a recovered slot must not stand in for a live connection");
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(2),
+        "the default off mode fails fast even over a dirty slot"
+    );
+}
+
+#[test]
+fn eager_connect_adopts_dirty_slot_and_replays_on_live_server() {
+    let dir = TempDir::new().unwrap();
+    let dead_port = unused_local_port();
+    let offline = format!(
+        "ws::addr=127.0.0.1:{dead_port};lazy_connect=true;auth_timeout=200;\
+         sf_dir={};sender_id=eagerlive;sender_pool_min=1;sender_pool_max=1;\
+         pool_reap=manual;close_flush_timeout_millis=0;",
+        dir.path().display()
+    );
+    let db1 = QuestDb::connect(&offline).unwrap();
+    let mut sender1 = db1.borrow_sender().expect("seed the dirty slot");
+    let mut buf = sender1.new_buffer();
+    buf.table("eager_live")
+        .unwrap()
+        .column_i64("v", 2)
+        .unwrap()
+        .at_now()
+        .unwrap();
+    sender1.flush_buffer(&mut buf).expect("publish to disk");
+    drop(sender1);
+    db1.close();
+
+    // The eager prewarm adopts the dirty slot in the foreground and replays
+    // its queued frame as part of connect().
     let (server, frames) = MockServer::spawn_acking_capturing(1);
-    let conf = conf_for_endpoints(&[server.port()], "initial_connect_retry=sync;");
+    let eager = format!(
+        "ws::addr=127.0.0.1:{};auth_timeout=2000;\
+         sf_dir={};sender_id=eagerlive;sender_pool_min=1;sender_pool_max=1;\
+         query_pool_min=0;pool_reap=manual;",
+        server.port(),
+        dir.path().display()
+    );
+    let _db2 = QuestDb::connect(&eager).expect("eager adoption against a live server");
+    let replayed = frames
+        .recv_timeout(Duration::from_secs(5))
+        .expect("prewarm replays the adopted slot");
+    assert_eq!(frame_table_name(&replayed), "eager_live");
+    assert_eq!(frame_row_count(&replayed), 1);
+}
+
+#[test]
+fn eager_sync_with_reader_prewarm_is_a_config_conflict() {
+    // Explicit sync retries ingest pre-opens, but readers have no retry
+    // mode; refusing the combination keeps "retry my startup" from being a
+    // half-truth.
+    let err = QuestDb::connect("ws::addr=localhost:9000;initial_connect_retry=sync;")
+        .expect_err("sync with the default reader prewarm must conflict");
+    assert_eq!(err.code(), ErrorCode::ConfigError);
+    assert!(err.msg().contains("query_pool_min"), "{}", err.msg());
+
+    // sync with a lazy read pool is accepted; nothing prewarms here.
+    QuestDb::connect(&format!(
+        "ws::addr=127.0.0.1:{};initial_connect_retry=sync;\
+         sender_pool_min=0;query_pool_min=0;",
+        unused_local_port()
+    ))
+    .expect("sync with query_pool_min=0 must be accepted");
+}
+
+#[test]
+fn lazy_connect_rejects_explicit_blocking_initial_connect() {
+    for mode in ["off", "sync", "on"] {
+        let err = QuestDb::connect(&format!(
+            "ws::addr=localhost:9000;lazy_connect=true;initial_connect_retry={mode};"
+        ))
+        .expect_err("lazy_connect and a blocking initial connect must conflict");
+        assert_eq!(err.code(), ErrorCode::ConfigError);
+        assert!(
+            err.msg().contains("conflicting configuration"),
+            "{}",
+            err.msg()
+        );
+    }
+    // Explicit async is the mode lazy_connect implies; no conflict.
+    QuestDb::connect(&format!(
+        "ws::addr=127.0.0.1:{};lazy_connect=true;initial_connect_retry=async;",
+        unused_local_port()
+    ))
+    .expect("lazy_connect with explicit async must be accepted");
+
+    // An unrecognized mode is an invalid value, not a lazy_connect conflict.
+    let err =
+        QuestDb::connect("ws::addr=localhost:9000;lazy_connect=true;initial_connect_retry=banana;")
+            .expect_err("invalid mode value");
+    assert!(
+        err.msg().contains("invalid initial_connect_retry"),
+        "must report the invalid value, not a conflict: {}",
+        err.msg()
+    );
+}
+
+#[test]
+fn lazy_connect_rejects_positive_query_pool_min() {
+    let err = QuestDb::connect("ws::addr=localhost:9000;lazy_connect=true;query_pool_min=2;")
+        .expect_err("lazy_connect needs a lazy read pool");
+    assert_eq!(err.code(), ErrorCode::ConfigError);
+    assert!(err.msg().contains("query_pool_min"), "{}", err.msg());
+    // Explicit 0 restates the lazy default; accepted.
+    QuestDb::connect(&format!(
+        "ws::addr=127.0.0.1:{};lazy_connect=true;query_pool_min=0;",
+        unused_local_port()
+    ))
+    .expect("query_pool_min=0 is the lazy default");
+}
+
+#[test]
+fn eager_borrow_honors_explicit_initial_connect_retry_sync() {
+    let (server, frames) = MockServer::spawn_acking_capturing(1);
+    let conf = eager_conf(
+        &[server.port()],
+        "initial_connect_retry=sync;sender_pool_min=0;query_pool_min=0;",
+    );
     let db = QuestDb::connect(&conf).unwrap();
     let mut sender = db.borrow_sender().expect("sync initial connect");
     assert_eq!(
@@ -926,17 +1163,17 @@ fn borrow_honors_explicit_initial_connect_retry_sync() {
 }
 
 #[test]
-fn borrow_ignores_reconnect_promoted_sync_and_buffers_offline() {
-    // `conf_for_endpoints` sets `reconnect_max_duration_millis`, which
-    // promotes `initial_connect_retry=sync` for the standalone sender. Pool
-    // borrows must ignore the promoted mode: the background runner already
-    // applies the reconnect budget to its initial connect, and a borrow must
-    // keep working while the server is away.
+fn lazy_borrow_ignores_reconnect_promoted_sync_and_buffers_offline() {
+    // `conf_for_endpoints` sets `reconnect_max_duration_millis` (promoting
+    // `initial_connect_retry=sync` for the standalone sender) and
+    // `lazy_connect=true`. The lazy pool must keep its background initial
+    // connect — the runner already applies the reconnect budget — so both
+    // connect() and the borrow work while the server is away.
     let conf = conf_for_endpoints(&[unused_local_port()], "");
     let db = QuestDb::connect(&conf).unwrap();
     let _sender = db
         .borrow_sender()
-        .expect("default pool borrow buffers while the server is away");
+        .expect("lazy pool borrow buffers while the server is away");
 }
 
 #[test]
@@ -1191,7 +1428,7 @@ fn disk_store_and_forward_duplicate_pool_collides_on_managed_slot() {
     let port = unused_local_port();
     let dir = TempDir::new().unwrap();
     let conf = format!(
-        "ws::addr=127.0.0.1:{port};auth_timeout=200;\
+        "ws::addr=127.0.0.1:{port};lazy_connect=true;auth_timeout=200;\
          sf_dir={};sender_id=shared;sender_pool_min=1;sender_pool_max=2;\
          pool_reap=manual;close_flush_timeout_millis=0;",
         dir.path().display()
@@ -1223,7 +1460,7 @@ fn disk_store_and_forward_duplicate_pool_connect_warn_skips_flocked_slots() {
     let port = unused_local_port();
     let dir = TempDir::new().unwrap();
     let conf = format!(
-        "ws::addr=127.0.0.1:{port};auth_timeout=200;initial_connect_retry=async;\
+        "ws::addr=127.0.0.1:{port};lazy_connect=true;auth_timeout=200;initial_connect_retry=async;\
          sf_dir={};sender_id=dupe;sender_pool_min=1;sender_pool_max=1;\
          pool_reap=manual;close_flush_timeout_millis=0;",
         dir.path().display()
@@ -1274,11 +1511,180 @@ fn disk_store_and_forward_duplicate_pool_connect_warn_skips_flocked_slots() {
 }
 
 #[test]
+fn sync_borrow_adopts_dirty_slot_and_continues_recovered_symbol_dict() {
+    // The eager-connect branch of connect_qwp_ws_background_state seeds its
+    // encoder and send core from a recovered symbol dictionary. Reach it on a
+    // pooled core: pool 1 (lazy, unreachable server) publishes a symbol row
+    // into a disk slot and holds the flock through pool 2's connect, so
+    // recovery pre-open skips the slot and the later borrow — explicit
+    // initial_connect_retry=sync — adopts it through the eager branch. The
+    // replayed frame must register the recovered symbol from zero, and a new
+    // symbol published afterwards must continue above the recovered id.
+    let dir = TempDir::new().unwrap();
+    let dead_port = unused_local_port();
+    let offline_conf = format!(
+        "ws::addr=127.0.0.1:{dead_port};lazy_connect=true;auth_timeout=200;\
+         sf_dir={};sender_id=syncrec;sender_pool_min=1;sender_pool_max=1;\
+         pool_reap=manual;close_flush_timeout_millis=0;",
+        dir.path().display()
+    );
+    let db1 = QuestDb::connect(&offline_conf).unwrap();
+    let mut sender1 = db1
+        .borrow_sender()
+        .expect("first pool owns syncrec-ingest-0");
+    let mut buf = sender1.new_buffer();
+    buf.table("sync_recover")
+        .unwrap()
+        .symbol("symbol", "ETH-USDT")
+        .unwrap()
+        .column_f64("price", 2615.54)
+        .unwrap()
+        .at_now()
+        .unwrap();
+    sender1
+        .flush_buffer(&mut buf)
+        .expect("publish to the disk slot while the server is away");
+
+    let (server, frames) = MockServer::spawn_acking_capturing(1);
+    let live_conf = format!(
+        "ws::addr=127.0.0.1:{};auth_timeout=2000;initial_connect_retry=sync;\
+         sf_dir={};sender_id=syncrec;sender_pool_min=0;query_pool_min=0;\
+         sender_pool_max=1;pool_reap=manual;",
+        server.port(),
+        dir.path().display()
+    );
+    // Pool 1 still holds the slot flock: pool 2's connect-time recovery
+    // skips it and succeeds with nothing pre-opened.
+    let db2 = QuestDb::connect(&live_conf).expect("connect skips the flocked slot");
+    drop(sender1);
+    db1.close();
+
+    let mut sender2 = db2
+        .borrow_sender()
+        .expect("sync borrow adopts the released dirty slot");
+    // The eager branch first re-registers the recovered dictionary through a
+    // dict-only catch-up frame, then replays the queued data frame.
+    let catch_up = frames
+        .recv_timeout(Duration::from_secs(5))
+        .expect("adopting the slot re-registers the recovered dictionary");
+    assert_eq!(
+        read_symbol_prefix(&catch_up),
+        (0, vec![b"ETH-USDT".to_vec()]),
+        "the catch-up frame re-registers the recovered symbol from zero"
+    );
+    let replayed = frames
+        .recv_timeout(Duration::from_secs(5))
+        .expect("adopting the slot replays the unacked frame");
+    assert_eq!(frame_table_name(&replayed), "sync_recover");
+    assert_eq!(
+        read_symbol_prefix(&replayed),
+        (0, vec![b"ETH-USDT".to_vec()]),
+        "the replayed frame carries its original dictionary delta"
+    );
+
+    let mut buf = sender2.new_buffer();
+    buf.table("sync_recover")
+        .unwrap()
+        .symbol("symbol", "BTC-USDT")
+        .unwrap()
+        .column_f64("price", 65432.10)
+        .unwrap()
+        .at_now()
+        .unwrap();
+    sender2
+        .flush_buffer_and_wait(&mut buf, AckLevel::Ok)
+        .expect("publish a new symbol over the adopted slot");
+    let fresh = frames
+        .recv_timeout(Duration::from_secs(5))
+        .expect("server receives the new frame");
+    assert_eq!(
+        read_symbol_prefix(&fresh),
+        (1, vec![b"BTC-USDT".to_vec()]),
+        "the new symbol must continue above the recovered dictionary id"
+    );
+}
+
+#[test]
+fn failed_eager_borrow_on_disk_slot_releases_flock_and_keeps_data() {
+    // A borrow-time adoption of a dirty disk slot opens the flock and
+    // recovered segments BEFORE the eager fail-fast connect. A connect
+    // failure there must release the flock (so the next borrow can retry
+    // rather than colliding on "slot in use") and leave the segments
+    // recoverable by a later pool.
+    let dir = TempDir::new().unwrap();
+    let dead_port = unused_local_port();
+    let offline = format!(
+        "ws::addr=127.0.0.1:{dead_port};lazy_connect=true;auth_timeout=200;\
+         sf_dir={};sender_id=flockrec;sender_pool_min=1;sender_pool_max=1;\
+         pool_reap=manual;close_flush_timeout_millis=0;",
+        dir.path().display()
+    );
+    let db1 = QuestDb::connect(&offline).unwrap();
+    let mut sender1 = db1.borrow_sender().expect("seed the dirty slot");
+    let mut buf = sender1.new_buffer();
+    buf.table("flock_recover")
+        .unwrap()
+        .column_i64("v", 7)
+        .unwrap()
+        .at_now()
+        .unwrap();
+    sender1
+        .flush_buffer(&mut buf)
+        .expect("publish to disk while the server is away");
+
+    // Eager pool over the same slot: connect while the flock is still held
+    // so recovery pre-open skips the dirty slot and the BORROW adopts it.
+    let eager = format!(
+        "ws::addr=127.0.0.1:{dead_port};auth_timeout=200;\
+         sf_dir={};sender_id=flockrec;sender_pool_min=0;query_pool_min=0;\
+         sender_pool_max=1;acquire_timeout_ms=0;pool_reap=manual;\
+         close_flush_timeout_millis=0;",
+        dir.path().display()
+    );
+    let db2 = QuestDb::connect(&eager).expect("connect skips the flocked slot");
+    drop(sender1);
+    db1.close();
+
+    let first = db2
+        .borrow_sender()
+        .expect_err("eager borrow adopts the slot, then fails its connect");
+    assert_ne!(first.code(), ErrorCode::ConfigError, "{}", first.msg());
+    let second = db2
+        .borrow_sender()
+        .expect_err("second borrow retries the connect");
+    assert_ne!(
+        second.code(),
+        ErrorCode::ConfigError,
+        "a failed eager adoption must release the slot flock, not leave \
+         it 'in use': {}",
+        second.msg()
+    );
+    db2.close();
+
+    // The failed adoptions must not have consumed or corrupted the queued
+    // data: a pool against a live server replays it via recovery pre-open.
+    let (server, frames) = MockServer::spawn_acking_capturing(1);
+    let live = format!(
+        "ws::addr=127.0.0.1:{};auth_timeout=2000;\
+         sf_dir={};sender_id=flockrec;sender_pool_min=0;query_pool_min=0;\
+         sender_pool_max=1;pool_reap=manual;",
+        server.port(),
+        dir.path().display()
+    );
+    let _db3 = QuestDb::connect(&live).expect("recovery pre-open replays");
+    let replayed = frames
+        .recv_timeout(Duration::from_secs(5))
+        .expect("the queued frame must survive the failed eager adoptions");
+    assert_eq!(frame_table_name(&replayed), "flock_recover");
+    assert_eq!(frame_row_count(&replayed), 1);
+}
+
+#[test]
 fn disk_store_and_forward_restart_replays_reminted_and_out_of_range_managed_slots() {
     let dir = TempDir::new().unwrap();
     let seed_port = unused_local_port();
     let seed_conf = format!(
-        "ws::addr=127.0.0.1:{seed_port};auth_timeout=200;\
+        "ws::addr=127.0.0.1:{seed_port};lazy_connect=true;auth_timeout=200;\
          reconnect_max_duration_millis=100;sf_dir={};sender_id=replay;\
          sender_pool_min=1;sender_pool_max=2;pool_reap=manual;close_flush_timeout_millis=0;",
         dir.path().display()
@@ -1331,7 +1737,7 @@ fn disk_store_and_forward_restart_same_pool_max_replays_in_range_slots_without_b
     let dir = TempDir::new().unwrap();
     let seed_port = unused_local_port();
     let seed_conf = format!(
-        "ws::addr=127.0.0.1:{seed_port};auth_timeout=200;\
+        "ws::addr=127.0.0.1:{seed_port};lazy_connect=true;auth_timeout=200;\
          reconnect_max_duration_millis=100;sf_dir={};sender_id=samepool;\
          sender_pool_min=1;sender_pool_max=2;pool_reap=manual;close_flush_timeout_millis=0;",
         dir.path().display()
@@ -2040,7 +2446,7 @@ fn mixed_sfa_namespace_survives_endpoint_failover_and_catch_up() {
     let first = MockServer::spawn_ack_then_close(1, 1);
     let (live, frames) = MockServer::spawn_acking_capturing(4);
     let conf = format!(
-        "ws::addr=127.0.0.1:{},127.0.0.1:{};auth_timeout=2000;\
+        "ws::addr=127.0.0.1:{},127.0.0.1:{};lazy_connect=true;auth_timeout=2000;\
          reconnect_max_duration_millis=10000;pool_reap=manual;",
         first.port(),
         live.port()
@@ -2137,7 +2543,7 @@ fn disk_recovery_orphan_drains_mixed_shapes_with_one_dictionary() {
     let dir = TempDir::new().unwrap();
     let seed_port = unused_local_port();
     let seed_conf = format!(
-        "ws::addr=127.0.0.1:{seed_port};auth_timeout=200;\
+        "ws::addr=127.0.0.1:{seed_port};lazy_connect=true;auth_timeout=200;\
          reconnect_max_duration_millis=10000;sf_dir={};sender_id=mixedrec;\
          sender_pool_min=1;sender_pool_max=2;pool_reap=manual;close_flush_timeout_millis=0;",
         dir.path().display()
@@ -2944,7 +3350,7 @@ fn store_and_forward_runner_reconnects_and_replays_after_transport_death() {
     // No `sf_dir` -> in-memory SF; a longer reconnect budget so the runner can
     // rotate to the live endpoint.
     let conf = format!(
-        "ws::addr=127.0.0.1:{},127.0.0.1:{};auth_timeout=2000;\
+        "ws::addr=127.0.0.1:{},127.0.0.1:{};lazy_connect=true;auth_timeout=2000;\
          reconnect_max_duration_millis=10000;pool_reap=manual;",
         dead.port(),
         live.port()
@@ -4276,7 +4682,7 @@ fn buffer_sender_local_build_failure_releases_in_use_slot() {
     let dir = TempDir::new().unwrap();
     let port = unused_local_port();
     let conf = format!(
-        "ws::addr=127.0.0.1:{port};auth_timeout=200;sf_dir={};\
+        "ws::addr=127.0.0.1:{port};lazy_connect=true;auth_timeout=200;sf_dir={};\
          sender_id=buildfail;sender_pool_min=1;sender_pool_max=1;pool_reap=manual;\
          close_flush_timeout_millis=0;",
         dir.path().display()
@@ -6006,7 +6412,11 @@ fn flush_polars_dataframe_single_endpoint_commits_in_one_pass() {
     use polars::prelude::{IntoColumn, NamedFrom, PlSmallStr, Series};
 
     let (server, frames) = MockServer::spawn_acking_capturing(1);
-    let db = QuestDb::connect(&format!("ws::addr=127.0.0.1:{};", server.port())).unwrap();
+    let db = QuestDb::connect(&format!(
+        "ws::addr=127.0.0.1:{};lazy_connect=true;",
+        server.port()
+    ))
+    .unwrap();
 
     let i = Series::new(PlSmallStr::from("i"), &[1i64, 2, 3, 4]).into_column();
     let df = crate::polars_ffi::df_from_columns(vec![i]).unwrap();
@@ -6041,7 +6451,11 @@ fn flush_polars_dataframe_applies_column_overrides() {
     // A Symbol override for a plain Utf8 column must now thread through to every
     // sliced batch and commit cleanly.
     let (server, frames) = MockServer::spawn_acking_capturing(1);
-    let db = QuestDb::connect(&format!("ws::addr=127.0.0.1:{};", server.port())).unwrap();
+    let db = QuestDb::connect(&format!(
+        "ws::addr=127.0.0.1:{};lazy_connect=true;",
+        server.port()
+    ))
+    .unwrap();
 
     let s = Series::new(PlSmallStr::from("s"), &["a", "b", "c", "d"]).into_column();
     let i = Series::new(PlSmallStr::from("i"), &[1i64, 2, 3, 4]).into_column();
@@ -6078,7 +6492,11 @@ fn flush_arrow_batch_at_now_commits_in_one_call() {
     // `Ok` ack, and returns the sender to the pool — all without the caller
     // touching a sender.
     let (server, frames) = MockServer::spawn_acking_capturing(1);
-    let db = QuestDb::connect(&format!("ws::addr=127.0.0.1:{};", server.port())).unwrap();
+    let db = QuestDb::connect(&format!(
+        "ws::addr=127.0.0.1:{};lazy_connect=true;",
+        server.port()
+    ))
+    .unwrap();
 
     let schema = Arc::new(Schema::new(vec![Field::new("i", DataType::Int64, false)]));
     let arr = Arc::new(Int64Array::from(vec![1i64, 2, 3, 4]));
@@ -6113,7 +6531,11 @@ fn flush_arrow_batch_durable_without_opt_in_is_rejected() {
     // caller-named `Durable` level must be rejected up front rather than
     // accepted without durable opt-in.
     let (server, _frames) = MockServer::spawn_acking_capturing(1);
-    let db = QuestDb::connect(&format!("ws::addr=127.0.0.1:{};", server.port())).unwrap();
+    let db = QuestDb::connect(&format!(
+        "ws::addr=127.0.0.1:{};lazy_connect=true;",
+        server.port()
+    ))
+    .unwrap();
 
     let schema = Arc::new(Schema::new(vec![Field::new("i", DataType::Int64, false)]));
     let arr = Arc::new(Int64Array::from(vec![1i64, 2]));
@@ -6136,7 +6558,11 @@ fn flush_arrow_batch_at_column_commits_in_one_call() {
     // The `Some(ts)` arm sources the designated timestamp from the named
     // column and threads through to `flush_arrow_batch_at_column_and_wait`.
     let (server, frames) = MockServer::spawn_acking_capturing(1);
-    let db = QuestDb::connect(&format!("ws::addr=127.0.0.1:{};", server.port())).unwrap();
+    let db = QuestDb::connect(&format!(
+        "ws::addr=127.0.0.1:{};lazy_connect=true;",
+        server.port()
+    ))
+    .unwrap();
 
     let schema = Arc::new(Schema::new(vec![
         Field::new("price", DataType::Float64, false),
@@ -6187,7 +6613,7 @@ mod reader_pool {
     use std::thread;
     use std::time::Duration;
 
-    use super::{conf_for, park_connection, wait_until};
+    use super::{conf_for, eager_conf, park_connection, wait_until};
     use crate::ErrorCode;
     // Front-door import: `QuestDb` is re-exported at the crate root.
     use crate::QuestDb;
@@ -6411,6 +6837,26 @@ mod reader_pool {
         assert_eq!(server.accepted(), 3, "reuse must not open new connections");
     }
 
+    /// Eager (non-lazy) startup pre-opens `query_pool_min` readers at
+    /// `connect()`, and a later borrow reuses one instead of opening a new
+    /// connection.
+    #[test]
+    fn eager_connect_prewarms_query_pool_min_readers() {
+        let server = ReaderMockServer::spawn(4);
+        let db = QuestDb::connect(&eager_conf(
+            &[server.port()],
+            "sender_pool_min=0;query_pool_min=2;pool_reap=manual;",
+        ))
+        .unwrap();
+        assert_eq!(
+            server.accepted(),
+            2,
+            "connect() must pre-open the warm minimum of readers"
+        );
+        let _reader = db.borrow_reader().expect("borrow pops a prewarmed reader");
+        assert_eq!(server.accepted(), 2, "the borrow must reuse a warm reader");
+    }
+
     /// Borrowing past `query_pool_max` with `acquire_timeout_ms=0` fails
     /// fast with an egress `InvalidApiCall` instead of over-committing.
     #[test]
@@ -6418,7 +6864,7 @@ mod reader_pool {
         let server = ReaderMockServer::spawn(8);
         let db = QuestDb::connect(&conf_for(
             server.port(),
-            "query_pool_min=1;query_pool_max=2;acquire_timeout_ms=0;",
+            "query_pool_max=2;acquire_timeout_ms=0;",
         ))
         .unwrap();
 
@@ -6754,7 +7200,7 @@ mod conn_event_tests {
             listener.local_addr().unwrap().port()
         };
         let conf = format!(
-            "ws::addr=127.0.0.1:{port};auth_timeout=2000;\
+            "ws::addr=127.0.0.1:{port};lazy_connect=true;auth_timeout=2000;\
              reconnect_max_duration_millis=200;connect_timeout=100;\
              sender_pool_min=1;sender_pool_max=1;pool_reap=manual;"
         );
@@ -6905,7 +7351,7 @@ mod conn_event_tests {
     fn sfa_unreachable_endpoint_fires_attempt_failed_and_unreachable() {
         let port = unused_local_port();
         let conf = format!(
-            "ws::addr=127.0.0.1:{port};auth_timeout=2000;\
+            "ws::addr=127.0.0.1:{port};lazy_connect=true;auth_timeout=2000;\
              reconnect_max_duration_millis=200;connect_timeout=100;\
              sender_pool_min=1;sender_pool_max=1;pool_reap=manual;close_flush_timeout_millis=0;"
         );
@@ -7218,7 +7664,7 @@ mod sender_conn_event_tests {
         };
         let (seen, listener) = collecting_listener();
         let conf = format!(
-            "ws::addr=127.0.0.1:{port};auth_timeout=2000;\
+            "ws::addr=127.0.0.1:{port};lazy_connect=true;auth_timeout=2000;\
              reconnect_max_duration_millis=200;connect_timeout=100;"
         );
         let err = SenderBuilder::from_conf(conf)

--- a/questdb-rs/src/tests/qwp_ws.rs
+++ b/questdb-rs/src/tests/qwp_ws.rs
@@ -3832,6 +3832,10 @@ fn qwp_ws_reconnects_and_replays_in_all_progress_modes() {
         let frame2 = rx.recv_timeout(Duration::from_secs(5)).unwrap();
         assert_eq!(&frame1[0..4], b"QWP1");
         assert_eq!(frame1, frame2, "mode={}", progress.name());
+
+        let totals = sender.qwp_ws_totals().unwrap();
+        assert_eq!(totals.frames_sent, 2, "mode={}", progress.name());
+        assert_eq!(totals.frames_replayed, 1, "mode={}", progress.name());
     }
 }
 

--- a/questdb-rs/tests/egress_failover.rs
+++ b/questdb-rs/tests/egress_failover.rs
@@ -2116,47 +2116,6 @@ fn initial_connect_walks_all_endpoints() {
 }
 
 #[test]
-fn backoff_bounded_by_jitter_ceiling() {
-    // Egress backoff uses **full-jitter** `[0, base)` per
-    // failover.md §3.1, so each individual sleep is drawn uniformly
-    // and there is no per-run lower bound that survives a single
-    // CI invocation. What we CAN assert is the upper bound: total
-    // backoff sleep across the schedule MUST NOT exceed the sum of
-    // the per-attempt jitter ceilings.
-    //
-    // Setup: initial=20ms, max=200ms, max_attempts=3 → 2 reconnect
-    // rounds; sleeps use base 20ms, then 40ms.
-    // Sum of bases (= upper bound on total sleep under full-jitter)
-    // is 60ms. The walk itself does host_count × 2 dials per outer
-    // attempt × 2 attempts = 8 dials on loopback. Allow generous slack
-    // for scheduler noise and connect overhead on busy CI runners.
-    let srv_a = MockServer::start(vec![
-        drop_after_query_script(ServerRole::Standalone, "a"),
-        drop_at_connect_script(),
-    ]);
-    let srv_b = MockServer::start(vec![drop_at_connect_script()]);
-    let conf = format!(
-        "ws::addr={};failover_max_attempts=3;failover_backoff_initial_ms=20;failover_backoff_max_ms=200",
-        build_addr_list(&[&srv_a, &srv_b])
-    );
-    let mut reader = Reader::from_conf(&conf).expect("connect");
-    let mut cursor = reader.prepare("select 1").execute().expect("execute");
-    let start = Instant::now();
-    let _ = cursor.next_batch();
-    let elapsed = start.elapsed();
-    // Sum of jitter ceilings (60ms) + scheduler/connect slack (580ms)
-    // = 640ms upper bound. A regression that disables the cap or
-    // reverts to deterministic backoff (60ms minimum + dials)
-    // wouldn't trip this, but one that *runs away* (e.g. backoff
-    // doubling without saturation) would push elapsed well over 1s.
-    assert!(
-        elapsed < Duration::from_millis(640),
-        "elapsed {:?} exceeds the full-jitter ceiling — backoff schedule has run away",
-        elapsed
-    );
-}
-
-#[test]
 fn cancelling_cursor_does_not_failover_on_drop() {
     // Cursor: connects to A, executes the query, calls cancel(), then
     // drains. While the drain is waiting, A drops the socket. The
@@ -2463,49 +2422,6 @@ fn failover_event_attempts_is_cumulative_across_rotations() {
         attempts[0] >= 2,
         "expected cumulative attempts >= 2 (rotation skipped past dead B); got {}",
         attempts[0],
-    );
-}
-
-#[test]
-fn backoff_caps_at_max_ms() {
-    // Counterpart to `backoff_grows_between_attempts` (which only
-    // checks the lower bound). Here we set the cap WAY below the
-    // value the doubling would otherwise reach, then verify that
-    // total elapsed is closer to "9 sleeps × cap" than to "9
-    // sleeps in pure doubling".
-    //
-    // initial=10, max=20, max_attempts=10 → 9 reconnect rounds:
-    //   - capped:    10 + 20*8 ≈ 170 ms  (plus dial time)
-    //   - uncapped: 10+20+40+80+160+320+640+1280+2560 ≈ 5110 ms
-    // Anything well below the uncapped figure proves the `.min(max_ms)`
-    // is firing.
-    let srv_a = MockServer::start(vec![
-        drop_after_query_script(ServerRole::Standalone, "a"),
-        drop_at_connect_script(),
-    ]);
-    let srv_b = MockServer::start(vec![drop_at_connect_script()]);
-    let conf = format!(
-        "ws::addr={};failover_max_attempts=10;failover_backoff_initial_ms=10;failover_backoff_max_ms=20",
-        build_addr_list(&[&srv_a, &srv_b])
-    );
-    let mut reader = Reader::from_conf(&conf).expect("initial connect");
-    let mut cursor = reader.prepare("select 1").execute().expect("execute");
-    let start = Instant::now();
-    let _ = cursor.next_batch();
-    let elapsed = start.elapsed();
-    // A working cap totals ~170 ms of backoff plus the 9 dial round-
-    // trips; an uncapped run would total ~5.11 s of backoff alone
-    // (10+20+40+80+160+320+640+1280+2560) plus dials. The 2 s threshold
-    // sits well below the uncapped *backoff floor* and well above any
-    // realistic capped run — including the slack a loaded CI runner
-    // can add to each dial. Tightening this threshold has bitten us
-    // before on busy CI hosts (a previous 800 ms cap regressed at
-    // 841 ms with the cap correctly applied), so prefer wide head-
-    // room over narrow precision here.
-    assert!(
-        elapsed < Duration::from_millis(2000),
-        "elapsed {:?} suggests the backoff cap is not being applied",
-        elapsed
     );
 }
 

--- a/system_test/arrow_ingress_fuzz.py
+++ b/system_test/arrow_ingress_fuzz.py
@@ -1362,7 +1362,6 @@ class TestArrowIngressSfa(afc.ArrowFuzzBase):
             nonlocal rows_produced
             extras = self._sfa_extras(sender_id, sf_dir)
             extras.update({
-                "initial_connect_retry": "sync",
                 "reconnect_max_duration_millis": "120000",
                 "reconnect_max_backoff_millis": "250",
                 "close_flush_timeout_millis": "120000",

--- a/system_test/arrow_ingress_fuzz.py
+++ b/system_test/arrow_ingress_fuzz.py
@@ -901,6 +901,7 @@ class TestArrowIngressSfa(afc.ArrowFuzzBase):
         return {
             "sender_id": sender_id,
             "sf_dir": sf_dir,
+            "lazy_connect": "true",
             "sender_pool_min": "1",
             "sender_pool_max": "1",
             "pool_reap": "manual",
@@ -1562,16 +1563,19 @@ class TestColumnSenderBorrowWithRetry(unittest.TestCase):
             db_close,
             db_borrow_direct_conn_with_retry,
         )
-        # Bind then close to get a definitely-closed local port. The pool is
-        # lazy, so the connect only happens on borrow; a closed port refuses
+        # Bind then close to get a definitely-closed local port. The pool
+        # uses lazy_connect, so the connect only happens on borrow; a closed
+        # port refuses
         # immediately, so the Direct retry shim must exhaust its budget and
         # raise across the FFI boundary instead of hanging or crashing.
         probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         probe.bind(("127.0.0.1", 0))
         dead_port = probe.getsockname()[1]
         probe.close()
-        conf = f"ws::addr=127.0.0.1:{dead_port};".encode("utf-8")
-        db = db_connect(conf)  # lazy: opens no socket, so it succeeds
+        conf = (
+            f"ws::addr=127.0.0.1:{dead_port};lazy_connect=true;"
+            .encode("utf-8"))
+        db = db_connect(conf)  # lazy_connect: opens no socket, so it succeeds
         try:
             # Non-zero budget exercises the retry loop (attempts + backoff).
             with self.assertRaises(ArrowSenderError):

--- a/system_test/c_sidecars/qwp_c_sidecar.c
+++ b/system_test/c_sidecars/qwp_c_sidecar.c
@@ -24,10 +24,10 @@
  *
  * STATS note: the C FFI exposes the durable-ack watermark
  * (line_sender_qwpws_acked_fsn) but NOT the qwp_ws_totals counters
- * (sent/acks/reconnAttempts/reconnSucc/serverErrors). We emit the real
- * `acked` and zero the rest -- the same fallback shape the Rust sidecar
- * uses when totals are unavailable (qwp_sidecar.rs:236-238). The
- * binding-variant tests do not rely on the zeroed fields.
+ * (sent/replayed/startupSent/acks/reconnAttempts/reconnSucc/serverErrors).
+ * We emit the real `acked` and zero the rest -- the same fallback shape the
+ * Rust sidecar uses when totals are unavailable. The binding-variant tests do
+ * not rely on the zeroed fields.
  */
 
 #define _POSIX_C_SOURCE 200809L
@@ -265,9 +265,10 @@ static void handle_stats(void)
         reply_err("no sender");
         return;
     }
-    /* Only the durable-ack watermark is exported by the C FFI; the
-     * sent / acks / reconnect / serverErrors counters have no FFI wrapper.
-     * Emit the real acked and zero the rest, like the Rust sidecar fallback. */
+    /* Only the durable-ack watermark is exported by the C FFI; the sent /
+     * replayed / startupSent / acks / reconnect / serverErrors counters have
+     * no FFI wrapper. Emit the real acked and zero the rest, like the Rust
+     * sidecar fallback. */
     line_sender_error* err = NULL;
     line_sender_qwpws_fsn fsn = {false, 0};
     long long acked = -1;
@@ -284,7 +285,8 @@ static void handle_stats(void)
     snprintf(
         payload,
         sizeof(payload),
-        "acked=%lld sent=0 acks=0 reconnAttempts=0 reconnSucc=0 serverErrors=0",
+        "acked=%lld sent=0 replayed=0 startupSent=0 acks=0 "
+        "reconnAttempts=0 reconnSucc=0 serverErrors=0",
         acked);
     reply_ok(payload);
 }

--- a/system_test/c_sidecars/qwp_cpp_sidecar.cpp
+++ b/system_test/c_sidecars/qwp_cpp_sidecar.cpp
@@ -27,7 +27,8 @@
 //   EXIT                                 -> (no reply, exits 0)
 //
 // STATS exposes only the real `acked` (line_sender_qwpws_acked_fsn); the
-// sent/acks/reconn*/serverErrors counters have no FFI wrapper, so they are
+// sent/replayed/startupSent/acks/reconn*/serverErrors counters have no FFI
+// wrapper, so they are
 // zeroed -- the same fallback the Rust sidecar uses.
 
 // line_sender.hpp pulls in the C ABI (the ::line_sender_* functions we use) and
@@ -267,7 +268,8 @@ void handle_stats()
     }
     std::ostringstream oss;
     oss << "acked=" << acked
-        << " sent=0 acks=0 reconnAttempts=0 reconnSucc=0 serverErrors=0";
+        << " sent=0 replayed=0 startupSent=0 acks=0"
+           " reconnAttempts=0 reconnSucc=0 serverErrors=0";
     reply_ok(oss.str());
 }
 

--- a/system_test/enterprise_e2e/tests/test_arrow_db_failover.py
+++ b/system_test/enterprise_e2e/tests/test_arrow_db_failover.py
@@ -60,7 +60,8 @@ _SRC = "arrow_db"  # column sidecar SEND shape that drives Db::flush_arrow_batch
 
 def _connect_string(http_ports: list[int], *, request_durable_ack: bool = False,
                     reconnect_max_ms: int = 60_000,
-                    close_flush_timeout_ms: int = 5_000) -> str:
+                    close_flush_timeout_ms: int = 5_000,
+                    lazy: bool = True) -> str:
     """Direct Arrow facade connect string (``ws`` schema).
 
     ``request_durable_ack`` defaults off: ``flush_arrow_batch`` then waits for
@@ -82,6 +83,8 @@ def _connect_string(http_ports: list[int], *, request_durable_ack: bool = False,
         "sender_pool_min=1",
         "sender_pool_max=1",
     ]
+    if lazy:
+        parts.append("lazy_connect=true")
     if request_durable_ack:
         parts.append("request_durable_ack=on")
     return ";".join(parts) + ";"
@@ -126,10 +129,10 @@ def test_arrow_db_flush_against_stale_primary_at_first_send_c_client_rust(
     scenario_dir: Path,
 ) -> None:
     """Stale primary: the configured primary is already gone before the FIRST
-    send. ``QuestDb::connect`` is lazy (opens a sender only on first borrow), so
-    the first ``flush_arrow_batch`` is what binds a connection -- it must reach
-    the live successor on the configured address rather than failing on the
-    dead one."""
+    send. The pool is configured with ``lazy_connect=true`` (a sender opens
+    only on first borrow), so the first ``flush_arrow_batch`` is what binds a
+    connection -- it must reach the live successor on the configured address
+    rather than failing on the dead one."""
     table = "trades_arrow_db_stale_c_client_rust"
     row_count = 50
 
@@ -158,6 +161,31 @@ def test_arrow_db_flush_against_stale_primary_at_first_send_c_client_rust(
 
     wait_for_dense_sequence(port=p1_ports.pg, table=table,
                             expected_count=row_count, timeout_s=60.0)
+
+
+@pytest.mark.c_client
+@pytest.mark.c_client_rust
+def test_arrow_db_eager_connect_against_live_primary_c_client_rust(
+    server_factory,
+    c_client_rust_column_sidecar: CClientRustColumnSidecar,
+    scenario_dir: Path,
+) -> None:
+    """The eager default (no ``lazy_connect``): ``connect`` pre-opens the
+    warm sender minimum against the live primary, so the first flush rides an
+    already-established connection. Covers the startup path every C, C++, and
+    Python user now gets by default."""
+    table = "trades_arrow_db_eager_connect_c_client_rust"
+
+    p1 = server_factory("p1")
+    p1_ports = p1.start()
+    c_client_rust_column_sidecar.connect(
+        _connect_string([p1_ports.http], lazy=False))
+
+    c_client_rust_column_sidecar.send(table, count=25, start_index=0, src=_SRC)
+    _flush_with_failover_retry(c_client_rust_column_sidecar)
+
+    wait_for_dense_sequence(port=p1_ports.pg, table=table,
+                            expected_count=25, timeout_s=90.0)
 
 
 @pytest.mark.c_client
@@ -251,8 +279,8 @@ def test_arrow_db_flush_across_inplace_role_switch_c_client_rust(
         time.sleep(0.5)
     assert rejected, "flush_arrow_batch was NOT rejected on the read-only replica"
 
-    # Drop the buffered probe row + reset the pool (CONNECT is lazy, so this
-    # does not open a connection against the replica).
+    # Drop the buffered probe row + reset the pool (lazy_connect is set, so
+    # this does not open a connection against the replica).
     c_client_rust_column_sidecar.connect(_connect_string([p1_ports.http]))
 
     # Promote back to primary IN PLACE.

--- a/system_test/enterprise_e2e/tests/test_polars_db_failover.py
+++ b/system_test/enterprise_e2e/tests/test_polars_db_failover.py
@@ -87,6 +87,7 @@ def _connect_string(http_ports: list[int], *, request_durable_ack: bool = False,
         f"close_flush_timeout_millis={close_flush_timeout_ms}",
         "sender_pool_min=1",
         "sender_pool_max=1",
+        "lazy_connect=true",
     ]
     if request_durable_ack:
         parts.append("request_durable_ack=on")
@@ -102,9 +103,9 @@ def test_polars_db_flush_against_stale_primary_at_first_send_c_client_rust(
     scenario_dir: Path,
 ) -> None:
     """Stale primary: the configured primary is already gone before the FIRST
-    send. ``QuestDb::connect`` is lazy, so the first ``flush_polars_dataframe``
-    binds a connection -- a single call must reach the live successor (the
-    DataFrame path re-drives internally)."""
+    send. The pool is configured with ``lazy_connect=true``, so the first
+    ``flush_polars_dataframe`` binds a connection -- a single call must reach
+    the live successor (the DataFrame path re-drives internally)."""
     table = "trades_polars_db_stale_c_client_rust"
     row_count = 50
 
@@ -224,7 +225,8 @@ def test_polars_db_flush_across_inplace_role_switch_c_client_rust(
         LOG.info("flush_polars_dataframe rejected on read-only replica (expected): %s", exc)
     assert rejected, "flush_polars_dataframe was NOT rejected on the read-only replica"
 
-    # Drop the buffered probe row + reset the pool (CONNECT is lazy).
+    # Drop the buffered probe row + reset the pool (lazy_connect is set,
+    # so this does not open a connection against the replica).
     c_client_rust_column_sidecar.connect(cs)
 
     # Promote back to primary IN PLACE.

--- a/system_test/failover_clients/src/bin/qwp_sidecar.rs
+++ b/system_test/failover_clients/src/bin/qwp_sidecar.rs
@@ -23,6 +23,7 @@
 //!   FLUSH                                     -> OK <fsn> | ERR <msg>
 //!   AWAIT_ACKED <fsn> <timeout_ms>            -> OK true|false | ERR <msg>
 //!   STATS                                     -> OK acked=N sent=N acks=N
+//!                                                replayed=N startupSent=N
 //!                                                reconnAttempts=N reconnSucc=N
 //!                                                serverErrors=N
 //!   CLOSE                                     -> OK | ERR <msg>
@@ -32,17 +33,18 @@
 //! loop keeps reading; only an internal fault (poisoned stdout, etc.)
 //! exits with status 4.
 //!
-//! STATS coverage: emits the same six fields the Java sidecar reports
-//! (`acked`, `sent`, `acks`, `reconnAttempts`, `reconnSucc`, `serverErrors`).
-//! `acked` comes from `Sender::acked_fsn`; the rest come from
-//! `Sender::qwp_ws_totals` and are bumped at the same QWP/WebSocket
-//! event sites as their Java counterparts.
+//! STATS coverage: emits the same eight fields the Java sidecar reports
+//! (`acked`, `sent`, `replayed`, `startupSent`, `acks`, `reconnAttempts`,
+//! `reconnSucc`, `serverErrors`). `acked` comes from `Sender::acked_fsn`;
+//! `startupSent` is sidecar phase state; the rest come from
+//! `Sender::qwp_ws_totals` and are bumped at the same QWP/WebSocket event sites
+//! as their Java counterparts.
 
 use std::io::{BufRead, BufReader, Write};
 use std::process;
 use std::time::Duration;
 
-use questdb::ingress::{AckLevel, Buffer, Sender, TimestampMicros};
+use questdb::ingress::{AckLevel, Buffer, QwpWsTotals, Sender, TimestampMicros};
 
 fn main() {
     let stdin = std::io::stdin();
@@ -95,6 +97,7 @@ struct State {
     sender: Option<Sender>,
     buf: Option<Buffer>,
     request_durable_ack: bool,
+    producer_published: bool,
 }
 
 impl State {
@@ -108,6 +111,7 @@ impl State {
         }
         self.buf = None;
         self.request_durable_ack = false;
+        self.producer_published = false;
     }
 }
 
@@ -180,6 +184,9 @@ fn handle(line: &str, state: &mut State, out: &mut impl Write) -> Result<(), Str
                 // so -1 is the closest equivalent sentinel.
                 .map(|n| n as i64)
                 .unwrap_or(-1);
+            // Match Java's phase marker: only a successful producer FLUSH ends
+            // the startup-recovery observation window.
+            state.producer_published = true;
             reply_ok(out, &fsn.to_string())
         }
         "AWAIT_ACKED" => {
@@ -232,22 +239,12 @@ fn handle(line: &str, state: &mut State, out: &mut impl Write) -> Result<(), Str
                 .flatten()
                 .map(|n| n as i64)
                 .unwrap_or(-1);
-            let payload = match sender.qwp_ws_totals() {
-                Ok(t) => format!(
-                    "acked={acked} sent={} acks={} reconnAttempts={} reconnSucc={} serverErrors={}",
-                    t.frames_sent,
-                    t.acks,
-                    t.reconnect_attempts,
-                    t.reconnects_succeeded,
-                    t.server_errors,
-                ),
-                Err(_) => format!(
-                    "acked={acked} sent=0 acks=0 reconnAttempts=0 reconnSucc=0 serverErrors=0"
-                ),
-            };
+            let totals = sender.qwp_ws_totals().ok();
+            let payload = stats_payload(acked, totals.as_ref(), state.producer_published);
             reply_ok(out, &payload)
         }
         "CLOSE" => {
+            state.producer_published = false;
             if let Some(mut s) = state.sender.take() {
                 // close_drain is the Rust analogue of Java's
                 // Sender.close(): flush, wait for ACKs up to the
@@ -265,6 +262,26 @@ fn handle(line: &str, state: &mut State, out: &mut impl Write) -> Result<(), Str
             process::exit(0);
         }
         _ => Err(format!("unknown verb: {verb}")),
+    }
+}
+
+fn stats_payload(acked: i64, totals: Option<&QwpWsTotals>, producer_published: bool) -> String {
+    match totals {
+        Some(t) => {
+            let startup_sent = if producer_published { 0 } else { t.frames_sent };
+            format!(
+                "acked={acked} sent={} replayed={} startupSent={startup_sent} acks={} reconnAttempts={} reconnSucc={} serverErrors={}",
+                t.frames_sent,
+                t.frames_replayed,
+                t.acks,
+                t.reconnect_attempts,
+                t.reconnects_succeeded,
+                t.server_errors,
+            )
+        }
+        None => format!(
+            "acked={acked} sent=0 replayed=0 startupSent=0 acks=0 reconnAttempts=0 reconnSucc=0 serverErrors=0"
+        ),
     }
 }
 
@@ -292,4 +309,33 @@ fn sanitize(s: &str) -> String {
     // Newlines in an ERR message would break the line-based protocol.
     // Match the Java sidecar's substitution: CR → space, LF → '|'.
     s.replace('\r', " ").replace('\n', "|")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stats_payload_matches_the_eight_field_enterprise_contract() {
+        let mut totals = QwpWsTotals::default();
+        totals.frames_sent = 7;
+        totals.frames_replayed = 3;
+        totals.acks = 5;
+        totals.reconnect_attempts = 2;
+        totals.reconnects_succeeded = 1;
+        totals.server_errors = 4;
+
+        assert_eq!(
+            stats_payload(6, Some(&totals), false),
+            "acked=6 sent=7 replayed=3 startupSent=7 acks=5 reconnAttempts=2 reconnSucc=1 serverErrors=4"
+        );
+        assert_eq!(
+            stats_payload(6, Some(&totals), true),
+            "acked=6 sent=7 replayed=3 startupSent=0 acks=5 reconnAttempts=2 reconnSucc=1 serverErrors=4"
+        );
+        assert_eq!(
+            stats_payload(-1, None, false),
+            "acked=-1 sent=0 replayed=0 startupSent=0 acks=0 reconnAttempts=0 reconnSucc=0 serverErrors=0"
+        );
+    }
 }


### PR DESCRIPTION
Aligns the pool's startup model with the Java client:
1. `initial_connect_retry` is honored again on pool borrows. Since the `borrow_sender()` unification the key parsed but was silently forced to async; an explicit `off` now connects at borrow and fails fast, `sync` retries within the reconnect budget.

2. `connect()` is eager by default: it pre-opens the warm minimums (`sender_pool_min` senders, `query_pool_min` readers) honoring `initial_connect_retry`, so a down server or bad credentials fail the constructor. `lazy_connect=true` restores the offline-tolerant startup (non-blocking connect, background sender connects, `query_pool_min` defaults to 0) and rejects a blocking `initial_connect_retry` or positive `query_pool_min` as a config conflict, with Java's remedy wording. Recovery pre-opens connect in the background under either mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable `lazy_connect` pool behavior (eager-by-default remains default): connect on first use; reader connections/errors can be deferred until borrow.
  * Added clearer replay accounting for reconnects (e.g., replay vs initial sent frames).
* **Bug Fixes**
  * Enforced stricter `lazy_connect` validation vs retry and reader minimum settings to prevent startup blocking and fail-fast conflicts.
  * Improved async initial-connect behavior during recovery/store-and-forward flows.
* **Documentation**
  * Updated C/C++/Rust docs and STATS protocol field descriptions to match eager vs lazy startup and replay counters.
* **Tests**
  * Expanded/standardized lazy-connect usage across unit, system, fuzz, and failover suites, including eager-vs-lazy scenarios and validation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->