### PR TITLE
ci(maven): rerun the Maven compile task when it fails

### DIFF
--- a/ci/run_fuzz_pipeline.yaml
+++ b/ci/run_fuzz_pipeline.yaml
@@ -70,6 +70,7 @@ stages:
           - template: templates/maven_settings.yaml
           - task: Maven@3
             displayName: "Compile QuestDB"
+            retryCountOnTaskFailure: 2
             inputs:
               mavenPOMFile: "questdb/pom.xml"
               javaHomeOption: "Path"
@@ -184,6 +185,7 @@ stages:
           - template: templates/maven_settings.yaml
           - task: Maven@3
             displayName: "Compile QuestDB"
+            retryCountOnTaskFailure: 2
             inputs:
               mavenPOMFile: "questdb/pom.xml"
               javaHomeOption: "Path"
@@ -295,6 +297,7 @@ stages:
             displayName: "Install JDK 25"
           - task: Maven@3
             displayName: "Compile QuestDB"
+            retryCountOnTaskFailure: 2
             inputs:
               mavenPOMFile: "questdb/pom.xml"
               jdkVersionOption: "default"

--- a/ci/run_soak_pipeline.yaml
+++ b/ci/run_soak_pipeline.yaml
@@ -96,6 +96,7 @@ stages:
           - template: templates/maven_settings.yaml
           - task: Maven@3
             displayName: "Compile QuestDB"
+            retryCountOnTaskFailure: 2
             inputs:
               mavenPOMFile: "questdb/pom.xml"
               javaHomeOption: "Path"

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -58,6 +58,7 @@ stages:
           - template: templates/clone_questdb.yaml
           - task: Maven@3
             displayName: "Compile QuestDB"
+            retryCountOnTaskFailure: 2
             inputs:
               mavenPOMFile: "questdb/pom.xml"
               javaHomeOption: "Path"
@@ -120,6 +121,7 @@ stages:
           - template: templates/clone_questdb.yaml
           - task: Maven@3
             displayName: "Compile QuestDB"
+            retryCountOnTaskFailure: 2
             inputs:
               mavenPOMFile: "questdb/pom.xml"
               javaHomeOption: "Path"
@@ -345,6 +347,7 @@ stages:
           - template: templates/maven_settings.yaml
           - task: Maven@3
             displayName: "Compile QuestDB"
+            retryCountOnTaskFailure: 2
             inputs:
               mavenPOMFile: "questdb/pom.xml"
               javaHomeOption: "Path"
@@ -420,6 +423,7 @@ stages:
           - template: templates/maven_settings.yaml
           - task: Maven@3
             displayName: "Compile QuestDB"
+            retryCountOnTaskFailure: 2
             inputs:
               mavenPOMFile: "questdb/pom.xml"
               javaHomeOption: "Path"
@@ -521,6 +525,7 @@ stages:
           - template: templates/maven_settings.yaml
           - task: Maven@3
             displayName: "Compile QuestDB"
+            retryCountOnTaskFailure: 2
             inputs:
               mavenPOMFile: "questdb/pom.xml"
               javaHomeOption: "Path"
@@ -581,6 +586,7 @@ stages:
             displayName: "Install JDK 25 (required by QuestDB master)"
           - task: Maven@3
             displayName: "Compile QuestDB"
+            retryCountOnTaskFailure: 2
             inputs:
               mavenPOMFile: "questdb/pom.xml"
               jdkVersionOption: "default"

--- a/ci/templates/maven_settings.yaml
+++ b/ci/templates/maven_settings.yaml
@@ -52,9 +52,12 @@
 # how a scheduled fuzz run on a hosted macOS agent failed despite these
 # options). The Maven compile steps therefore also set
 # retryCountOnTaskFailure: 2, which makes Azure rerun the whole task on
-# failure. A rerun keeps everything already in the local repository and spends
-# minutes recompiling the modules built so far before it reaches the download
-# that failed, so it retries on a timescale that outlasts such an outage.
+# failure. A rerun keeps everything already in the local repository, so a
+# download that failed deep in the build is re-reached only after minutes of
+# recompiling the modules built so far — far more likely to outlast such an
+# outage than a back-to-back retry. A download that fails during the initial
+# dependency resolution is re-reached sooner, so the rerun helps most once the
+# build has made progress.
 #
 # The echo lines run without `set -x`. Azure treats any line containing
 # `##vso[` as a command and takes the text after `]` as the value; tracing the

--- a/ci/templates/maven_settings.yaml
+++ b/ci/templates/maven_settings.yaml
@@ -44,20 +44,12 @@
 #     short cap discards a connection the network may have silently dropped
 #     instead of handing it to the next download.
 #
-# The retryHandler retries fire back-to-back within about a second, so they
-# only cover a failure that is over the moment it happens: one dropped
-# connection, one bad response. A network or DNS outage that lasts longer
-# swallows every attempt (the JVM even caches a failed hostname lookup for 10
-# seconds, so immediate retries re-fail without touching the network — that is
-# how a scheduled fuzz run on a hosted macOS agent failed despite these
-# options). The Maven compile steps therefore also set
-# retryCountOnTaskFailure: 2, which makes Azure rerun the whole task on
-# failure. A rerun keeps everything already in the local repository, so a
-# download that failed deep in the build is re-reached only after minutes of
-# recompiling the modules built so far — far more likely to outlast such an
-# outage than a back-to-back retry. A download that fails during the initial
-# dependency resolution is re-reached sooner, so the rerun helps most once the
-# build has made progress.
+# These retries fire back-to-back within a second, so they only cover a blip:
+# one dropped connection, one bad response. A longer network or DNS outage
+# defeats them (the JVM even caches a failed hostname lookup for 10 seconds).
+# The Maven compile steps therefore also set retryCountOnTaskFailure: 2, so
+# Azure reruns the whole task; that rerun reuses the local repository and takes
+# minutes to reach the failed download again, giving a short outage time to pass.
 #
 # The echo lines run without `set -x`. Azure treats any line containing
 # `##vso[` as a command and takes the text after `]` as the value; tracing the

