### PR TITLE
fix(egress): allow synchronized cursor thread handoff

### DIFF
--- a/cpp_test/test_reader_mock.cpp
+++ b/cpp_test/test_reader_mock.cpp
@@ -3364,7 +3364,7 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "mock: query and cursor migrate across threads with callback and destruction")
+    "mock: query and cursor migrate across threads with callbacks and destruction")
 {
     qm::Script s_a = {
         qm::ActionSendServerInfo{qm::ROLE_STANDALONE, "c", "a"},
@@ -3386,33 +3386,56 @@ TEST_CASE(
     struct ThreadRecord
     {
         std::mutex mutex;
-        std::optional<std::thread::id> callback_on;
-        std::optional<std::thread::id> destroyed_on;
+        std::optional<std::thread::id> reset_callback_on;
+        std::optional<std::thread::id> reset_destroyed_on;
+        std::optional<std::thread::id> progress_callback_on;
+        std::optional<std::thread::id> progress_destroyed_on;
     };
-    struct CallbackPayload
+    struct ResetCallbackPayload
     {
         std::shared_ptr<ThreadRecord> record;
 
-        ~CallbackPayload()
+        ~ResetCallbackPayload()
         {
             std::lock_guard<std::mutex> guard{record->mutex};
-            record->destroyed_on = std::this_thread::get_id();
+            record->reset_destroyed_on = std::this_thread::get_id();
+        }
+    };
+    struct ProgressCallbackPayload
+    {
+        std::shared_ptr<ThreadRecord> record;
+
+        ~ProgressCallbackPayload()
+        {
+            std::lock_guard<std::mutex> guard{record->mutex};
+            record->progress_destroyed_on = std::this_thread::get_id();
         }
     };
 
     auto record = std::make_shared<ThreadRecord>();
-    auto payload = std::make_shared<CallbackPayload>();
-    payload->record = record;
+    auto reset_payload = std::make_shared<ResetCallbackPayload>();
+    reset_payload->record = record;
+    auto progress_payload = std::make_shared<ProgressCallbackPayload>();
+    progress_payload->record = record;
     auto query = reader.prepare("select 1"_utf8);
     query.on_failover_reset(
-        [payload](const eg::failover_reset_event_view&)
+        [reset_payload](const eg::failover_reset_event_view&)
         {
-            std::lock_guard<std::mutex> guard{payload->record->mutex};
-            payload->record->callback_on = std::this_thread::get_id();
+            std::lock_guard<std::mutex> guard{reset_payload->record->mutex};
+            reset_payload->record->reset_callback_on =
+                std::this_thread::get_id();
         });
-    // The stored callback is now the sole payload owner. Its destruction
+    query.on_failover_progress(
+        [progress_payload](const eg::failover_progress_event_view&)
+        {
+            std::lock_guard<std::mutex> guard{progress_payload->record->mutex};
+            progress_payload->record->progress_callback_on =
+                std::this_thread::get_id();
+        });
+    // The stored callbacks are now the sole payload owners. Their destruction
     // therefore records the thread that finally destroys the cursor.
-    payload.reset();
+    reset_payload.reset();
+    progress_payload.reset();
 
     const auto main_thread = std::this_thread::get_id();
     std::optional<eg::cursor> cursor;
@@ -3460,7 +3483,7 @@ TEST_CASE(
             {
                 drive_error = std::current_exception();
             }
-            // `cursor` and its heap-stored callback are destroyed here.
+            // `cursor` and its heap-stored callbacks are destroyed here.
         });
     drive_worker.join();
     if (drive_error)
@@ -3468,10 +3491,14 @@ TEST_CASE(
     CHECK(drive_thread != main_thread);
 
     std::lock_guard<std::mutex> guard{record->mutex};
-    REQUIRE(record->callback_on.has_value());
-    REQUIRE(record->destroyed_on.has_value());
-    CHECK(*record->callback_on == drive_thread);
-    CHECK(*record->destroyed_on == drive_thread);
+    REQUIRE(record->reset_callback_on.has_value());
+    REQUIRE(record->reset_destroyed_on.has_value());
+    REQUIRE(record->progress_callback_on.has_value());
+    REQUIRE(record->progress_destroyed_on.has_value());
+    CHECK(*record->reset_callback_on == drive_thread);
+    CHECK(*record->reset_destroyed_on == drive_thread);
+    CHECK(*record->progress_callback_on == drive_thread);
+    CHECK(*record->progress_destroyed_on == drive_thread);
 }
 
 // ---------------------------------------------------------------------------

--- a/cpp_test/test_reader_mock.cpp
+++ b/cpp_test/test_reader_mock.cpp
@@ -36,7 +36,10 @@
 #include <atomic>
 #include <chrono>
 #include <cstring>
+#include <exception>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <type_traits>
@@ -3358,6 +3361,117 @@ TEST_CASE(
     // main entered the loop, the rest of the assertions don't actually
     // prove cross-thread concurrency.
     CHECK(poll_count > 0);
+}
+
+TEST_CASE(
+    "mock: query and cursor migrate across threads with callback and destruction")
+{
+    qm::Script s_a = {
+        qm::ActionSendServerInfo{qm::ROLE_STANDALONE, "c", "a"},
+        qm::ActionAwaitQueryRequest{},
+        qm::ActionHardDrop{},
+    };
+    qm::Script s_b = {
+        qm::ActionSendServerInfo{qm::ROLE_STANDALONE, "c", "b"},
+        qm::ActionAwaitQueryRequest{},
+        qm::ActionSendResultEnd{},
+    };
+    qm::MockServer srv_a({s_a});
+    qm::MockServer srv_b({s_b});
+    const std::string conf =
+        "ws::addr=" + srv_a.addr() + "," + srv_b.addr() +
+        ";failover_backoff_initial_ms=1;failover_backoff_max_ms=10";
+    eg::reader reader{questdb::ingress::utf8_view{conf}};
+
+    struct ThreadRecord
+    {
+        std::mutex mutex;
+        std::optional<std::thread::id> callback_on;
+        std::optional<std::thread::id> destroyed_on;
+    };
+    struct CallbackPayload
+    {
+        std::shared_ptr<ThreadRecord> record;
+
+        ~CallbackPayload()
+        {
+            std::lock_guard<std::mutex> guard{record->mutex};
+            record->destroyed_on = std::this_thread::get_id();
+        }
+    };
+
+    auto record = std::make_shared<ThreadRecord>();
+    auto payload = std::make_shared<CallbackPayload>();
+    payload->record = record;
+    auto query = reader.prepare("select 1"_utf8);
+    query.on_failover_reset(
+        [payload](const eg::failover_reset_event_view&)
+        {
+            std::lock_guard<std::mutex> guard{payload->record->mutex};
+            payload->record->callback_on = std::this_thread::get_id();
+        });
+    // The stored callback is now the sole payload owner. Its destruction
+    // therefore records the thread that finally destroys the cursor.
+    payload.reset();
+
+    const auto main_thread = std::this_thread::get_id();
+    std::optional<eg::cursor> cursor;
+    std::thread::id execute_thread;
+    std::exception_ptr execute_error;
+    std::thread execute_worker(
+        [query = std::move(query),
+         &cursor,
+         &execute_thread,
+         &execute_error]() mutable
+        {
+            execute_thread = std::this_thread::get_id();
+            try
+            {
+                cursor.emplace(query.execute());
+            }
+            catch (...)
+            {
+                execute_error = std::current_exception();
+            }
+        });
+    execute_worker.join();
+    if (execute_error)
+        std::rethrow_exception(execute_error);
+    REQUIRE(cursor.has_value());
+    CHECK(execute_thread != main_thread);
+
+    auto migrated_cursor = std::move(*cursor);
+    cursor.reset();
+    std::thread::id drive_thread;
+    std::exception_ptr drive_error;
+    std::thread drive_worker(
+        [cursor = std::move(migrated_cursor),
+         &drive_thread,
+         &drive_error]() mutable
+        {
+            drive_thread = std::this_thread::get_id();
+            try
+            {
+                while (cursor.next_batch())
+                {
+                }
+            }
+            catch (...)
+            {
+                drive_error = std::current_exception();
+            }
+            // `cursor` and its heap-stored callback are destroyed here.
+        });
+    drive_worker.join();
+    if (drive_error)
+        std::rethrow_exception(drive_error);
+    CHECK(drive_thread != main_thread);
+
+    std::lock_guard<std::mutex> guard{record->mutex};
+    REQUIRE(record->callback_on.has_value());
+    REQUIRE(record->destroyed_on.has_value());
+    CHECK(*record->callback_on == drive_thread);
+    CHECK(*record->destroyed_on == drive_thread);
 }
 
 // ---------------------------------------------------------------------------

--- a/include/questdb/egress/qwp_reader.h
+++ b/include/questdb/egress/qwp_reader.h
@@ -40,41 +40,24 @@ extern "C" {
 
 /////////// Thread safety.
 //
-// All four handles must be accessed by only one thread at a time. Beyond
-// that, the four handle types have different thread-mobility rules:
+// All four handles must be accessed by only one thread at a time. They may
+// be migrated between threads, but the caller MUST establish a happens-before
+// edge on every transfer. A pthread mutex hand-off, a thread spawn/join, or a
+// `std::atomic` with release/acquire on the handle pointer are all sufficient.
+// Concurrent operations from two threads are always undefined behaviour —
+// only sequential migration is supported.
 //
-//   `qwp_reader`         — may be migrated between threads (no concurrent
-//                           access). The caller MUST establish a
-//                           happens-before edge on every transfer — the
-//                           reader's internal state is non-atomic and the
-//                           library does not insert a fence for you. A
-//                           pthread mutex hand-off, a thread spawn/join,
-//                           or a `std::atomic` with release/acquire on
-//                           the handle pointer are all sufficient. The
-//                           library does maintain an internal AtomicBool
-//                           that guards the reader-vs-query/cursor
-//                           lifecycle and pairs Release with Acquire on
-//                           every lifecycle event, but that pairing is an
-//                           implementation detail — it cannot publish the
-//                           reader's state on the very first migration
-//                           after `_from_conf` / `_from_env` (no
-//                           lifecycle event has happened yet). Concurrent
-//                           operations from two threads are always
-//                           undefined behaviour — only sequential
-//                           migration is supported.
+//   `qwp_reader`         — thread-mobile under the rule above. The reader's
+//                           internal state is non-atomic and the library does
+//                           not insert a general publication fence for you.
 //
-//   `qwp_reader_query`   — MUST stay on the thread that created it.
-//   `qwp_reader_cursor`     The query/cursor wraps an internal failover
-//                           callback closure that is `!Send` (it can
-//                           legitimately capture `!Send` user state in a
-//                           future revision), so handing the handle to
-//                           another thread — even with a happens-before
-//                           edge and no concurrent access — is undefined
-//                           behaviour.
+//   `qwp_reader_query`   — thread-mobile under the rule above. Any installed
+//   `qwp_reader_cursor`     failover callback runs on the thread that drives
+//                           the current cursor operation. Its `user_data`
+//                           must therefore remain valid and be safe to use on
+//                           every destination thread.
 //
-//   `questdb_error`   — has no thread affinity. May be created on one
-//                           thread and freed/inspected on another, but
-//                           must not be used from two threads at once.
+//   `questdb_error`      — thread-mobile under the rule above.
 //
 // Borrowed pointers returned by this API — `qwp_reader_server_info*`,
 // `qwp_reader_failover_reset_event*`, host byte slices, varchar/binary/symbol
@@ -486,11 +469,14 @@ typedef struct qwp_reader_failover_reset_event qwp_reader_failover_reset_event;
  *    accumulator, set a flag, signal a condition variable — and do
  *    any heavy work outside the cursor's drive thread.
  *
- * The callback may freely touch `event` and `user_data`; both are
- * owned by the caller's logic, not by the in-flight cursor.
+ * The callback may freely touch `event` and `user_data`; both are owned by
+ * the caller's logic, not by the in-flight cursor. If the query/cursor is
+ * handed to another thread, the caller MUST also ensure that `user_data` is
+ * valid and safe to access on that destination thread.
  *
- * The callback runs on the thread driving the in-flight cursor
- * operation.
+ * The callback runs on the thread driving the in-flight cursor operation.
+ * If the query/cursor is handed to another thread, the caller MUST ensure
+ * that `user_data` remains valid and is safe to access there.
  */
 typedef void (*qwp_reader_failover_reset_callback)(
     const qwp_reader_failover_reset_event* event,
@@ -613,8 +599,9 @@ typedef struct qwp_reader_failover_progress_event qwp_reader_failover_progress_e
  *    accumulator, set a flag, signal a condition variable — and do
  *    any heavy work outside the cursor's drive thread.
  *
- * The callback runs on the thread driving the in-flight cursor
- * operation.
+ * The callback runs on the thread driving the in-flight cursor operation.
+ * If the query/cursor is handed to another thread, the caller MUST ensure
+ * that `user_data` remains valid and is safe to access there.
  */
 typedef void (*qwp_reader_failover_progress_callback)(
     const qwp_reader_failover_progress_event* event,
@@ -1050,7 +1037,8 @@ QUESTDB_CLIENT_API void qwp_reader_query_on_failover_progress(
 
 /*
  * Opaque cursor handle. Borrows from the originating `qwp_reader` for its
- * entire lifetime — the reader MUST outlive the cursor. Single-threaded.
+ * entire lifetime — the reader MUST outlive the cursor. Thread-mobile but
+ * single-threaded: follow the synchronized hand-off contract above.
  *
  * The `qwp_reader_cursor` type is forward-declared near the top of this
  * header.

--- a/include/questdb/egress/qwp_reader.h
+++ b/include/questdb/egress/qwp_reader.h
@@ -470,9 +470,7 @@ typedef struct qwp_reader_failover_reset_event qwp_reader_failover_reset_event;
  *    any heavy work outside the cursor's drive thread.
  *
  * The callback may freely touch `event` and `user_data`; both are owned by
- * the caller's logic, not by the in-flight cursor. If the query/cursor is
- * handed to another thread, the caller MUST also ensure that `user_data` is
- * valid and safe to access on that destination thread.
+ * the caller's logic, not by the in-flight cursor.
  *
  * The callback runs on the thread driving the in-flight cursor operation.
  * If the query/cursor is handed to another thread, the caller MUST ensure

--- a/include/questdb/egress/qwp_reader.hpp
+++ b/include/questdb/egress/qwp_reader.hpp
@@ -50,15 +50,14 @@ namespace questdb::egress
 // `std::move` lets you transfer ownership, but the destination thread inherits
 // the same per-handle access rules:
 //
-//   `reader`               — may be moved between threads (no concurrent
-//                            access). Insert a happens-before edge on
-//                            transfer; the underlying C handle uses non-
-//                            atomic state with no automatic visibility.
-//   `query` / `cursor`     — MUST stay on the thread that created them.
-//                            Even with external synchronisation, moving
-//                            either across threads is undefined behaviour
-//                            (their internal failover-callback closure is
-//                            `!Send`).
+//   `reader` / `query` /   — may be moved between threads (no concurrent
+//   `cursor`                 access). Insert a happens-before edge on every
+//                            transfer; the underlying handles use non-atomic
+//                            state with no general publication fence.
+//                            Failover callbacks run, and their captured state
+//                            may eventually be destroyed, on the thread that
+//                            drives or destroys the migrated handle. Captures
+//                            must be safe for that hand-off.
 // The wrappers cannot statically enforce these rules; they document the
 // same contract the C API does.
 // ---------------------------------------------------------------------------
@@ -1133,7 +1132,8 @@ public:
      * not leave any visible side effect outside the callback itself.
      *
      * The callback runs on the thread driving the in-flight cursor
-     * operation.
+     * operation. If the query/cursor is moved to another thread, its
+     * captures must be safe to access and eventually destroy there.
      */
     query& on_failover_reset(failover_reset_callback cb)
     {
@@ -1176,7 +1176,10 @@ public:
      * Reentrancy contract is identical to `on_failover_reset`: the
      * callback MUST NOT touch the originating reader / query / cursor,
      * MUST NOT block, and any thrown exception is swallowed (an
-     * unwind across the C boundary would be undefined behaviour).
+     * unwind across the C boundary would be undefined behaviour). The
+     * callback runs on the cursor's drive thread; after a cross-thread
+     * move, its captures must be safe to access and eventually destroy
+     * on the destination thread.
      */
     query& on_failover_progress(failover_progress_callback cb)
     {

--- a/include/questdb/egress/qwp_reader.hpp
+++ b/include/questdb/egress/qwp_reader.hpp
@@ -58,6 +58,9 @@ namespace questdb::egress
 //                            may eventually be destroyed, on the thread that
 //                            drives or destroys the migrated handle. Captures
 //                            must be safe for that hand-off.
+//   `questdb_error`          — may likewise be transferred between threads,
+//                            but only one thread may access or free it at a
+//                            time.
 // The wrappers cannot statically enforce these rules; they document the
 // same contract the C API does.
 // ---------------------------------------------------------------------------

--- a/questdb-rs-ffi/src/egress.rs
+++ b/questdb-rs-ffi/src/egress.rs
@@ -379,6 +379,47 @@ pub struct qwp_reader {
     ownership: ReaderOwnership,
 }
 
+/// Raw reader backpointer carried by a query/cursor across an externally
+/// synchronized thread hand-off.
+///
+/// SAFETY: the C contract requires the originating reader to outlive every
+/// query/cursor and prohibits concurrent access. The caller's happens-before
+/// edge publishes both the pointee and the handle state before migration.
+/// Keeping this unsafe assertion on the pointer field, rather than the whole
+/// FFI handle, lets compile-time `Send` assertions catch future non-Send
+/// fields added to either handle.
+#[derive(Clone, Copy)]
+struct ReaderBackptr(*mut qwp_reader);
+
+unsafe impl Send for ReaderBackptr {}
+
+impl ReaderBackptr {
+    fn as_ptr(&self) -> *mut qwp_reader {
+        self.0
+    }
+
+    fn is_null(&self) -> bool {
+        self.0.is_null()
+    }
+}
+
+/// Opaque callback context supplied by C. The library never dereferences it;
+/// it only round-trips the bit pattern to the callback on the cursor's current
+/// drive thread.
+///
+/// SAFETY: installing a callback and migrating the query/cursor promises that
+/// the caller-provided context is valid on the destination thread. This is the
+/// C equivalent of the Rust callback's `Send` bound.
+struct CallbackUserData(*mut c_void);
+
+unsafe impl Send for CallbackUserData {}
+
+impl CallbackUserData {
+    fn as_ptr(&self) -> *mut c_void {
+        self.0
+    }
+}
+
 /// How a [`qwp_reader`] is owned, and what to do with it on close.
 ///
 /// `must_close` lives inside the `Pooled` arm because it is only
@@ -1263,12 +1304,12 @@ pub unsafe extern "C" fn qwp_reader_query_on_failover_reset(
     user_data: *mut c_void,
 ) {
     unsafe {
+        let user_data = CallbackUserData(user_data);
         // Wrap the C function pointer + user_data in a Rust closure that
         // matches the `FnMut(&FailoverResetEvent) + 'r` signature `ReaderQuery`
-        // expects. The trait bound has no `Send` requirement; the cursor
-        // is single-threaded and the trampoline runs on the same thread
-        // that drives `next_batch`. The C caller owns `user_data` and is
-        // responsible for its lifetime — see the header docs.
+        // expects. The cursor is thread-mobile but single-threaded: the
+        // trampoline runs on whichever thread drives `next_batch`. The C
+        // caller owns `user_data` and must keep it valid across any hand-off.
         let trampoline = move |event: &FailoverResetEvent| {
             if let Some(c_cb) = callback {
                 let opaque =
@@ -1283,7 +1324,7 @@ pub unsafe extern "C" fn qwp_reader_query_on_failover_reset(
                 // users get the unwind-into-C protection from the wrapper's
                 // noexcept trampoline.
                 let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    c_cb(opaque, user_data)
+                    c_cb(opaque, user_data.as_ptr())
                 }));
                 if result.is_err() {
                     std::process::abort();
@@ -1638,12 +1679,13 @@ pub unsafe extern "C" fn qwp_reader_query_on_failover_progress(
     user_data: *mut c_void,
 ) {
     unsafe {
+        let user_data = CallbackUserData(user_data);
         let trampoline = move |event: &FailoverProgressEvent| {
             if let Some(c_cb) = callback {
                 let opaque = event as *const FailoverProgressEvent
                     as *const qwp_reader_failover_progress_event;
                 let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    c_cb(opaque, user_data)
+                    c_cb(opaque, user_data.as_ptr())
                 }));
                 if result.is_err() {
                     std::process::abort();
@@ -1672,7 +1714,7 @@ pub struct qwp_reader_query {
     /// flag on `_query_free` or `_query_execute` failure. Always non-NULL
     /// for a valid query (the C contract requires the reader to outlive
     /// the query).
-    reader: *mut qwp_reader,
+    reader: ReaderBackptr,
     /// First fatal error detected by an FFI-level bind/builder method
     /// that has no `err_out` slot of its own (currently only
     /// `_bind_varchar`'s UTF-8 re-validation). `_query_execute` checks
@@ -1800,7 +1842,7 @@ pub unsafe extern "C" fn qwp_reader_prepare(
             let q_static: ReaderQuery<'static> = std::mem::transmute(q);
             Box::into_raw(Box::new(qwp_reader_query {
                 inner: ManuallyDrop::new(q_static),
-                reader,
+                reader: ReaderBackptr(reader),
                 deferred_err: None,
             }))
         }));
@@ -1826,7 +1868,7 @@ pub unsafe extern "C" fn qwp_reader_query_free(query: *mut qwp_reader_query) {
         // Release the reader's active flag so a new query/cursor can be
         // started.
         if !boxed.reader.is_null() {
-            (*boxed.reader)
+            (*boxed.reader.as_ptr())
                 .cursor_active
                 .store(false, Ordering::Release);
         }
@@ -1888,7 +1930,9 @@ pub unsafe extern "C" fn qwp_reader_query_execute(
         if let Some(e) = boxed.deferred_err.take() {
             drop(q);
             if !reader.is_null() {
-                (*reader).cursor_active.store(false, Ordering::Release);
+                (*reader.as_ptr())
+                    .cursor_active
+                    .store(false, Ordering::Release);
             }
             write_err_box(err_out, e);
             return ptr::null_mut();
@@ -1927,7 +1971,9 @@ pub unsafe extern "C" fn qwp_reader_query_execute(
                 Err(e) => {
                     // Query gone, no cursor produced — release the active flag.
                     if !reader.is_null() {
-                        (*reader).cursor_active.store(false, Ordering::Release);
+                        (*reader.as_ptr())
+                            .cursor_active
+                            .store(false, Ordering::Release);
                     }
                     write_err_box(err_out, e);
                     ptr::null_mut()
@@ -2000,7 +2046,7 @@ pub unsafe extern "C" fn qwp_reader_execute(
                         current_batch: None,
                         #[cfg(feature = "arrow")]
                         arrow_schema_pin: None,
-                        reader,
+                        reader: ReaderBackptr(reader),
                     }))
                 }
                 Err(e) => {
@@ -2416,8 +2462,19 @@ pub struct qwp_reader_cursor {
     arrow_schema_pin: Option<arrow::datatypes::SchemaRef>,
     /// Backpointer to the originating reader, used to clear its `active`
     /// flag on `_cursor_free`. Always non-NULL for a valid cursor.
-    reader: *mut qwp_reader,
+    reader: ReaderBackptr,
 }
+
+// Pin the FFI mobility contract. These handles may be transferred across
+// threads under external synchronization; this does not permit concurrent
+// access. Keeping this assertion here makes any future non-Send field a
+// compile error instead of a silent contract regression.
+const _: fn() = || {
+    fn assert_send<T: Send>() {}
+    assert_send::<qwp_reader>();
+    assert_send::<qwp_reader_query>();
+    assert_send::<qwp_reader_cursor>();
+};
 
 impl qwp_reader_cursor {
     /// Drop any in-flight `BatchView` and yield exclusive access to the
@@ -2485,7 +2542,7 @@ pub unsafe extern "C" fn qwp_reader_cursor_free(cursor: *mut qwp_reader_cursor) 
         // Release the reader's active flag so a new query/cursor can be
         // started.
         if !boxed.reader.is_null() {
-            (*boxed.reader)
+            (*boxed.reader.as_ptr())
                 .cursor_active
                 .store(false, Ordering::Release);
         }

--- a/questdb-rs-ffi/src/egress.rs
+++ b/questdb-rs-ffi/src/egress.rs
@@ -2421,7 +2421,8 @@ fn column_kind_from_c(k: u32) -> Option<ColumnKind> {
 // ---------------------------------------------------------------------------
 
 /// Opaque cursor handle. Borrows from the originating `qwp_reader` for its
-/// entire lifetime — the reader MUST outlive the cursor. Single-threaded.
+/// entire lifetime — the reader MUST outlive the cursor. Thread-mobile but
+/// single-threaded.
 ///
 /// # Self-referential invariant (READ BEFORE EDITING)
 ///

--- a/questdb-rs/src/egress/reader.rs
+++ b/questdb-rs/src/egress/reader.rs
@@ -203,23 +203,18 @@ const _: fn() = || {
     assert_send_sync::<HostHealthTracker>();
 };
 
-// Two blanket impls of the same trait force method-resolution ambiguity
-// iff the target type IS `Send`; the call thus compiles only when the
-// type is `!Send`.
+// Query and cursor handles may be migrated between threads, provided the
+// caller establishes a happens-before edge and never accesses a handle
+// concurrently. Keep this assertion next to Reader's stronger Send + Sync
+// assertion so a future non-Send field cannot silently narrow that contract.
 const _: fn() = || {
-    trait AmbiguousIfSend<A> {
-        fn _disambiguate() {}
-    }
-    impl<T: ?Sized> AmbiguousIfSend<()> for T {}
-    impl<T: ?Sized + Send> AmbiguousIfSend<u8> for T {}
-    fn assert_not_send<T: ?Sized>() {
-        let _: fn() = <T as AmbiguousIfSend<_>>::_disambiguate;
-    }
-    assert_not_send::<crate::egress::Cursor<'_>>();
+    fn assert_send<T: Send>() {}
+    assert_send::<crate::egress::ReaderQuery<'_>>();
+    assert_send::<crate::egress::Cursor<'_>>();
     #[cfg(feature = "arrow-egress")]
-    assert_not_send::<crate::egress::arrow::CursorRecordBatchReader<'_, '_>>();
+    assert_send::<crate::egress::arrow::CursorRecordBatchReader<'_, '_>>();
     #[cfg(feature = "polars-egress")]
-    assert_not_send::<crate::egress::arrow::polars::CursorPolarsIter<'_, '_>>();
+    assert_send::<crate::egress::arrow::polars::CursorPolarsIter<'_, '_>>();
 };
 
 impl Reader {
@@ -707,7 +702,6 @@ impl Reader {
             reset_symbol_dict: false,
             on_failover_reset: None,
             on_failover_progress: None,
-            _not_send: std::marker::PhantomData,
         }
     }
 
@@ -778,7 +772,7 @@ pub struct FailoverResetEvent {
 }
 
 /// Boxed user callback type for failover-reset notifications.
-type FailoverResetCallback<'r> = Box<dyn FnMut(&FailoverResetEvent) + 'r>;
+type FailoverResetCallback<'r> = Box<dyn FnMut(&FailoverResetEvent) + Send + 'r>;
 
 /// Phase discriminant on [`FailoverProgressEvent`].
 ///
@@ -864,17 +858,15 @@ pub struct FailoverProgressEvent {
 }
 
 /// Boxed user callback type for failover-progress notifications.
-type FailoverProgressCallback<'r> = Box<dyn FnMut(&FailoverProgressEvent) + 'r>;
+type FailoverProgressCallback<'r> = Box<dyn FnMut(&FailoverProgressEvent) + Send + 'r>;
 
 /// Borrows a `Reader` exclusively while the query is being constructed and
 /// (eventually) the cursor is live.
 ///
-/// `ReaderQuery` is unconditionally `!Send`. The failover-reset callback
-/// can capture non-`Send` state (the C FFI trampoline captures
-/// `*mut c_void` `user_data`), so allowing the type to migrate threads
-/// based on whether a callback is currently installed would be a leaky
-/// abstraction. The `_not_send` marker pins the choice regardless of
-/// callback presence.
+/// `ReaderQuery` is [`Send`], but not safe for concurrent access. It may be
+/// moved to another thread after an explicit happens-before hand-off. Any
+/// installed failover callback must therefore also be [`Send`]; it runs on
+/// whichever thread subsequently drives the cursor.
 #[must_use = "ReaderQuery does nothing until you call .execute(); dropping it discards \
               the prepared SQL and any binds without sending a QUERY_REQUEST"]
 pub struct ReaderQuery<'r> {
@@ -891,8 +883,6 @@ pub struct ReaderQuery<'r> {
     /// failover lifecycle — see [`FailoverProgressEvent`] /
     /// [`FailoverPhase`].
     on_failover_progress: Option<FailoverProgressCallback<'r>>,
-    /// Pin `!Send` regardless of whether the callback is installed.
-    _not_send: std::marker::PhantomData<*const ()>,
 }
 
 macro_rules! bind_method {
@@ -941,6 +931,9 @@ impl<'r> ReaderQuery<'r> {
     ///
     /// Calling this method twice on the same `ReaderQuery` **replaces**
     /// the previous closure — only the most recent callback is invoked.
+    /// The callback must be [`Send`]: a query/cursor may be handed to
+    /// another thread, and the callback then runs and is dropped on that
+    /// destination thread.
     ///
     /// Mirrors the Java client's `onFailoverReset(newNode)` contract.
     ///
@@ -994,7 +987,7 @@ impl<'r> ReaderQuery<'r> {
     /// ```
     pub fn on_failover_reset<F>(mut self, callback: F) -> Self
     where
-        F: FnMut(&FailoverResetEvent) + 'r,
+        F: FnMut(&FailoverResetEvent) + Send + 'r,
     {
         self.on_failover_reset = Some(Box::new(callback));
         self
@@ -1015,6 +1008,9 @@ impl<'r> ReaderQuery<'r> {
     ///
     /// Calling this method twice on the same `ReaderQuery` **replaces**
     /// the previous closure — only the most recent callback is invoked.
+    /// The callback must be [`Send`]: a query/cursor may be handed to
+    /// another thread, and the callback then runs and is dropped on that
+    /// destination thread.
     ///
     /// # Reentrancy
     ///
@@ -1031,7 +1027,7 @@ impl<'r> ReaderQuery<'r> {
     ///   grant, and cancel waits until the callback returns.
     pub fn on_failover_progress<F>(mut self, callback: F) -> Self
     where
-        F: FnMut(&FailoverProgressEvent) + 'r,
+        F: FnMut(&FailoverProgressEvent) + Send + 'r,
     {
         self.on_failover_progress = Some(Box::new(callback));
         self
@@ -1231,7 +1227,6 @@ impl<'r> ReaderQuery<'r> {
             symbol_registry: None,
             #[cfg(feature = "polars-egress")]
             symbol_delta_modes: Vec::new(),
-            _not_send: std::marker::PhantomData,
         })
     }
 }
@@ -1424,12 +1419,9 @@ pub enum Terminal {
 /// terminal frame arrives (which is then accessible via [`Cursor::terminal`]).
 /// `cancel` sends a `CANCEL` frame and drains until the server's terminal.
 ///
-/// `Cursor` is unconditionally `!Send`. The failover-reset callback can
-/// capture non-`Send` state (the C FFI trampoline captures
-/// `*mut c_void` `user_data`); pinning `!Send` regardless of whether a
-/// callback is currently installed avoids a leaky abstraction whereby
-/// a Cursor that happens not to have a callback would be `Send` and
-/// then suddenly stop being so when one is installed.
+/// `Cursor` is [`Send`], but not safe for concurrent access. It may be moved
+/// to another thread after an explicit happens-before hand-off. Failover
+/// callbacks run on whichever thread drives the cursor.
 #[must_use = "Cursor must be drained via next_batch() or cancelled via cancel(); \
               dropping mid-stream sends a best-effort CANCEL and closes the WebSocket, \
               tearing down the connection for the next query on this Reader"]
@@ -1544,8 +1536,6 @@ pub struct Cursor<'r> {
     /// `DecodedBatch` before it is assembled.
     #[cfg(feature = "polars-egress")]
     symbol_delta_modes: Vec<bool>,
-    /// Pin `!Send` regardless of whether the callback is installed.
-    _not_send: std::marker::PhantomData<*const ()>,
 }
 
 /// Borrow-free outcome of `next_batch_inner`. The wrapper in

--- a/questdb-rs/src/egress/reader.rs
+++ b/questdb-rs/src/egress/reader.rs
@@ -933,7 +933,8 @@ impl<'r> ReaderQuery<'r> {
     /// the previous closure — only the most recent callback is invoked.
     /// The callback must be [`Send`]: a query/cursor may be handed to
     /// another thread, and the callback then runs and is dropped on that
-    /// destination thread.
+    /// destination thread. This bound is required even if the caller never
+    /// migrates the handle.
     ///
     /// Mirrors the Java client's `onFailoverReset(newNode)` contract.
     ///
@@ -1010,7 +1011,8 @@ impl<'r> ReaderQuery<'r> {
     /// the previous closure — only the most recent callback is invoked.
     /// The callback must be [`Send`]: a query/cursor may be handed to
     /// another thread, and the callback then runs and is dropped on that
-    /// destination thread.
+    /// destination thread. This bound is required even if the caller never
+    /// migrates the handle.
     ///
     /// # Reentrancy
     ///

--- a/questdb-rs/tests/egress_failover.rs
+++ b/questdb-rs/tests/egress_failover.rs
@@ -4646,9 +4646,9 @@ fn reader_migrates_to_worker_thread_with_concurrent_stats_polling() {
 }
 
 #[test]
-fn query_and_cursor_migrate_across_threads_with_callback_and_drop() {
+fn query_and_cursor_migrate_across_threads_with_callbacks_and_drop() {
     // A accepts the query and then drops. B serves the replay to terminal,
-    // guaranteeing that the reset callback fires on the cursor's drive
+    // guaranteeing that the reset and progress callbacks fire on the cursor's drive
     // thread.
     let srv_a = MockServer::start(vec![drop_after_query_script(ServerRole::Standalone, "a")]);
     let srv_b = MockServer::start(vec![happy_script(ServerRole::Standalone, "b")]);
@@ -4667,18 +4667,30 @@ fn query_and_cursor_migrate_across_threads_with_callback_and_drop() {
         }
     }
 
-    let callback_on = Arc::new(Mutex::new(None));
-    let dropped_on = Arc::new(Mutex::new(None));
-    let callback_on_cloned = Arc::clone(&callback_on);
-    let probe = DropProbe {
-        dropped_on: Arc::clone(&dropped_on),
+    let reset_callback_on = Arc::new(Mutex::new(None));
+    let reset_dropped_on = Arc::new(Mutex::new(None));
+    let progress_callback_on = Arc::new(Mutex::new(None));
+    let progress_dropped_on = Arc::new(Mutex::new(None));
+    let reset_callback_on_cloned = Arc::clone(&reset_callback_on);
+    let progress_callback_on_cloned = Arc::clone(&progress_callback_on);
+    let reset_probe = DropProbe {
+        dropped_on: Arc::clone(&reset_dropped_on),
     };
-    let query = reader.prepare("select 1").on_failover_reset(move |_ev| {
-        // Keep the drop probe inside the callback allocation. It must be
-        // destroyed with the cursor on the final owner thread.
-        let _probe = &probe;
-        *callback_on_cloned.lock().unwrap() = Some(thread::current().id());
-    });
+    let progress_probe = DropProbe {
+        dropped_on: Arc::clone(&progress_dropped_on),
+    };
+    let query = reader
+        .prepare("select 1")
+        .on_failover_reset(move |_ev| {
+            // Keep the drop probe inside the callback allocation. It must be
+            // destroyed with the cursor on the final owner thread.
+            let _probe = &reset_probe;
+            *reset_callback_on_cloned.lock().unwrap() = Some(thread::current().id());
+        })
+        .on_failover_progress(move |_ev| {
+            let _probe = &progress_probe;
+            *progress_callback_on_cloned.lock().unwrap() = Some(thread::current().id());
+        });
 
     let main_thread = thread::current().id();
     thread::scope(|scope| {
@@ -4695,7 +4707,7 @@ fn query_and_cursor_migrate_across_threads_with_callback_and_drop() {
         assert_ne!(execute_thread, main_thread);
 
         // The cursor then crosses a second synchronized hand-off. The
-        // failover callback and final Cursor/closure drop both occur there.
+        // failover callbacks and final Cursor/closure drops all occur there.
         let drive_thread = scope
             .spawn(move || {
                 let mut cursor = cursor;
@@ -4709,8 +4721,10 @@ fn query_and_cursor_migrate_across_threads_with_callback_and_drop() {
             .join()
             .expect("drive worker panicked");
         assert_ne!(drive_thread, main_thread);
-        assert_eq!(*callback_on.lock().unwrap(), Some(drive_thread));
-        assert_eq!(*dropped_on.lock().unwrap(), Some(drive_thread));
+        assert_eq!(*reset_callback_on.lock().unwrap(), Some(drive_thread));
+        assert_eq!(*reset_dropped_on.lock().unwrap(), Some(drive_thread));
+        assert_eq!(*progress_callback_on.lock().unwrap(), Some(drive_thread));
+        assert_eq!(*progress_dropped_on.lock().unwrap(), Some(drive_thread));
     });
 }
 

--- a/questdb-rs/tests/egress_failover.rs
+++ b/questdb-rs/tests/egress_failover.rs
@@ -4645,6 +4645,75 @@ fn reader_migrates_to_worker_thread_with_concurrent_stats_polling() {
     );
 }
 
+#[test]
+fn query_and_cursor_migrate_across_threads_with_callback_and_drop() {
+    // A accepts the query and then drops. B serves the replay to terminal,
+    // guaranteeing that the reset callback fires on the cursor's drive
+    // thread.
+    let srv_a = MockServer::start(vec![drop_after_query_script(ServerRole::Standalone, "a")]);
+    let srv_b = MockServer::start(vec![happy_script(ServerRole::Standalone, "b")]);
+    let conf = format!(
+        "ws::addr={};failover_backoff_initial_ms=1;failover_backoff_max_ms=2",
+        build_addr_list(&[&srv_a, &srv_b])
+    );
+    let mut reader = Reader::from_conf(&conf).expect("connect");
+
+    struct DropProbe {
+        dropped_on: Arc<Mutex<Option<thread::ThreadId>>>,
+    }
+    impl Drop for DropProbe {
+        fn drop(&mut self) {
+            *self.dropped_on.lock().unwrap() = Some(thread::current().id());
+        }
+    }
+
+    let callback_on = Arc::new(Mutex::new(None));
+    let dropped_on = Arc::new(Mutex::new(None));
+    let callback_on_cloned = Arc::clone(&callback_on);
+    let probe = DropProbe {
+        dropped_on: Arc::clone(&dropped_on),
+    };
+    let query = reader.prepare("select 1").on_failover_reset(move |_ev| {
+        // Keep the drop probe inside the callback allocation. It must be
+        // destroyed with the cursor on the final owner thread.
+        let _probe = &probe;
+        *callback_on_cloned.lock().unwrap() = Some(thread::current().id());
+    });
+
+    let main_thread = thread::current().id();
+    thread::scope(|scope| {
+        // ReaderQuery was created on main and handed to the first worker.
+        let (cursor, execute_thread) = scope
+            .spawn(move || {
+                (
+                    query.execute().expect("execute on first worker"),
+                    thread::current().id(),
+                )
+            })
+            .join()
+            .expect("execute worker panicked");
+        assert_ne!(execute_thread, main_thread);
+
+        // The cursor then crosses a second synchronized hand-off. The
+        // failover callback and final Cursor/closure drop both occur there.
+        let drive_thread = scope
+            .spawn(move || {
+                let mut cursor = cursor;
+                while cursor
+                    .next_batch()
+                    .expect("next_batch on drive worker")
+                    .is_some()
+                {}
+                thread::current().id()
+            })
+            .join()
+            .expect("drive worker panicked");
+        assert_ne!(drive_thread, main_thread);
+        assert_eq!(*callback_on.lock().unwrap(), Some(drive_thread));
+        assert_eq!(*dropped_on.lock().unwrap(), Some(drive_thread));
+    });
+}
+
 // ---------------------------------------------------------------------------
 // `on_failover_progress` lifecycle callback
 // ---------------------------------------------------------------------------

--- a/questdb-rs/tests/egress_live_server.rs
+++ b/questdb-rs/tests/egress_live_server.rs
@@ -3267,12 +3267,11 @@ fn cancel_does_not_replenish_credit_window() {
 /// done after a `QUERY_ERROR` terminal. Polling `is_finished()` lets
 /// the test fail with a useful message instead of hanging the CI run.
 ///
-/// `F` is **not** required to be `Send`. `Cursor` is intentionally
-/// `!Send` (the `on_failover_reset` callback can capture non-`Send`
-/// state — see the `_not_send` marker on `Cursor` / `ReaderQuery`) but
-/// the watchdog needs to spawn the operation on a side thread to be
-/// able to time it out. We bridge the two by wrapping `op` in a
-/// newtype that unsafely asserts `Send`.
+/// `Cursor` is `Send`, so the wrapper below is redundant for the current
+/// callers, whose operations capture only a cursor. `F` remains
+/// unconstrained so this watchdog can also time operations that capture
+/// other non-`Send` test state; only such additional state makes the
+/// local `ForceSend` assertion necessary.
 ///
 /// Safety: the only thing the main thread does while the side thread
 /// runs is poll `JoinHandle::is_finished()` and sleep — it never


### PR DESCRIPTION
Reader queries and cursors can now be handed off between threads. You can prepare a query on one thread, run it on a worker, and drive the resulting cursor on yet another  as long as you never touch a handle from two threads at once and synchronize each hand-off (a thread spawn/join, a mutex, or a release/acquire on the handle is enough).

Previously `ReaderQuery` and `Cursor` were pinned to the thread that created them, which made the common "prepare here, iterate on a worker pool" pattern impossible.

The failover callbacks (`on_failover_reset` / `on_failover_progress`) run on whichever thread is driving the cursor, and their captured state is dropped there too. Because of this they must now be `Send`. In C/C++ the same rule applies: any `user_data` (or lambda capture) must be safe to use and destroy on the destination thread.

This applies across all surfaces — Rust, C, and C++ — with matching docs and cross-thread tests.