### PR TITLE
docs(qwp): define standalone direct sender drop contract

### DIFF
--- a/ci/check_docs.py
+++ b/ci/check_docs.py
@@ -380,6 +380,10 @@ def check_compatibility(errors):
                 "Enterprise-only `qwpws_ack_level_durable`",
                 "durable ACK edition qualifier",
             ),
+            (
+                "NULL for a standalone handle",
+                "standalone direct-sender force-drop contract",
+            ),
         ),
         ROOT / "include" / "questdb" / "ingress" / "line_sender.h": (
             (

--- a/ci/check_docs.py
+++ b/ci/check_docs.py
@@ -399,6 +399,10 @@ def check_compatibility(errors):
                 "Enterprise-only\n * `qwpws_ack_level_durable`",
                 "durable ACK edition qualifier",
             ),
+            (
+                "For a standalone handle, pass NULL for `db`.",
+                "standalone direct-sender force-drop contract",
+            ),
         ),
     }
     for path, required_text in public_contract_requirements.items():

--- a/include/questdb/ingress/qwp_sender.h
+++ b/include/questdb/ingress/qwp_sender.h
@@ -89,16 +89,17 @@ extern "C" {
  *  store-and-forward queue owns delivery. */
 typedef struct qwp_sender qwp_sender;
 
-/** Borrowed direct (pipelined, non-store-and-forward) column-major QWP/WS
- *  sender from the always-direct pool, independent of `sf_dir`. Not
- *  thread-safe; belongs to the borrowing thread until returned via
- *  `questdb_db_return_direct_sender`.
+/** Direct (pipelined, non-store-and-forward) column-major QWP/WS sender.
+ *  Either borrowed from the always-direct pool, independent of `sf_dir`, or
+ *  opened standalone by `qwp_direct_sender_from_conf` /
+ *  `qwp_direct_sender_from_opts`. Not thread-safe; belongs to the calling
+ *  thread until released through the matching return, drop, or free function.
  *
  *  Exposes publish-only `qwp_direct_sender_flush`, the
  *  `qwp_direct_sender_commit` boundary, and the Arrow batch variants.
  *  There is no internal failover: on a transient
- *  `line_sender_error_failover_retry` the caller drops the sender, re-borrows
- *  a live one, and re-drives the uncommitted tail from its own source. */
+ *  `line_sender_error_failover_retry` the caller drops the sender, obtains a
+ *  new one, and re-drives the uncommitted tail from its own source. */
 typedef struct qwp_direct_sender qwp_direct_sender;
 
 /** One DataFrame's worth of column buffers destined for one QuestDB table.
@@ -251,8 +252,10 @@ qwp_direct_sender* questdb_db_borrow_direct_sender_with_retry(
  * QWP/WebSocket config string, owning its own connection with no pool — for
  * one-off DataFrame bulk loads without a `questdb_db`. `conf` is a UTF-8
  * string of `conf_len` bytes. Returns NULL on failure and sets `*err_out` if
- * provided. Free the returned handle with `qwp_direct_sender_free` (there
- * is no pool to return it to).
+ * provided. On normal completion free the returned handle with
+ * `qwp_direct_sender_free` (there is no pool to return it to). To discard
+ * uncommitted frames after a failure, call
+ * `questdb_db_drop_direct_sender(NULL, sender)` instead.
  */
 QUESTDB_CLIENT_API
 qwp_direct_sender* qwp_direct_sender_from_conf(
@@ -267,8 +270,10 @@ qwp_direct_sender* qwp_direct_sender_from_conf(
  * the `line_sender_opts_*` builder functions rather than a config string — so
  * this works for a sender configured either way. `opts` is borrowed, not
  * consumed: the caller retains ownership and must still free it. Returns NULL
- * on failure and sets `*err_out` if provided. Free the returned handle with
- * `qwp_direct_sender_free` (there is no pool to return it to).
+ * on failure and sets `*err_out` if provided. On normal completion free the
+ * returned handle with `qwp_direct_sender_free` (there is no pool to return it
+ * to). To discard uncommitted frames after a failure, call
+ * `questdb_db_drop_direct_sender(NULL, sender)` instead.
  */
 QUESTDB_CLIENT_API
 qwp_direct_sender* qwp_direct_sender_from_opts(
@@ -280,6 +285,11 @@ qwp_direct_sender* qwp_direct_sender_from_opts(
  * Invalidates the `sender` pointer. If the sender has latched terminal state,
  * or if the pool has been closed, it is closed instead of recycled. A sender
  * returned with uncommitted pipelined frames has them committed best-effort.
+ * This function accepts only handles borrowed through
+ * `questdb_db_borrow_direct_sender` /
+ * `questdb_db_borrow_direct_sender_with_retry`. For a standalone handle use
+ * `qwp_direct_sender_free`, or `questdb_db_drop_direct_sender(NULL, sender)` to
+ * discard uncommitted frames after a failure.
  *
  * Mutually exclusive with `questdb_db_drop_direct_sender` on the same
  * `sender`: call exactly one of the two. Calling both (or either twice) is UB.
@@ -290,16 +300,27 @@ void questdb_db_return_direct_sender(
     qwp_direct_sender* sender);
 
 /**
- * Force-drop a borrowed direct sender instead of recycling it. Invalidates
- * `sender`. Accepts NULL and no-ops.
+ * Force-drop a direct sender, closing its connection instead of recycling it
+ * or committing its uncommitted frames. `sender` may be either borrowed from a
+ * pool or returned by `qwp_direct_sender_from_conf` /
+ * `qwp_direct_sender_from_opts`.
+ *
+ * `db` is ignored and may be NULL: `sender` retains the backing information
+ * needed to release itself. Pass the originating `db` for a borrowed handle.
+ * For a standalone handle, pass NULL for `db`.
+ *
+ * Invalidates `sender`. Accepts NULL `sender` and no-ops.
  *
  * Use this after a failure that may have left in-doubt or uncommitted frames
  * on the connection; otherwise a later borrower could commit those frames
  * together with its own batch. Uncommitted frames are discarded with the
- * connection — the caller re-drives them from its own source.
+ * connection — the caller re-drives them from its own source. A pooled sender
+ * is closed instead of recycled; a standalone sender is closed outright.
  *
- * Mutually exclusive with `questdb_db_return_direct_sender` on the same
- * `sender`: call exactly one of the two. Calling both (or either twice) is UB.
+ * For a pool-borrowed handle this is mutually exclusive with
+ * `questdb_db_return_direct_sender`; for a standalone handle it is mutually
+ * exclusive with `qwp_direct_sender_free`. Call exactly one matching release
+ * function. Calling more than one (or any release function twice) is UB.
  */
 QUESTDB_CLIENT_API
 void questdb_db_drop_direct_sender(
@@ -307,11 +328,15 @@ void questdb_db_drop_direct_sender(
     qwp_direct_sender* sender);
 
 /**
- * Free a standalone `qwp_direct_sender_from_conf` handle, committing any
- * un-sync'd deferred frames best-effort first (call
- * `qwp_direct_sender_commit` or a waited flush beforehand for delivery
- * certainty). Invalidates `sender`. Accepts NULL and no-ops. For a
- * pool-borrowed handle use `questdb_db_return_direct_sender` instead.
+ * Free a standalone `qwp_direct_sender_from_conf` /
+ * `qwp_direct_sender_from_opts` handle, committing any un-sync'd deferred
+ * frames best-effort first (call `qwp_direct_sender_commit` or a waited flush
+ * beforehand for delivery certainty). Invalidates `sender`. Accepts NULL and
+ * no-ops. For a pool-borrowed handle use
+ * `questdb_db_return_direct_sender` instead. To discard a standalone handle's
+ * uncommitted frames after a failure, use
+ * `questdb_db_drop_direct_sender(NULL, sender)` instead; calling both release
+ * functions (or either twice) is UB.
  */
 QUESTDB_CLIENT_API
 void qwp_direct_sender_free(

--- a/include/questdb/ingress/qwp_sender.h
+++ b/include/questdb/ingress/qwp_sender.h
@@ -285,7 +285,7 @@ qwp_direct_sender* qwp_direct_sender_from_opts(
  * Invalidates the `sender` pointer. If the sender has latched terminal state,
  * or if the pool has been closed, it is closed instead of recycled. A sender
  * returned with uncommitted pipelined frames has them committed best-effort.
- * This function accepts only handles borrowed through
+ * This function is intended only for handles borrowed through
  * `questdb_db_borrow_direct_sender` /
  * `questdb_db_borrow_direct_sender_with_retry`. For a standalone handle use
  * `qwp_direct_sender_free`, or `questdb_db_drop_direct_sender(NULL, sender)` to
@@ -312,10 +312,11 @@ void questdb_db_return_direct_sender(
  * Invalidates `sender`. Accepts NULL `sender` and no-ops.
  *
  * Use this after a failure that may have left in-doubt or uncommitted frames
- * on the connection; otherwise a later borrower could commit those frames
- * together with its own batch. Uncommitted frames are discarded with the
- * connection — the caller re-drives them from its own source. A pooled sender
- * is closed instead of recycled; a standalone sender is closed outright.
+ * on the connection; for a pooled sender this stops a later borrower from
+ * committing those frames together with its own batch. Uncommitted frames are
+ * discarded with the connection — the caller re-drives them from its own
+ * source. A pooled sender is closed instead of recycled; a standalone sender
+ * is closed outright.
  *
  * For a pool-borrowed handle this is mutually exclusive with
  * `questdb_db_return_direct_sender`; for a standalone handle it is mutually

--- a/questdb-rs-ffi/src/column_sender.rs
+++ b/questdb-rs-ffi/src/column_sender.rs
@@ -94,9 +94,10 @@ pub struct questdb_db(pub(crate) QuestDb);
 pub struct qwp_sender(pub(crate) OwnedSender, pub(crate) AtomicU32);
 
 /// Direct (pipelined, non-store-and-forward) sibling of [`qwp_sender`],
-/// borrowed from the always-direct pool via
-/// `questdb_db_borrow_direct_sender`. Same single-threaded /
-/// reentrancy-latch contract as [`qwp_sender`]; it exposes
+/// either borrowed from the always-direct pool via
+/// `questdb_db_borrow_direct_sender` or opened standalone via
+/// `qwp_direct_sender_from_conf` / `qwp_direct_sender_from_opts`. Same
+/// single-threaded / reentrancy-latch contract as [`qwp_sender`]; it exposes
 /// `qwp_direct_sender_flush` + `qwp_direct_sender_flush_and_wait` +
 /// `qwp_direct_sender_commit` instead of the store-and-forward queue
 /// primitives exposed by [`qwp_sender`].
@@ -1065,9 +1066,11 @@ pub unsafe extern "C" fn questdb_db_borrow_direct_sender_with_retry(
 
 /// Build a direct (pipelined, non-store-and-forward) column sender from a
 /// QWP/WebSocket config string, owning its own connection with no pool. `conf`
-/// is a UTF-8 string of `conf_len` bytes. Free the returned handle with
-/// `qwp_direct_sender_free`; there is no pool to return it to. Returns NULL
-/// on failure; sets `*err_out` if provided.
+/// is a UTF-8 string of `conf_len` bytes. On normal completion free the
+/// returned handle with `qwp_direct_sender_free`; there is no pool to return
+/// it to. To discard uncommitted frames after a failure, call
+/// `questdb_db_drop_direct_sender(NULL, sender)` instead. Returns NULL on
+/// failure; sets `*err_out` if provided.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qwp_direct_sender_from_conf(
     conf: *const c_char,
@@ -1092,9 +1095,11 @@ pub unsafe extern "C" fn qwp_direct_sender_from_conf(
 /// opts carry the full auth/TLS configuration (including options set through
 /// the `line_sender_opts_*` builder functions rather than a config string), so
 /// this works for senders built either way. `opts` is borrowed, not consumed:
-/// the caller retains ownership and must still free it. Free the returned
-/// handle with `qwp_direct_sender_free`. Returns NULL on failure; sets
-/// `*err_out` if provided.
+/// the caller retains ownership and must still free it. On normal completion
+/// free the returned handle with `qwp_direct_sender_free`. To discard
+/// uncommitted frames after a failure, call
+/// `questdb_db_drop_direct_sender(NULL, sender)` instead. Returns NULL on
+/// failure; sets `*err_out` if provided.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qwp_direct_sender_from_opts(
     opts: *const line_sender_opts,
@@ -1159,7 +1164,9 @@ pub unsafe extern "C" fn questdb_db_return_sender(_db: *mut questdb_db, sender: 
     unsafe { return_or_drop_cs(sender, 0) };
 }
 
-/// Direct-handle counterpart of `questdb_db_return_sender`.
+/// Return a pool-borrowed direct sender. Standalone handles must instead use
+/// `qwp_direct_sender_free`, or `questdb_db_drop_direct_sender(NULL, sender)`
+/// to discard uncommitted frames after a failure.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn questdb_db_return_direct_sender(
     _db: *mut questdb_db,
@@ -1184,7 +1191,13 @@ pub unsafe extern "C" fn questdb_db_drop_sender(_db: *mut questdb_db, sender: *m
     unsafe { return_or_drop_cs(sender, LATCH_DROP) };
 }
 
-/// Direct-handle counterpart of `questdb_db_drop_sender`.
+/// Force-drop a direct sender, closing its connection instead of recycling it
+/// or committing its uncommitted frames. The sender may be pool-borrowed or
+/// standalone. `_db` is ignored and may be NULL because the sender retains its
+/// own backing information. Pass the originating db for a pool-borrowed
+/// handle and NULL for a standalone handle. For a pool-borrowed handle this is
+/// mutually exclusive with `questdb_db_return_direct_sender`; for a standalone
+/// handle it is mutually exclusive with `qwp_direct_sender_free`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn questdb_db_drop_direct_sender(
     _db: *mut questdb_db,
@@ -1193,11 +1206,14 @@ pub unsafe extern "C" fn questdb_db_drop_direct_sender(
     unsafe { return_or_drop_cs(sender, LATCH_DROP) };
 }
 
-/// Free a standalone `qwp_direct_sender_from_conf` handle, committing any
-/// un-sync'd deferred frames first (call `qwp_direct_sender_commit` or a
-/// waited flush beforehand for delivery certainty). Accepts NULL and no-ops.
-/// For a pool-borrowed handle use `questdb_db_return_direct_sender`
-/// instead. A racing in-flight call defers the free to that call's exit path.
+/// Free a standalone `qwp_direct_sender_from_conf` /
+/// `qwp_direct_sender_from_opts` handle, committing any un-sync'd deferred
+/// frames first (call `qwp_direct_sender_commit` or a waited flush beforehand
+/// for delivery certainty). Accepts NULL and no-ops. For a pool-borrowed
+/// handle use `questdb_db_return_direct_sender` instead. To discard a
+/// standalone handle's uncommitted frames, use
+/// `questdb_db_drop_direct_sender(NULL, sender)` instead. A racing in-flight
+/// call defers the free to that call's exit path.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qwp_direct_sender_free(sender: *mut qwp_direct_sender) {
     unsafe { return_or_drop_cs(sender, 0) };
@@ -6029,6 +6045,13 @@ mod tests {
     #[test]
     fn qwp_direct_sender_free_accepts_null() {
         unsafe { qwp_direct_sender_free(std::ptr::null_mut()) };
+    }
+
+    #[test]
+    fn questdb_db_drop_direct_sender_accepts_null_db_and_sender() {
+        unsafe {
+            questdb_db_drop_direct_sender(std::ptr::null_mut(), std::ptr::null_mut());
+        }
     }
 
     #[test]

--- a/questdb-rs/src/tests/qwp_sender_pool.rs
+++ b/questdb-rs/src/tests/qwp_sender_pool.rs
@@ -2992,6 +2992,104 @@ fn direct_flush_split_floor_marks_must_close_to_discard_uncommitted_prefix() {
     );
 }
 
+/// A standalone direct sender built with `OwnedDirectColumnSender::from_conf`
+/// (the backing of the FFI `qwp_direct_sender_from_conf` /
+/// `qwp_direct_sender_from_opts` handles) owns its connection outright with no
+/// pool. On a plain drop — the path `qwp_direct_sender_free` and
+/// `questdb_db_return_direct_sender` take (`return_or_drop_cs(sender, 0)`) — it
+/// best-effort commits any un-sync'd deferred frames before closing, so the
+/// deferred tail reaches the server with a commit boundary. Exercises the
+/// `DirectBacking::Standalone` arm of `OwnedDirectColumnSender::drop` and
+/// `commit_in_flight_on_drop`.
+#[cfg(feature = "ffi-support")]
+#[test]
+fn standalone_direct_sender_free_commits_in_flight_on_drop() {
+    const FLAG_DEFER_COMMIT: u8 = 0x01;
+    let (server, frames) = MockServer::spawn_acking_capturing(1);
+    let conf = conf_for(server.port(), "");
+    let mut sender =
+        crate::db::OwnedDirectColumnSender::from_conf(&conf).expect("standalone connect");
+
+    let qty = [1_i64];
+    let ts = [1_i64];
+    let mut c1 = Chunk::new("trades");
+    c1.column_i64("qty", &qty, None).unwrap();
+    c1.at_nanos(&ts).unwrap();
+    sender.get_mut().flush(&mut c1).unwrap(); // committed inline
+
+    let mut c2 = Chunk::new("trades");
+    c2.column_i64("qty", &qty, None).unwrap();
+    c2.at_nanos(&ts).unwrap();
+    sender.get_mut().flush(&mut c2).unwrap(); // deferred: published, uncommitted
+    assert!(
+        sender.get().in_flight() > 0,
+        "deferred flush must leave an uncommitted in-flight frame"
+    );
+
+    drop(sender); // free path: must_close stays unset -> best-effort commit of the tail
+
+    let mut captured = Vec::new();
+    while let Ok(frame) = frames.recv_timeout(Duration::from_millis(500)) {
+        captured.push(frame);
+    }
+    let last = captured.last().expect("server must have received frames");
+    assert_eq!(
+        last[5] & FLAG_DEFER_COMMIT,
+        0,
+        "free-drop must close the deferred tail with a commit boundary, not discard it"
+    );
+}
+
+/// Force-drop counterpart: `questdb_db_drop_direct_sender(NULL, sender)` on a
+/// standalone handle (`return_or_drop_cs(sender, LATCH_DROP)`) sets
+/// `must_close` before the box is dropped, so `commit_in_flight_on_drop`
+/// short-circuits and the connection closes outright with its un-sync'd
+/// deferred frames discarded — never committed, so in-doubt data cannot reach
+/// the table. The `NULL` `db` is irrelevant: the standalone backing lives in
+/// the sender itself.
+#[cfg(feature = "ffi-support")]
+#[test]
+fn standalone_direct_sender_force_drop_discards_in_flight() {
+    const FLAG_DEFER_COMMIT: u8 = 0x01;
+    let (server, frames) = MockServer::spawn_acking_capturing(1);
+    let conf = conf_for(server.port(), "");
+    let mut sender =
+        crate::db::OwnedDirectColumnSender::from_conf(&conf).expect("standalone connect");
+
+    let qty = [1_i64];
+    let ts = [1_i64];
+    let mut c1 = Chunk::new("trades");
+    c1.column_i64("qty", &qty, None).unwrap();
+    c1.at_nanos(&ts).unwrap();
+    sender.get_mut().flush(&mut c1).unwrap(); // committed inline
+
+    let mut c2 = Chunk::new("trades");
+    c2.column_i64("qty", &qty, None).unwrap();
+    c2.at_nanos(&ts).unwrap();
+    sender.get_mut().flush(&mut c2).unwrap(); // deferred: published, uncommitted
+    assert!(
+        sender.get().in_flight() > 0,
+        "deferred flush must be in-flight"
+    );
+
+    // `questdb_db_drop_direct_sender` sets must_close before dropping the
+    // box (via `on_deferred_close`); replicate that to drive the discard arm.
+    sender.mark_must_close();
+    drop(sender);
+
+    let mut captured = Vec::new();
+    while let Ok(frame) = frames.recv_timeout(Duration::from_millis(500)) {
+        captured.push(frame);
+    }
+    let last = captured.last().expect("server must have received frames");
+    assert_ne!(
+        last[5] & FLAG_DEFER_COMMIT,
+        0,
+        "force-drop must leave the deferred tail uncommitted (discarded), \
+         not send a commit boundary"
+    );
+}
+
 #[test]
 fn store_and_forward_flush_splits_oversize_chunk_into_self_sufficient_frames() {
     // The store-and-forward backend also splits an oversize chunk, but into

--- a/system_test/arrow_ffi.py
+++ b/system_test/arrow_ffi.py
@@ -36,7 +36,7 @@ class _QwpSender(ctypes.Structure):
 
 
 class _DirectColumnSender(ctypes.Structure):
-    """Opaque `qwp_direct_sender*` (borrowed pipelined connection)."""
+    """Opaque `qwp_direct_sender*` (pipelined connection: pool-borrowed or standalone)."""
 
 
 class ArrowSenderError(_SenderError):


### PR DESCRIPTION
## Summary

- clarify that `qwp_direct_sender` handles may be pool-borrowed or standalone
- define the normal-release and force-drop contract for both ownership modes
- explicitly support `questdb_db_drop_direct_sender(NULL, sender)` for standalone failure cleanup
- mirror the public contract in the Rust FFI docs and pin it with documentation and ABI regression checks

## Context

A client review flagged the NULL `db` call as a possible crash or leak. The Rust implementation already ignores that argument and retains the pool-versus-standalone backing in the sender itself, so the runtime behavior is safe. The public C documentation, however, only described borrowed handles and did not exempt `db` from the general non-NULL opaque-handle convention.

This PR aligns the existing API contract with the implemented ownership semantics. It does not change ABI signatures or add a new symbol.

## Testing

- `python3 ci/check_docs.py`
- `cargo fmt --manifest-path questdb-rs-ffi/Cargo.toml -- --check`
- `cargo test --manifest-path questdb-rs-ffi/Cargo.toml` — 87 passed
- `cargo clippy --manifest-path questdb-rs-ffi/Cargo.toml --tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded direct sender lifecycle and failure-handling guidance, including when to return, free, or force-drop handles.
  - Clarified standalone vs pooled handle expectations and the correct cleanup after failures, including `db` being allowed to be `NULL`.
  - Documented connection-close behavior and the mutually exclusive release/discard methods.

- **Tests**
  - Added integration coverage verifying standalone direct-sender drop behavior for deferred frames: best-effort commit on the “free” path vs discarding uncommitted deferred frames on the “force drop” path.
  - Added checks that discarding accepts `NULL` for both `db` and the sender handle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->