--- a/ci/templates/maven_settings.yaml
+++ b/ci/templates/maven_settings.yaml
@@ -44,6 +44,18 @@
 #     short cap discards a connection the network may have silently dropped
 #     instead of handing it to the next download.
 #
+# The retryHandler retries fire back-to-back within about a second, so they
+# only cover a failure that is over the moment it happens: one dropped
+# connection, one bad response. A network or DNS outage that lasts longer
+# swallows every attempt (the JVM even caches a failed hostname lookup for 10
+# seconds, so immediate retries re-fail without touching the network — that is
+# how a scheduled fuzz run on a hosted macOS agent failed despite these
+# options). The Maven compile steps therefore also set
+# retryCountOnTaskFailure: 2, which makes Azure rerun the whole task on
+# failure. A rerun keeps everything already in the local repository and spends
+# minutes recompiling the modules built so far before it reaches the download
+# that failed, so it retries on a timescale that outlasts such an outage.
+#
 # The echo lines run without `set -x`. Azure treats any line containing
 # `##vso[` as a command and takes the text after `]` as the value; tracing the
 # echo would print the closing quote that bash adds, and that quote would end

--- a/system_test/qwp_egress_reader.py
+++ b/system_test/qwp_egress_reader.py
@@ -258,9 +258,12 @@ _setsig(
 
 # Reader error handling.
 _setsig("questdb_error_get_code", _c_int32, ctypes.POINTER(_LineReaderError))
+# restype is a raw void pointer, not c_char_p: the message is a borrowed,
+# non-NUL-terminated slice with its length in the out-param. A c_char_p
+# restype would make ctypes scan for a NUL and read past the slice's end.
 _setsig(
     "questdb_error_msg",
-    _c_char_p,
+    _c_void_p,
     ctypes.POINTER(_LineReaderError),
     ctypes.POINTER(_c_size_t),
 )
@@ -290,7 +293,7 @@ def _take_error(err_ptr) -> ReaderError:
     msg_len = _c_size_t(0)
     raw = _DLL.questdb_error_msg(err_ptr, ctypes.byref(msg_len))
     msg = (
-        bytes(ctypes.string_at(raw, msg_len.value)).decode("utf-8", "replace")
+        ctypes.string_at(raw, msg_len.value).decode("utf-8", "replace")
         if raw and msg_len.value
         else ""
     )
@@ -909,11 +912,17 @@ class QwpEgressReader:
             )
             if not ok:
                 raise _take_error(err_ref)
+            # The FFI hands back a borrowed, non-NUL-terminated slice with its
+            # length in `name_len`. Read the pointer's address via a void_p
+            # cast (no dereference) and copy exactly `name_len` bytes.
+            # `name_ptr.value` would instead scan for a NUL terminator and walk
+            # off the end of the slice into unmapped memory.
+            name_addr = ctypes.cast(name_ptr, ctypes.c_void_p).value
             name = (
                 ctypes.string_at(name_ptr, name_len.value).decode(
                     "utf-8", "replace"
                 )
-                if name_ptr.value and name_len.value
+                if name_addr and name_len.value
                 else ""
             )
             cols.append({"name": name, "type": ""})  # type filled in after decode


### PR DESCRIPTION
## What happened

The scheduled fuzz run on 2026-07-27 ([build 255975](https://dev.azure.com/questdb/questdb/_build/results?buildId=255975)) failed on the hosted macOS agent even though the Maven invocation carried the wagon retry options added in #169. The settings-file probe and the retry flags all worked as designed; the agent then lost DNS resolution for `repo.maven.apache.org` for ~30 seconds mid-build. All three wagon retries re-failed instantly out of the JVM's 10-second negative DNS cache without ever touching the network. Back-to-back retries only cover a failure that is over the moment it happens; they cannot outlast an outage.

## The fix

Add `retryCountOnTaskFailure: 2` to every Maven "Compile QuestDB" task across all three pipelines (ten tasks in total: three in `run_fuzz_pipeline.yaml`, six in `run_tests_pipeline.yaml`, one in `run_soak_pipeline.yaml`). A task rerun keeps everything already present in the local Maven repository and spends minutes recompiling the modules built so far before it reaches the download that failed, so it is far more likely to outlast this kind of outage.

This also covers the two integration-test jobs in `run_tests_pipeline.yaml` that never got the wagon retry options, and it applies to the hetzner jobs too, where a rerun rides out a hiccup of the internal cache.

The comment in `templates/maven_settings.yaml` now documents how the two retry layers divide the work.

`retryCountOnTaskFailure` needs agent ≥ 2.194; the hetzner pool runs 4.274.1, so it is honored on every pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI stability by enabling Maven “Compile QuestDB” task retries (up to two) across scheduled fuzz, test, native, and soak pipeline jobs.
  * Fixed native QWP egress reader handling for error messages and column names to safely process non-NUL-terminated strings.
* **Documentation**
  * Clarified Maven settings guidance on when built-in retry handling applies versus when full task retries are needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
