### PR TITLE
chore(ci): give the clang-format check teeth, pin 21.1.8, cover QWP sources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,10 @@ see [`questdb-rs/Cargo.toml`](questdb-rs/Cargo.toml)).
 - **Rust:** `cargo fmt` + `cargo clippy --all-targets -- -D warnings` must
   pass. The `almost-all-features` flag is the canonical lint target. Apply
   this to both `questdb-rs/` and `questdb-rs-ffi/`.
-- **C / C++:** run `clang-format` on touched files (config lives in
-  [`.clang-format`](.clang-format)).
+- **C / C++:** run `python3 ci/format_cpp.py` (config lives in
+  [`.clang-format`](.clang-format)). CI pins clang-format 21.1.8
+  (`pipx install clang-format==21.1.8`); other versions reflow comments
+  differently and will fail the check.
 - **Comments:** explain *why*, not *what*. The reviewers look closely at any
   comment that restates the code.
 - **Unsafe Rust:** keep `unsafe` blocks narrow and document the safety

--- a/ci/format_cpp.py
+++ b/ci/format_cpp.py
@@ -3,33 +3,41 @@
 """
 Format all the C and C++ code using `clang-format`.
 If --check is passed, check for formatting issues instead of modifying files.
+
+CI and local runs must use the same clang-format version (see
+`ci/run_tests_pipeline.yaml`): `pipx install clang-format==21.1.8`.
 """
 
 import sys
 sys.dont_write_bytecode = True
 import subprocess
 import glob
+import os.path
 
-FILES = [
-    'include/questdb/ingress/line_sender.h',
-    'include/questdb/ingress/line_sender.hpp',
-    'cpp_test/build_env.h',
-    'cpp_test/mock_server.hpp',
-    'cpp_test/mock_server.cpp',
-    'cpp_test/test_line_sender.cpp',
-]
+# Vendored third-party code keeps its upstream formatting.
+VENDORED = {'doctest.h'}
 
-# Also include all examples.
-FILES += glob.glob('examples/*.c')
-FILES += glob.glob('examples/*.cpp')
-FILES += glob.glob('examples/*.h')
-FILES += glob.glob('examples/*.hpp')
+FILES = sorted(
+    f
+    for f in glob.glob('include/questdb/**/*.h', recursive=True)
+    + glob.glob('include/questdb/**/*.hpp', recursive=True)
+    + glob.glob('cpp_test/*.c')
+    + glob.glob('cpp_test/*.cpp')
+    + glob.glob('cpp_test/*.h')
+    + glob.glob('cpp_test/*.hpp')
+    + glob.glob('examples/*.c')
+    + glob.glob('examples/*.cpp')
+    + glob.glob('examples/*.h')
+    + glob.glob('examples/*.hpp')
+    if os.path.basename(f) not in VENDORED
+)
 
 if __name__ == '__main__':
     check_mode = '--check' in sys.argv
-    command = [
-        'clang-format',
-        '--style=file',
-        '--dry-run' if check_mode else '-i'
-        ] + FILES
+    command = ['clang-format', '--style=file']
+    if check_mode:
+        command += ['--dry-run', '--Werror']
+    else:
+        command += ['-i']
+    command += FILES
     subprocess.check_call(command)

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -198,7 +198,12 @@ stages:
         steps:
           - checkout: self
           - script: |
-              apt install clang-format
+              set -e
+              # Pinned so local runs (`pipx install clang-format==21.1.8`)
+              # and CI agree byte-for-byte; comment reflow differs between
+              # clang-format major versions.
+              pipx install clang-format==21.1.8
+              clang-format --version | grep -F 21.1.8
               rustup component add clippy
               rustup component add rustfmt
             displayName: "Install clang-format, clippy and rustfmt"

--- a/cpp_test/qwp_mock_c.cpp
+++ b/cpp_test/qwp_mock_c.cpp
@@ -51,8 +51,7 @@ extern "C" qwp_mock_c* qwp_mock_c_start(int slot_count)
     return start_mock(slot_count, 1);
 }
 
-extern "C" qwp_mock_c* qwp_mock_c_start_frames(
-    int slot_count, int frame_count)
+extern "C" qwp_mock_c* qwp_mock_c_start_frames(int slot_count, int frame_count)
 {
     return start_mock(slot_count, frame_count);
 }

--- a/cpp_test/qwp_mock_c.h
+++ b/cpp_test/qwp_mock_c.h
@@ -17,8 +17,7 @@
 #define QWP_MOCK_C_H
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 typedef struct qwp_mock_c qwp_mock_c;

--- a/cpp_test/qwp_mock_server.cpp
+++ b/cpp_test/qwp_mock_server.cpp
@@ -25,41 +25,41 @@
 #include <stdexcept>
 
 #ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#pragma comment(lib, "Ws2_32.lib")
+#    include <winsock2.h>
+#    include <ws2tcpip.h>
+#    pragma comment(lib, "Ws2_32.lib")
 using socket_t = SOCKET;
 using ssize_t = std::intptr_t;
-#define INVALID_SOCKET_VALUE INVALID_SOCKET
-#define close_socket(s) closesocket(s)
+#    define INVALID_SOCKET_VALUE INVALID_SOCKET
+#    define close_socket(s) closesocket(s)
 // Winsock spells the shutdown constants differently.
-#define QWP_SHUT_RDWR SD_BOTH
-#define QWP_SHUT_WR   SD_SEND
+#    define QWP_SHUT_RDWR SD_BOTH
+#    define QWP_SHUT_WR SD_SEND
 // Windows TCP has no SIGPIPE; closed-peer writes return WSAECONNRESET.
-#define QWP_MSG_NOSIGNAL 0
+#    define QWP_MSG_NOSIGNAL 0
 #else
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <unistd.h>
-#include <netinet/tcp.h>
-#include <cerrno>
+#    include <arpa/inet.h>
+#    include <netinet/in.h>
+#    include <sys/socket.h>
+#    include <sys/time.h>
+#    include <unistd.h>
+#    include <netinet/tcp.h>
+#    include <cerrno>
 using socket_t = int;
-#define INVALID_SOCKET_VALUE (-1)
-#define close_socket(s) ::close(s)
-#define QWP_SHUT_RDWR SHUT_RDWR
-#define QWP_SHUT_WR   SHUT_WR
+#    define INVALID_SOCKET_VALUE (-1)
+#    define close_socket(s) ::close(s)
+#    define QWP_SHUT_RDWR SHUT_RDWR
+#    define QWP_SHUT_WR SHUT_WR
 // Suppress SIGPIPE on closed-peer writes. Linux exposes the flag per
 // `send()` call (`MSG_NOSIGNAL`); macOS/BSD exposes it as a per-socket
 // option (`SO_NOSIGPIPE` set via `setsockopt`). Define both portably so
 // the mock server can refuse to take down the test process when a
 // client closes the connection mid-frame.
-#ifdef MSG_NOSIGNAL
-#define QWP_MSG_NOSIGNAL MSG_NOSIGNAL
-#else
-#define QWP_MSG_NOSIGNAL 0
-#endif
+#    ifdef MSG_NOSIGNAL
+#        define QWP_MSG_NOSIGNAL MSG_NOSIGNAL
+#    else
+#        define QWP_MSG_NOSIGNAL 0
+#    endif
 #endif
 
 namespace
@@ -73,8 +73,7 @@ inline void set_no_sigpipe([[maybe_unused]] socket_t fd)
 {
 #if defined(SO_NOSIGPIPE)
     int one = 1;
-    (void)::setsockopt(
-        fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one));
+    (void)::setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one));
 #endif
 }
 } // namespace
@@ -98,7 +97,10 @@ struct Sha1State
     size_t buf_len;
 };
 
-inline uint32_t rotl(uint32_t x, int n) { return (x << n) | (x >> (32 - n)); }
+inline uint32_t rotl(uint32_t x, int n)
+{
+    return (x << n) | (x >> (32 - n));
+}
 
 void sha1_init(Sha1State& s)
 {
@@ -116,7 +118,8 @@ void sha1_compress(Sha1State& s, const uint8_t* block)
     uint32_t w[80];
     for (int i = 0; i < 16; ++i)
     {
-        w[i] = (uint32_t(block[i * 4]) << 24) | (uint32_t(block[i * 4 + 1]) << 16) |
+        w[i] = (uint32_t(block[i * 4]) << 24) |
+               (uint32_t(block[i * 4 + 1]) << 16) |
                (uint32_t(block[i * 4 + 2]) << 8) | uint32_t(block[i * 4 + 3]);
     }
     for (int i = 16; i < 80; ++i)
@@ -259,7 +262,9 @@ void encode_varint_u64(uint64_t v, std::vector<uint8_t>& out)
 }
 
 std::vector<uint8_t> framed(
-    uint8_t version, uint8_t flags, uint16_t table_count,
+    uint8_t version,
+    uint8_t flags,
+    uint16_t table_count,
     const std::vector<uint8_t>& payload)
 {
     std::vector<uint8_t> out;
@@ -329,7 +334,8 @@ std::vector<uint8_t> result_end_frame(int64_t request_id)
     for (int i = 0; i < 8; ++i)
         p.push_back(uint8_t(request_id >> (i * 8)));
     encode_varint_u64(0, p); // final_seq
-    encode_varint_u64(0, p); // total_rows (not asserted by client beyond plumbing)
+    encode_varint_u64(
+        0, p); // total_rows (not asserted by client beyond plumbing)
     return framed(1, 0, 0, p);
 }
 
@@ -380,8 +386,10 @@ std::vector<uint8_t> ingress_ok_frame(uint64_t wire_seq)
 }
 
 std::vector<uint8_t> result_batch_frame(
-    int64_t request_id, uint64_t batch_seq,
-    size_t row_count, const std::vector<ColumnSpec>& columns)
+    int64_t request_id,
+    uint64_t batch_seq,
+    size_t row_count,
+    const std::vector<ColumnSpec>& columns)
 {
     std::vector<uint8_t> p;
     p.push_back(MSG_RESULT_BATCH);
@@ -417,8 +425,10 @@ std::vector<uint8_t> result_batch_frame(
 }
 
 std::vector<uint8_t> result_batch_frame_with_dict(
-    int64_t request_id, uint64_t batch_seq,
-    size_t row_count, const std::vector<ColumnSpec>& columns,
+    int64_t request_id,
+    uint64_t batch_seq,
+    size_t row_count,
+    const std::vector<ColumnSpec>& columns,
     uint64_t dict_delta_start,
     const std::vector<std::string>& dict_entries)
 {
@@ -486,13 +496,15 @@ std::vector<uint8_t> fixed_column_bytes_nullable(
 {
     assert(is_null.size() == row_count);
     std::vector<uint8_t> out;
-    bool any_null = std::any_of(is_null.begin(), is_null.end(),
-                                [](bool b) { return b; });
+    bool any_null =
+        std::any_of(is_null.begin(), is_null.end(), [](bool b) { return b; });
     if (!any_null)
     {
         out.push_back(0x00);
-        out.insert(out.end(), packed_non_null_values.begin(),
-                   packed_non_null_values.end());
+        out.insert(
+            out.end(),
+            packed_non_null_values.begin(),
+            packed_non_null_values.end());
         return out;
     }
     out.push_back(0x01); // null_flag = validity present
@@ -502,8 +514,10 @@ std::vector<uint8_t> fixed_column_bytes_nullable(
         if (is_null[i])
             bitmap[i >> 3] |= uint8_t(1u << (i & 7));
     out.insert(out.end(), bitmap.begin(), bitmap.end());
-    out.insert(out.end(), packed_non_null_values.begin(),
-               packed_non_null_values.end());
+    out.insert(
+        out.end(),
+        packed_non_null_values.begin(),
+        packed_non_null_values.end());
     (void)elem_size;
     return out;
 }
@@ -517,8 +531,7 @@ std::vector<uint8_t> varlen_column_bytes(
     // raw data. Note: the egress decoder expects offsets *immediately
     // after* the null_flag, no varint length prefix.
     uint32_t off = 0;
-    auto push_u32 = [&](uint32_t v)
-    {
+    auto push_u32 = [&](uint32_t v) {
         out.push_back(uint8_t(v));
         out.push_back(uint8_t(v >> 8));
         out.push_back(uint8_t(v >> 16));
@@ -562,8 +575,8 @@ std::vector<uint8_t> decimal256_column_bytes(
     const std::vector<std::array<uint8_t, 32>>& values, int8_t scale)
 {
     std::vector<uint8_t> out;
-    out.push_back(0x00);                  // validity: no nulls
-    out.push_back(uint8_t(scale));        // 1B scale (decode_decimal_wide reads u8)
+    out.push_back(0x00);           // validity: no nulls
+    out.push_back(uint8_t(scale)); // 1B scale (decode_decimal_wide reads u8)
     for (const auto& v : values)
         out.insert(out.end(), v.begin(), v.end());
     return out;
@@ -575,8 +588,8 @@ std::vector<uint8_t> geohash_column_bytes(
     uint8_t precision_bits)
 {
     std::vector<uint8_t> out;
-    bool any_null = std::any_of(is_null.begin(), is_null.end(),
-                                [](bool b) { return b; });
+    bool any_null =
+        std::any_of(is_null.begin(), is_null.end(), [](bool b) { return b; });
     if (!any_null)
     {
         out.push_back(0x00);
@@ -592,8 +605,10 @@ std::vector<uint8_t> geohash_column_bytes(
         out.insert(out.end(), bitmap.begin(), bitmap.end());
     }
     encode_varint_u64(uint64_t(precision_bits), out);
-    out.insert(out.end(), packed_non_null_values.begin(),
-               packed_non_null_values.end());
+    out.insert(
+        out.end(),
+        packed_non_null_values.begin(),
+        packed_non_null_values.end());
     return out;
 }
 
@@ -601,8 +616,10 @@ std::vector<uint8_t> array_column_bytes(
     const std::vector<std::optional<ArrayRow>>& rows)
 {
     std::vector<uint8_t> out;
-    bool any_null = std::any_of(rows.begin(), rows.end(),
-                                [](const std::optional<ArrayRow>& r) { return !r.has_value(); });
+    bool any_null = std::any_of(
+        rows.begin(), rows.end(), [](const std::optional<ArrayRow>& r) {
+            return !r.has_value();
+        });
     if (!any_null)
     {
         out.push_back(0x00);
@@ -645,13 +662,15 @@ bool send_all(socket_t fd, const uint8_t* data, size_t len)
 {
     while (len > 0)
     {
-        ssize_t n = ::send(fd, reinterpret_cast<const char*>(data),
+        ssize_t n = ::send(
+            fd,
+            reinterpret_cast<const char*>(data),
 #ifdef _WIN32
-                           int(len),
+            int(len),
 #else
-                           len,
+            len,
 #endif
-                           QWP_MSG_NOSIGNAL);
+            QWP_MSG_NOSIGNAL);
         if (n <= 0)
             return false;
         data += n;
@@ -664,13 +683,15 @@ bool recv_all(socket_t fd, uint8_t* data, size_t len)
 {
     while (len > 0)
     {
-        ssize_t n = ::recv(fd, reinterpret_cast<char*>(data),
+        ssize_t n = ::recv(
+            fd,
+            reinterpret_cast<char*>(data),
 #ifdef _WIN32
-                           int(len),
+            int(len),
 #else
-                           len,
+            len,
 #endif
-                           0);
+            0);
         if (n <= 0)
             return false;
         data += n;
@@ -692,8 +713,7 @@ bool ws_handshake(socket_t fd, bool reject_401)
         if (n <= 0)
             return false;
         buf.push_back(b);
-        if (buf.size() >= 4 &&
-            buf.compare(buf.size() - 4, 4, "\r\n\r\n") == 0)
+        if (buf.size() >= 4 && buf.compare(buf.size() - 4, 4, "\r\n\r\n") == 0)
             break;
         if (buf.size() > 8192)
             return false;
@@ -723,8 +743,9 @@ bool ws_handshake(socket_t fd, bool reject_401)
             if (colon == std::string::npos)
                 continue;
             std::string name = line.substr(0, colon);
-            std::transform(name.begin(), name.end(), name.begin(),
-                           [](char c) { return char(std::tolower(c)); });
+            std::transform(name.begin(), name.end(), name.begin(), [](char c) {
+                return char(std::tolower(c));
+            });
             std::string value = line.substr(colon + 1);
             size_t vs = value.find_first_not_of(" \t");
             size_t ve = value.find_last_not_of(" \t");
@@ -763,8 +784,8 @@ bool ws_handshake(socket_t fd, bool reject_401)
         "X-QWP-Version: 1\r\n"
         "Sec-WebSocket-Accept: " +
         accept + "\r\n\r\n";
-    return send_all(fd, reinterpret_cast<const uint8_t*>(resp.data()),
-                    resp.size());
+    return send_all(
+        fd, reinterpret_cast<const uint8_t*>(resp.data()), resp.size());
 }
 
 // Read a single WebSocket frame from `fd`. Returns:
@@ -858,7 +879,9 @@ void graceful_close(socket_t fd)
 #ifdef _WIN32
     DWORD drain_timeout_ms = 500;
     (void)::setsockopt(
-        fd, SOL_SOCKET, SO_RCVTIMEO,
+        fd,
+        SOL_SOCKET,
+        SO_RCVTIMEO,
         reinterpret_cast<const char*>(&drain_timeout_ms),
         sizeof(drain_timeout_ms));
 #else
@@ -868,13 +891,15 @@ void graceful_close(socket_t fd)
         fd, SOL_SOCKET, SO_RCVTIMEO, &drain_timeout, sizeof(drain_timeout));
 #endif
     char drain_buf[512];
-    while (::recv(fd, drain_buf,
+    while (::recv(
+               fd,
+               drain_buf,
 #ifdef _WIN32
-                  int(sizeof(drain_buf)),
+               int(sizeof(drain_buf)),
 #else
-                  sizeof(drain_buf),
+               sizeof(drain_buf),
 #endif
-                  0) > 0)
+               0) > 0)
     {
     }
     close_socket(fd);
@@ -912,7 +937,8 @@ bool ws_write_binary(socket_t fd, const std::vector<uint8_t>& payload)
 // the request_id from a QUERY_REQUEST (offset 1, i64 LE) when the
 // expected kind is QUERY_REQUEST; -1 otherwise. Returns -1 on error.
 int64_t read_until_kind(
-    socket_t fd, uint8_t expected_kind,
+    socket_t fd,
+    uint8_t expected_kind,
     std::vector<std::vector<uint8_t>>& out_captured,
     std::mutex& out_captured_mtx)
 {
@@ -973,14 +999,15 @@ struct MockServer::Impl
     static void wsa_init()
     {
         static std::once_flag once;
-        std::call_once(once, []
-        {
+        std::call_once(once, [] {
             WSADATA wsa;
             WSAStartup(MAKEWORD(2, 2), &wsa);
         });
     }
 #else
-    static void wsa_init() {}
+    static void wsa_init()
+    {
+    }
 #endif
 
     void run_listener()
@@ -1035,10 +1062,10 @@ struct MockServer::Impl
 
         int64_t last_request_id = 0;
 #ifdef _MSC_VER
-#pragma warning(push)
+#    pragma warning(push)
 // MSVC C4456 fires spuriously on `auto* a = std::get_if<>(...)` in
 // successive `else if` branches even though each branch has its own scope.
-#pragma warning(disable : 4456)
+#    pragma warning(disable : 4456)
 #endif
         for (const auto& action : script)
         {
@@ -1050,8 +1077,12 @@ struct MockServer::Impl
             else if (auto* a = std::get_if<ActionSendServerInfo>(&action))
             {
                 auto frame = server_info_frame(
-                    a->role, a->cluster_id, a->node_id,
-                    a->epoch, a->capabilities, a->server_wall_ns,
+                    a->role,
+                    a->cluster_id,
+                    a->node_id,
+                    a->epoch,
+                    a->capabilities,
+                    a->server_wall_ns,
                     a->zone_id);
                 if (!ws_write_binary(fd, frame))
                 {
@@ -1061,8 +1092,8 @@ struct MockServer::Impl
             }
             else if (std::holds_alternative<ActionAwaitQueryRequest>(action))
             {
-                int64_t rid =
-                    read_until_kind(fd, MSG_QUERY_REQUEST, captured, captured_mtx);
+                int64_t rid = read_until_kind(
+                    fd, MSG_QUERY_REQUEST, captured, captured_mtx);
                 if (rid < 0)
                 {
                     close_socket(fd);
@@ -1072,8 +1103,8 @@ struct MockServer::Impl
             }
             else if (auto* a = std::get_if<ActionAwaitClientFrame>(&action))
             {
-                int64_t rc =
-                    read_until_kind(fd, a->expected_msg_kind, captured, captured_mtx);
+                int64_t rc = read_until_kind(
+                    fd, a->expected_msg_kind, captured, captured_mtx);
                 if (rc < 0)
                 {
                     close_socket(fd);
@@ -1131,7 +1162,7 @@ struct MockServer::Impl
             }
         }
 #ifdef _MSC_VER
-#pragma warning(pop)
+#    pragma warning(pop)
 #endif
 
         // End of script: graceful close (WS Close frame, then TCP
@@ -1156,8 +1187,12 @@ MockServer::MockServer(std::vector<Script> scripts)
         throw std::runtime_error("socket() failed");
 
     int one = 1;
-    ::setsockopt(_impl->listen_fd, SOL_SOCKET, SO_REUSEADDR,
-                 reinterpret_cast<const char*>(&one), sizeof(one));
+    ::setsockopt(
+        _impl->listen_fd,
+        SOL_SOCKET,
+        SO_REUSEADDR,
+        reinterpret_cast<const char*>(&one),
+        sizeof(one));
 
     sockaddr_in addr{};
     addr.sin_family = AF_INET;

--- a/cpp_test/qwp_mock_server.hpp
+++ b/cpp_test/qwp_mock_server.hpp
@@ -117,7 +117,9 @@ void encode_varint_u64(uint64_t v, std::vector<uint8_t>& out);
 // Wrap a payload in the 12-byte QWP1 frame header. Server frames carry
 // this header; client→server frames are bare payloads (no header).
 std::vector<uint8_t> framed(
-    uint8_t version, uint8_t flags, uint16_t table_count,
+    uint8_t version,
+    uint8_t flags,
+    uint16_t table_count,
     const std::vector<uint8_t>& payload);
 
 // Convenience builders.
@@ -156,8 +158,10 @@ struct ColumnSpec
     std::vector<uint8_t> data;
 };
 std::vector<uint8_t> result_batch_frame(
-    int64_t request_id, uint64_t batch_seq,
-    size_t row_count, const std::vector<ColumnSpec>& columns);
+    int64_t request_id,
+    uint64_t batch_seq,
+    size_t row_count,
+    const std::vector<ColumnSpec>& columns);
 
 // `result_batch_frame` variant that ships a `FLAG_DELTA_SYMBOL_DICT` delta
 // section in the payload before the table block. `dict_delta_start` is the
@@ -165,8 +169,10 @@ std::vector<uint8_t> result_batch_frame(
 // connection (the client validates `delta_start == current dict size`).
 // Pair with `symbol_column_bytes` for any SYMBOL columns in `columns`.
 std::vector<uint8_t> result_batch_frame_with_dict(
-    int64_t request_id, uint64_t batch_seq,
-    size_t row_count, const std::vector<ColumnSpec>& columns,
+    int64_t request_id,
+    uint64_t batch_seq,
+    size_t row_count,
+    const std::vector<ColumnSpec>& columns,
     uint64_t dict_delta_start,
     const std::vector<std::string>& dict_entries);
 
@@ -199,29 +205,31 @@ std::vector<uint8_t> fixed_column_bytes_nullable(
 std::vector<uint8_t> decimal64_column_bytes(
     const std::vector<int64_t>& values, int8_t scale);
 
-// Build a DECIMAL128 column body: `[validity][varint scale][non_null × 16 raw LE bytes]`.
-// Each entry in `values` is the raw 16-byte two's-complement little-endian
-// mantissa exactly as it should appear on the wire.
+// Build a DECIMAL128 column body: `[validity][varint scale][non_null × 16 raw
+// LE bytes]`. Each entry in `values` is the raw 16-byte two's-complement
+// little-endian mantissa exactly as it should appear on the wire.
 std::vector<uint8_t> decimal128_column_bytes(
     const std::vector<std::array<uint8_t, 16>>& values, int8_t scale);
 
-// Build a DECIMAL256 column body: `[validity][1B scale][non_null × 32 raw LE bytes]`.
-// Each entry in `values` is the raw 32-byte two's-complement little-endian
-// mantissa exactly as it should appear on the wire.
+// Build a DECIMAL256 column body: `[validity][1B scale][non_null × 32 raw LE
+// bytes]`. Each entry in `values` is the raw 32-byte two's-complement
+// little-endian mantissa exactly as it should appear on the wire.
 std::vector<uint8_t> decimal256_column_bytes(
     const std::vector<std::array<uint8_t, 32>>& values, int8_t scale);
 
-// Build a GEOHASH column body: `[validity][varint precision_bits][non_null × ceil(precision_bits/8) LE bytes]`.
-// `packed_non_null_values` must already be `non_null_count × byte_width` bytes.
+// Build a GEOHASH column body: `[validity][varint precision_bits][non_null ×
+// ceil(precision_bits/8) LE bytes]`. `packed_non_null_values` must already be
+// `non_null_count × byte_width` bytes.
 std::vector<uint8_t> geohash_column_bytes(
     const std::vector<bool>& is_null,
     const std::vector<uint8_t>& packed_non_null_values,
     uint8_t precision_bits);
 
-// Build a DOUBLE_ARRAY / LONG_ARRAY column body: `[validity][per-row: 1B nDims, nDims×u32_le shape, prod(shape)×8 LE element bytes]`.
-// `rows[i] == std::nullopt` marks a NULL row. Each present row carries its
-// own shape and packed flat-data bytes (caller-provided so this helper
-// stays single for both DOUBLE_ARRAY and LONG_ARRAY).
+// Build a DOUBLE_ARRAY / LONG_ARRAY column body: `[validity][per-row: 1B nDims,
+// nDims×u32_le shape, prod(shape)×8 LE element bytes]`. `rows[i] ==
+// std::nullopt` marks a NULL row. Each present row carries its own shape and
+// packed flat-data bytes (caller-provided so this helper stays single for both
+// DOUBLE_ARRAY and LONG_ARRAY).
 struct ArrayRow
 {
     std::vector<uint32_t> shape;
@@ -245,9 +253,11 @@ struct ActionSendServerInfo
     std::optional<std::string> zone_id = std::nullopt;
 };
 struct ActionAwaitQueryRequest
-{};
+{
+};
 struct ActionSendResultEnd
-{};
+{
+};
 struct ActionSendExecDone
 {
     uint8_t op_type = 0;
@@ -276,9 +286,11 @@ struct ActionAwaitClientFrame
     uint8_t expected_msg_kind;
 };
 struct ActionHardDrop
-{};
+{
+};
 struct ActionReject401
-{};
+{
+};
 
 using Action = std::variant<
     ActionSendServerInfo,

--- a/cpp_test/smoke_reader.c
+++ b/cpp_test/smoke_reader.c
@@ -38,8 +38,7 @@
 
 static int closed_port_phase(void)
 {
-    line_sender_utf8 conf =
-        QDB_UTF8_LITERAL("ws::addr=127.0.0.1:1;");
+    line_sender_utf8 conf = QDB_UTF8_LITERAL("ws::addr=127.0.0.1:1;");
 
     questdb_error* err = NULL;
     qwp_reader* reader = qwp_reader_from_conf(conf, &err);
@@ -103,8 +102,7 @@ static int pool_eager_connect_fails_phase(void)
     static const char conf[] = "ws::addr=127.0.0.1:1;";
 
     questdb_error* err = NULL;
-    struct questdb_db* db =
-        questdb_db_connect(conf, strlen(conf), &err);
+    struct questdb_db* db = questdb_db_connect(conf, strlen(conf), &err);
 
     if (db != NULL)
     {
@@ -132,8 +130,7 @@ static int pool_reader_only_phase(void)
     static const char conf[] = "ws::addr=127.0.0.1:1;lazy_connect=true;";
 
     questdb_error* err = NULL;
-    struct questdb_db* db =
-        questdb_db_connect(conf, strlen(conf), &err);
+    struct questdb_db* db = questdb_db_connect(conf, strlen(conf), &err);
 
     /*
      * lazy_connect pool: connect opens nothing, so it succeeds even
@@ -225,8 +222,8 @@ static int live_lifecycle_phase(const char* addr)
      * multi-endpoint aggregation wrapping.
      */
     char conf_buf[256];
-    int n = snprintf(
-        conf_buf, sizeof(conf_buf), "ws::addr=%s;failover=off", addr);
+    int n =
+        snprintf(conf_buf, sizeof(conf_buf), "ws::addr=%s;failover=off", addr);
     if (n <= 0 || (size_t)n >= sizeof(conf_buf))
     {
         fprintf(
@@ -288,9 +285,7 @@ static int live_lifecycle_phase(const char* addr)
         const size_t cols = qwp_reader_batch_column_count(batch);
         if (cols == 0)
         {
-            fprintf(
-                stderr,
-                "smoke live: batch has zero columns; expected 1\n");
+            fprintf(stderr, "smoke live: batch has zero columns; expected 1\n");
             goto fail;
         }
 
@@ -356,10 +351,7 @@ fail:;
         size_t err_len = 0;
         const char* err_msg = questdb_error_msg(err, &err_len);
         fprintf(
-            stderr,
-            "smoke live: %.*s\n",
-            (int)err_len,
-            err_msg ? err_msg : "");
+            stderr, "smoke live: %.*s\n", (int)err_len, err_msg ? err_msg : "");
     }
     else
     {

--- a/cpp_test/test_arrow_c.c
+++ b/cpp_test/test_arrow_c.c
@@ -44,8 +44,11 @@ static int tests = 0;
         }                                                                      \
         else                                                                   \
         {                                                                      \
-            fprintf(stderr, "FAILED TEST: %s (%d new errors)\n",               \
-                    #name, errors - before);                                   \
+            fprintf(                                                           \
+                stderr,                                                        \
+                "FAILED TEST: %s (%d new errors)\n",                           \
+                #name,                                                         \
+                errors - before);                                              \
         }                                                                      \
     } while (0)
 
@@ -80,32 +83,37 @@ TEST(test_appended_query_error_codes_have_distinct_values)
 {
     CHECK(
         questdb_error_schema_drift != questdb_error_no_schema &&
-        questdb_error_no_schema != questdb_error_arrow_export &&
-        questdb_error_arrow_export != questdb_error_schema_drift,
+            questdb_error_no_schema != questdb_error_arrow_export &&
+            questdb_error_arrow_export != questdb_error_schema_drift,
         "schema_drift / no_schema / arrow_export distinct");
-    CHECK(questdb_error_schema_drift > questdb_error_failover_would_duplicate,
-          "schema_drift appended (not renumbered)");
+    CHECK(
+        questdb_error_schema_drift > questdb_error_failover_would_duplicate,
+        "schema_drift appended (not renumbered)");
 }
 
 TEST(test_appended_sender_error_codes_exist)
 {
-    CHECK(line_sender_error_arrow_unsupported_column_kind !=
-              line_sender_error_arrow_ingest,
-          "sender error codes distinct");
+    CHECK(
+        line_sender_error_arrow_unsupported_column_kind !=
+            line_sender_error_arrow_ingest,
+        "sender error codes distinct");
 }
 
 TEST(test_symbol_dict_full_is_a_distinct_appended_code)
 {
     /* A full connection symbol dictionary must be recognisable by code, not by
      * message text -- that is the whole reason it is not invalid_api_call. */
-    CHECK(line_sender_error_symbol_dict_full !=
-              line_sender_error_invalid_api_call,
-          "symbol_dict_full distinct from invalid_api_call");
-    CHECK(line_sender_error_symbol_dict_full >
-              line_sender_error_store_resend_required,
-          "symbol_dict_full appended (not renumbered)");
-    CHECK(questdb_error_symbol_dict_full == line_sender_error_symbol_dict_full,
-          "neutral alias resolves to the same enumerator");
+    CHECK(
+        line_sender_error_symbol_dict_full !=
+            line_sender_error_invalid_api_call,
+        "symbol_dict_full distinct from invalid_api_call");
+    CHECK(
+        line_sender_error_symbol_dict_full >
+            line_sender_error_store_resend_required,
+        "symbol_dict_full appended (not renumbered)");
+    CHECK(
+        questdb_error_symbol_dict_full == line_sender_error_symbol_dict_full,
+        "neutral alias resolves to the same enumerator");
 }
 
 TEST(test_egress_null_cursor_returns_error_tristate)
@@ -180,8 +188,7 @@ TEST(test_ingress_at_column_null_conn_returns_false)
     memset(&sch, 0, sizeof(sch));
     line_sender_error* err = NULL;
     bool ok = qwp_sender_flush_arrow_batch_at_column(
-        NULL, make_table("t"), &arr, &sch, make_col("ts"),
-        NULL, 0, &err);
+        NULL, make_table("t"), &arr, &sch, make_col("ts"), NULL, 0, &err);
     CHECK(!ok, "NULL conn → false");
     CHECK(err != NULL, "err_out populated");
     if (err)
@@ -213,8 +220,8 @@ TEST(test_chunk_append_arrow_column_null_chunk)
     memset(&arr, 0, sizeof(arr));
     memset(&sch, 0, sizeof(sch));
     line_sender_error* err = NULL;
-    bool ok = qwp_chunk_append_arrow_column(
-        NULL, "v", 1, &arr, &sch, 0, 0, &err);
+    bool ok =
+        qwp_chunk_append_arrow_column(NULL, "v", 1, &arr, &sch, 0, 0, &err);
     CHECK(!ok, "NULL chunk → false");
     CHECK(err != NULL, "err_out populated");
     if (err)
@@ -235,8 +242,8 @@ TEST(test_chunk_append_arrow_column_null_array_schema)
     CHECK(err == NULL, "no err on chunk_new");
     if (!chunk)
         return;
-    bool ok = qwp_chunk_append_arrow_column(
-        chunk, "v", 1, NULL, NULL, 0, 0, &err);
+    bool ok =
+        qwp_chunk_append_arrow_column(chunk, "v", 1, NULL, NULL, 0, 0, &err);
     CHECK(!ok, "NULL array+schema → false");
     CHECK(err != NULL, "err_out populated");
     if (err)
@@ -289,8 +296,8 @@ TEST(test_chunk_append_arrow_column_valid_i64_smoke)
     sch.release = noop_schema_release;
     sch.private_data = NULL;
 
-    bool ok = qwp_chunk_append_arrow_column(
-        chunk, "v", 1, &arr, &sch, 0, 1, &err);
+    bool ok =
+        qwp_chunk_append_arrow_column(chunk, "v", 1, &arr, &sch, 0, 1, &err);
     CHECK(ok, "valid i64 append → true");
     CHECK(err == NULL, "no err on success");
     if (err)
@@ -985,16 +992,15 @@ static void expect_arrow_array_rejected(
             sch->release(sch);
         return;
     }
-    bool ok = qwp_chunk_append_arrow_column(
-        chunk, "v", 1, arr, sch, 0, 0, &err);
+    bool ok =
+        qwp_chunk_append_arrow_column(chunk, "v", 1, arr, sch, 0, 0, &err);
     CHECK(!ok, label);
     CHECK(err != NULL, "err_out populated on malformed array");
     if (err)
     {
         int code = (int)line_sender_error_get_code(err);
-        int accepted =
-            code == line_sender_error_arrow_ingest ||
-            code == line_sender_error_invalid_api_call;
+        int accepted = code == line_sender_error_arrow_ingest ||
+                       code == line_sender_error_invalid_api_call;
         CHECK(accepted, "malformed array → structured error (not abort)");
         line_sender_error_free(err);
     }
@@ -1050,9 +1056,7 @@ TEST(test_chunk_append_arrow_column_malformed_array_rejected)
 /* Open a mock + questdb_db + borrow a conn. Returns NULL on any setup
  * failure; populates *out_db / *out_mock on success. */
 static qwp_sender* mock_borrow_sender_frames(
-    qwp_mock_c** out_mock,
-    questdb_db** out_db,
-    int frame_count)
+    qwp_mock_c** out_mock, questdb_db** out_db, int frame_count)
 {
     *out_mock = NULL;
     *out_db = NULL;
@@ -1062,8 +1066,10 @@ static qwp_sender* mock_borrow_sender_frames(
     const char* addr = qwp_mock_c_addr(mock);
     char conf[256];
     snprintf(
-        conf, sizeof(conf),
-        "ws::addr=%s;lazy_connect=true;sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;",
+        conf,
+        sizeof(conf),
+        "ws::addr=%s;lazy_connect=true;sender_pool_min=1;pool_reap=manual;"
+        "close_flush_timeout_millis=0;",
         addr);
     line_sender_error* err = NULL;
     questdb_db* db = questdb_db_connect(conf, strlen(conf), &err);
@@ -1089,8 +1095,7 @@ static qwp_sender* mock_borrow_sender_frames(
 }
 
 static qwp_sender* mock_borrow_sender(
-    qwp_mock_c** out_mock,
-    questdb_db** out_db)
+    qwp_mock_c** out_mock, questdb_db** out_db)
 {
     return mock_borrow_sender_frames(out_mock, out_db, 1);
 }
@@ -1133,8 +1138,8 @@ TEST(test_one_sender_flushes_buffer_and_chunk)
             "buffer published through unified sender");
     }
 
-    qwp_chunk* chunk = qwp_chunk_new(
-        "mixed_c_chunk", strlen("mixed_c_chunk"), &err);
+    qwp_chunk* chunk =
+        qwp_chunk_new("mixed_c_chunk", strlen("mixed_c_chunk"), &err);
     CHECK(chunk != NULL, "chunk constructed");
     if (chunk != NULL)
     {
@@ -1162,8 +1167,10 @@ TEST(test_one_sender_flushes_buffer_and_chunk)
 }
 
 static void run_arrow_flush(
-    struct ArrowArray* arr, struct ArrowSchema* sch,
-    const char* table, const char* label)
+    struct ArrowArray* arr,
+    struct ArrowSchema* sch,
+    const char* table,
+    const char* label)
 {
     qwp_mock_c* mock;
     questdb_db* db;
@@ -1179,8 +1186,8 @@ static void run_arrow_flush(
     }
     line_sender_error* err = NULL;
     line_sender_table_name tbl = make_table(table);
-    bool ok = qwp_sender_flush_arrow_batch_at_now(
-        conn, tbl, arr, sch, NULL, 0, &err);
+    bool ok =
+        qwp_sender_flush_arrow_batch_at_now(conn, tbl, arr, sch, NULL, 0, &err);
     if (!ok)
     {
         CHECK(err != NULL, "err_out populated on failure");
@@ -1244,8 +1251,7 @@ TEST(test_mock_ingress_at_column_empty_name_via_real_conn)
     if (err)
     {
         CHECK(
-            line_sender_error_get_code(err) ==
-                line_sender_error_invalid_name,
+            line_sender_error_get_code(err) == line_sender_error_invalid_name,
             "empty column name → invalid_name");
         line_sender_error_free(err);
     }
@@ -1299,14 +1305,16 @@ TEST(test_mock_ingress_float32_float64_columns)
         struct ArrowArray arr;
         struct ArrowSchema sch;
         build_primitive(3, sizeof(float), values, "f", "f3", &arr, &sch);
-        run_arrow_flush(&arr, &sch, "f32_t", "float32 accepted/structured-error");
+        run_arrow_flush(
+            &arr, &sch, "f32_t", "float32 accepted/structured-error");
     }
     {
         double values[3] = {1.5, -2.5, 3.14159};
         struct ArrowArray arr;
         struct ArrowSchema sch;
         build_primitive(3, sizeof(double), values, "g", "f6", &arr, &sch);
-        run_arrow_flush(&arr, &sch, "f64_t", "float64 accepted/structured-error");
+        run_arrow_flush(
+            &arr, &sch, "f64_t", "float64 accepted/structured-error");
     }
 }
 
@@ -1319,7 +1327,8 @@ TEST(test_mock_ingress_timestamp_microseconds)
     /* Designated TS comes from the column itself via the at_column
      * variant; here we use the no-ts variant so the server stamps each
      * row on arrival. */
-    run_arrow_flush(&arr, &sch, "ts_t", "timestamp(µs) accepted/structured-error");
+    run_arrow_flush(
+        &arr, &sch, "ts_t", "timestamp(µs) accepted/structured-error");
 }
 
 TEST(test_mock_ingress_both_designated_timestamp_variants)
@@ -1337,7 +1346,8 @@ TEST(test_mock_ingress_both_designated_timestamp_variants)
         struct ArrowArray arr;
         struct ArrowSchema sch;
         build_primitive(2, sizeof(int64_t), values, "l", "v", &arr, &sch);
-        run_arrow_flush(&arr, &sch, "dts_t_now", "no-ts accepted/structured-error");
+        run_arrow_flush(
+            &arr, &sch, "dts_t_now", "no-ts accepted/structured-error");
     }
 
     /* At-column variant — pass a non-existent column name. The impl
@@ -1369,9 +1379,8 @@ TEST(test_mock_ingress_both_designated_timestamp_variants)
         if (err)
         {
             int code = (int)line_sender_error_get_code(err);
-            int accepted =
-                code == line_sender_error_arrow_ingest ||
-                code == line_sender_error_invalid_api_call;
+            int accepted = code == line_sender_error_arrow_ingest ||
+                           code == line_sender_error_invalid_api_call;
             CHECK(accepted, "missing ts column → structured error");
             line_sender_error_free(err);
         }
@@ -1434,9 +1443,8 @@ TEST(test_mock_ingress_arrow_release_contract)
         if (err)
         {
             int code = (int)line_sender_error_get_code(err);
-            int accepted =
-                code == line_sender_error_arrow_ingest ||
-                code == line_sender_error_invalid_api_call;
+            int accepted = code == line_sender_error_arrow_ingest ||
+                           code == line_sender_error_invalid_api_call;
             CHECK(accepted, "malformed +l → structured error (not abort)");
             line_sender_error_free(err);
         }

--- a/cpp_test/test_arrow_egress.cpp
+++ b/cpp_test/test_arrow_egress.cpp
@@ -99,7 +99,8 @@ TEST_CASE("arrow egress: empty stream returns _end without touching out_*")
 
     // `next_arrow_batch` snapshots schema eagerly. With ZERO batches the
     // adapter must EITHER:
-    //   - throw `questdb::error` with `questdb_error_no_schema` (when the QWP path
+    //   - throw `questdb::error` with `questdb_error_no_schema` (when the QWP
+    //   path
     //     reaches `as_arrow_reader` with no first batch), OR
     //   - return `nullopt` directly (when the inner pump terminates
     //     first).
@@ -122,7 +123,8 @@ TEST_CASE("arrow egress: empty stream returns _end without touching out_*")
 TEST_CASE("arrow egress: single Long batch — struct layout + release order")
 {
     qm::ColumnSpec col_v{
-        "v", qm::COL_LONG,
+        "v",
+        qm::COL_LONG,
         qm::fixed_column_bytes(3, pack_le<int64_t>({10, 20, 30}))};
 
     qm::Script s = {
@@ -170,7 +172,9 @@ TEST_CASE("arrow egress: single Long batch — struct layout + release order")
 // schema and verify each child's format code.
 // ---------------------------------------------------------------------------
 
-TEST_CASE("arrow egress: mixed kinds — Bool / Byte / Short / Int / Long / Float / Double")
+TEST_CASE(
+    "arrow egress: mixed kinds — Bool / Byte / Short / Int / Long / Float / "
+    "Double")
 {
     std::vector<uint8_t> bool_body;
     bool_body.push_back(0x00);
@@ -178,17 +182,29 @@ TEST_CASE("arrow egress: mixed kinds — Bool / Byte / Short / Int / Long / Floa
 
     qm::ColumnSpec c_bool{"b", qm::COL_BOOLEAN, std::move(bool_body)};
     qm::ColumnSpec c_byte{
-        "by", qm::COL_BYTE, qm::fixed_column_bytes(2, pack_le<int8_t>({-1, 1}))};
+        "by",
+        qm::COL_BYTE,
+        qm::fixed_column_bytes(2, pack_le<int8_t>({-1, 1}))};
     qm::ColumnSpec c_short{
-        "sh", qm::COL_SHORT, qm::fixed_column_bytes(2, pack_le<int16_t>({-2, 2}))};
+        "sh",
+        qm::COL_SHORT,
+        qm::fixed_column_bytes(2, pack_le<int16_t>({-2, 2}))};
     qm::ColumnSpec c_int{
-        "in", qm::COL_INT, qm::fixed_column_bytes(2, pack_le<int32_t>({-3, 3}))};
+        "in",
+        qm::COL_INT,
+        qm::fixed_column_bytes(2, pack_le<int32_t>({-3, 3}))};
     qm::ColumnSpec c_long{
-        "lo", qm::COL_LONG, qm::fixed_column_bytes(2, pack_le<int64_t>({-4, 4}))};
+        "lo",
+        qm::COL_LONG,
+        qm::fixed_column_bytes(2, pack_le<int64_t>({-4, 4}))};
     qm::ColumnSpec c_f32{
-        "f3", qm::COL_FLOAT, qm::fixed_column_bytes(2, pack_le<float>({1.5f, -2.5f}))};
+        "f3",
+        qm::COL_FLOAT,
+        qm::fixed_column_bytes(2, pack_le<float>({1.5f, -2.5f}))};
     qm::ColumnSpec c_f64{
-        "f6", qm::COL_DOUBLE, qm::fixed_column_bytes(2, pack_le<double>({1.5, -2.5}))};
+        "f6",
+        qm::COL_DOUBLE,
+        qm::fixed_column_bytes(2, pack_le<double>({1.5, -2.5}))};
 
     auto cols = std::vector<qm::ColumnSpec>{
         c_bool, c_byte, c_short, c_int, c_long, c_f32, c_f64};
@@ -224,17 +240,26 @@ TEST_CASE("arrow egress: mixed kinds — Bool / Byte / Short / Int / Long / Floa
     release_pair(&arr, &sch);
 }
 
-TEST_CASE("arrow egress: TIMESTAMP / TIMESTAMP_NS / DATE — timezone-carrying format codes")
+TEST_CASE(
+    "arrow egress: TIMESTAMP / TIMESTAMP_NS / DATE — timezone-carrying format "
+    "codes")
 {
     qm::ColumnSpec c_ts{
-        "ts", qm::COL_TIMESTAMP,
-        qm::fixed_column_bytes(2, pack_le<int64_t>({1700000000000000LL, 1700000000000001LL}))};
+        "ts",
+        qm::COL_TIMESTAMP,
+        qm::fixed_column_bytes(
+            2, pack_le<int64_t>({1700000000000000LL, 1700000000000001LL}))};
     qm::ColumnSpec c_ts_ns{
-        "tn", qm::COL_TIMESTAMP_NANOS,
-        qm::fixed_column_bytes(2, pack_le<int64_t>({1700000000000000000LL, 1700000000000000001LL}))};
+        "tn",
+        qm::COL_TIMESTAMP_NANOS,
+        qm::fixed_column_bytes(
+            2,
+            pack_le<int64_t>({1700000000000000000LL, 1700000000000000001LL}))};
     qm::ColumnSpec c_date{
-        "dt", qm::COL_DATE,
-        qm::fixed_column_bytes(2, pack_le<int64_t>({1700000000000LL, 1700000000001LL}))};
+        "dt",
+        qm::COL_DATE,
+        qm::fixed_column_bytes(
+            2, pack_le<int64_t>({1700000000000LL, 1700000000001LL}))};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
@@ -267,10 +292,10 @@ TEST_CASE("arrow egress: TIMESTAMP / TIMESTAMP_NS / DATE — timezone-carrying f
 TEST_CASE("arrow egress: VARCHAR + BINARY — variable-length format codes")
 {
     qm::ColumnSpec c_v{
-        "v", qm::COL_VARCHAR,
-        qm::varlen_column_bytes({{'a'}, {}, {'b', 'c'}})};
+        "v", qm::COL_VARCHAR, qm::varlen_column_bytes({{'a'}, {}, {'b', 'c'}})};
     qm::ColumnSpec c_b{
-        "b", qm::COL_BINARY,
+        "b",
+        qm::COL_BINARY,
         qm::varlen_column_bytes({{0x01}, {}, {0xFF, 0x00}})};
 
     qm::Script s = {
@@ -300,7 +325,9 @@ TEST_CASE("arrow egress: VARCHAR + BINARY — variable-length format codes")
     release_pair(&arr, &sch);
 }
 
-TEST_CASE("arrow egress: UUID — FixedSizeBinary(16) with arrow.uuid extension metadata")
+TEST_CASE(
+    "arrow egress: UUID — FixedSizeBinary(16) with arrow.uuid extension "
+    "metadata")
 {
     std::vector<uint8_t> raw;
     for (int i = 0; i < 32; ++i)
@@ -324,7 +351,8 @@ TEST_CASE("arrow egress: UUID — FixedSizeBinary(16) with arrow.uuid extension 
     auto& sch = _b->schema;
 
     REQUIRE(sch.children[0]->format != nullptr);
-    CHECK(std::string(sch.children[0]->format) == "w:16"); // FixedSizeBinary(16)
+    CHECK(
+        std::string(sch.children[0]->format) == "w:16"); // FixedSizeBinary(16)
 
     // Metadata is encoded as a length-prefixed byte buffer in the spec. We
     // don't decode it here exhaustively — but it MUST be non-NULL because
@@ -360,18 +388,22 @@ TEST_CASE("arrow egress: LONG256 — FixedSizeBinary(32)")
     release_pair(&arr, &sch);
 }
 
-TEST_CASE("arrow egress: SYMBOL — Dictionary(UInt32, Utf8) with questdb.symbol metadata")
+TEST_CASE(
+    "arrow egress: SYMBOL — Dictionary(UInt32, Utf8) with questdb.symbol "
+    "metadata")
 {
     qm::ColumnSpec c_sym{
-        "sym", qm::COL_SYMBOL,
-        qm::symbol_column_bytes({0u, 1u, 0u})};
+        "sym", qm::COL_SYMBOL, qm::symbol_column_bytes({0u, 1u, 0u})};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
         qm::ActionSendBuilt{[=](int64_t rid) {
             return qm::result_batch_frame_with_dict(
-                rid, 0, 3, {c_sym},
+                rid,
+                0,
+                3,
+                {c_sym},
                 /*dict_delta_start=*/0,
                 {"alpha", "beta"});
         }},
@@ -395,18 +427,23 @@ TEST_CASE("arrow egress: SYMBOL — Dictionary(UInt32, Utf8) with questdb.symbol
     release_pair(&arr, &sch);
 }
 
-TEST_CASE("arrow egress: DECIMAL64 / DECIMAL128 / DECIMAL256 — decimal format codes")
+TEST_CASE(
+    "arrow egress: DECIMAL64 / DECIMAL128 / DECIMAL256 — decimal format codes")
 {
-    qm::ColumnSpec c_d64{"d64", qm::COL_DECIMAL64,
-                        qm::decimal64_column_bytes({12345, 6789}, 2)};
+    qm::ColumnSpec c_d64{
+        "d64", qm::COL_DECIMAL64, qm::decimal64_column_bytes({12345, 6789}, 2)};
 
     std::vector<std::array<uint8_t, 16>> dec128_values(2);
-    qm::ColumnSpec c_d128{"d128", qm::COL_DECIMAL128,
-                          qm::decimal128_column_bytes(dec128_values, 5)};
+    qm::ColumnSpec c_d128{
+        "d128",
+        qm::COL_DECIMAL128,
+        qm::decimal128_column_bytes(dec128_values, 5)};
 
     std::vector<std::array<uint8_t, 32>> dec256_values(2);
-    qm::ColumnSpec c_d256{"d256", qm::COL_DECIMAL256,
-                          qm::decimal256_column_bytes(dec256_values, 7)};
+    qm::ColumnSpec c_d256{
+        "d256",
+        qm::COL_DECIMAL256,
+        qm::decimal256_column_bytes(dec256_values, 7)};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
@@ -424,7 +461,8 @@ TEST_CASE("arrow egress: DECIMAL64 / DECIMAL128 / DECIMAL256 — decimal format 
     auto& arr = _b->array;
     auto& sch = _b->schema;
 
-    // Arrow decimal format: "d:precision,scale" or "d:precision,scale,bitwidth".
+    // Arrow decimal format: "d:precision,scale" or
+    // "d:precision,scale,bitwidth".
     REQUIRE(sch.children[0]->format != nullptr);
     REQUIRE(sch.children[1]->format != nullptr);
     REQUIRE(sch.children[2]->format != nullptr);
@@ -441,8 +479,8 @@ TEST_CASE("arrow egress: DOUBLE_ARRAY — nested List(Float64)")
         qm::ArrayRow{{3}, pack_le<double>({1.0, 2.0, 3.0})},
         qm::ArrayRow{{2}, pack_le<double>({10.0, 20.0})},
     };
-    qm::ColumnSpec c_arr{"a", qm::COL_DOUBLE_ARRAY,
-                         qm::array_column_bytes(rows)};
+    qm::ColumnSpec c_arr{
+        "a", qm::COL_DOUBLE_ARRAY, qm::array_column_bytes(rows)};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
@@ -477,8 +515,8 @@ TEST_CASE("arrow egress: DOUBLE_ARRAY — nested List(Float64)")
 
 TEST_CASE("arrow egress: stream exhaustion — second call returns nullopt")
 {
-    qm::ColumnSpec c{"v", qm::COL_LONG,
-                     qm::fixed_column_bytes(1, pack_le<int64_t>({42}))};
+    qm::ColumnSpec c{
+        "v", qm::COL_LONG, qm::fixed_column_bytes(1, pack_le<int64_t>({42}))};
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
@@ -503,7 +541,9 @@ TEST_CASE("arrow egress: stream exhaustion — second call returns nullopt")
 // is array ndim (derived from each batch's row shapes, not the query
 // schema), so that is the only mid-stream drift the streaming Arrow adapter
 // can observe end-to-end.
-TEST_CASE("arrow egress: schema drift — array ndim change between batches throws schema_drift")
+TEST_CASE(
+    "arrow egress: schema drift — array ndim change between batches throws "
+    "schema_drift")
 {
     std::vector<std::optional<qm::ArrayRow>> b1_rows = {
         qm::ArrayRow{{3}, pack_le<double>({1.0, 2.0, 3.0})}};
@@ -547,7 +587,9 @@ TEST_CASE("arrow egress: schema drift — array ndim change between batches thro
 // is marked tentative. A later firm batch refines ndim; the streaming
 // adapter accepts this as an upgrade (`schemas_equal` ignores ndim while
 // either side is tentative) rather than rejecting it as drift.
-TEST_CASE("arrow egress: schema drift — tentative→firm array ndim upgrade does NOT drift")
+TEST_CASE(
+    "arrow egress: schema drift — tentative→firm array ndim upgrade does NOT "
+    "drift")
 {
     std::vector<std::optional<qm::ArrayRow>> b1_rows = {std::nullopt};
     std::vector<std::optional<qm::ArrayRow>> b2_rows = {
@@ -582,10 +624,12 @@ TEST_CASE("arrow egress: schema drift — tentative→firm array ndim upgrade do
     CHECK(!h.cursor.next_arrow_batch().has_value());
 }
 
-TEST_CASE("arrow egress: schema drift — same schema across batches does NOT drift")
+TEST_CASE(
+    "arrow egress: schema drift — same schema across batches does NOT drift")
 {
     qm::ColumnSpec b_col{
-        "v", qm::COL_LONG,
+        "v",
+        qm::COL_LONG,
         qm::fixed_column_bytes(2, pack_le<int64_t>({10, 20}))};
     qm::Script s = {
         qm::ActionSendServerInfo{},

--- a/cpp_test/test_arrow_ingress.cpp
+++ b/cpp_test/test_arrow_ingress.cpp
@@ -2,18 +2,18 @@
 // over the conn-level Arrow batch ingest API.
 //
 // This layer is a thin, type-agnostic forwarder: it packs `table_name_view` /
-// `column_name_view` into the C structs, passes the `ArrowArray*` / `ArrowSchema*`
-// through to the C ABI, and translates a C error into a thrown
+// `column_name_view` into the C structs, passes the `ArrowArray*` /
+// `ArrowSchema*` through to the C ABI, and translates a C error into a thrown
 // `line_sender_error`. So the only things it can get wrong are argument
 // marshalling and error translation — which is all this file covers:
 //   * error / NULL paths (wrong conn, NULL array/schema, empty name);
 //   * happy publish-only, FSN-returning, and ACKing Arrow flushes to prove
 //     the marshalling paths reach the C ABI.
 //
-// Per-type Arrow->column classification is backend-agnostic Rust code, exercised
-// exhaustively in `questdb-rs/src/ingress/qwp_sender/arrow_batch.rs` and
-// round-tripped in C in `cpp_test/test_arrow_c.c`; re-testing it per type here
-// would add no coverage.
+// Per-type Arrow->column classification is backend-agnostic Rust code,
+// exercised exhaustively in `questdb-rs/src/ingress/qwp_sender/arrow_batch.rs`
+// and round-tripped in C in `cpp_test/test_arrow_c.c`; re-testing it per type
+// here would add no coverage.
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
@@ -164,11 +164,13 @@ struct MockConn
     questdb_db* db = nullptr;
     qwp_sender* conn = nullptr;
 
-    explicit MockConn(qm::Script script = qm::Script{qm::ActionAwaitClientFrame{0x51}})
+    explicit MockConn(
+        qm::Script script = qm::Script{qm::ActionAwaitClientFrame{0x51}})
         : server(std::vector<qm::Script>{std::move(script)})
     {
         const std::string conf = "ws::addr=" + server.addr() +
-            ";lazy_connect=true;sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;";
+                                 ";lazy_connect=true;sender_pool_min=1;pool_"
+                                 "reap=manual;close_flush_timeout_millis=0;";
         line_sender_error* err = nullptr;
         db = questdb_db_connect(conf.c_str(), conf.size(), &err);
         REQUIRE(db != nullptr);
@@ -205,7 +207,8 @@ TEST_CASE("flush_arrow_batch: NULL array -> invalid_api_call")
         mc.conn, tbl, nullptr, &sch, nullptr, 0, &err);
     CHECK_FALSE(ok);
     REQUIRE(err != nullptr);
-    CHECK(line_sender_error_get_code(err) == line_sender_error_invalid_api_call);
+    CHECK(
+        line_sender_error_get_code(err) == line_sender_error_invalid_api_call);
     line_sender_error_free(err);
 }
 
@@ -220,11 +223,13 @@ TEST_CASE("flush_arrow_batch: NULL schema -> invalid_api_call")
         mc.conn, tbl, &arr, nullptr, nullptr, 0, &err);
     CHECK_FALSE(ok);
     REQUIRE(err != nullptr);
-    CHECK(line_sender_error_get_code(err) == line_sender_error_invalid_api_call);
+    CHECK(
+        line_sender_error_get_code(err) == line_sender_error_invalid_api_call);
     line_sender_error_free(err);
 }
 
-TEST_CASE("flush_arrow_batch_at_column: empty ts_column_name throws invalid_name")
+TEST_CASE(
+    "flush_arrow_batch_at_column: empty ts_column_name throws invalid_name")
 {
     try
     {
@@ -263,11 +268,12 @@ TEST_CASE("flush_arrow_batch_at_now: happy path marshals through to the C ABI")
 
 TEST_CASE("borrowed_sender exposes Arrow FSN helper")
 {
-    qm::MockServer server(std::vector<qm::Script>{
-        qm::Script{qm::ActionAwaitClientFrame{0x51}}});
+    qm::MockServer server(
+        std::vector<qm::Script>{qm::Script{qm::ActionAwaitClientFrame{0x51}}});
     questdb::pool db{
         "ws::addr=" + server.addr() +
-        ";lazy_connect=true;sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;"};
+        ";lazy_connect=true;sender_pool_min=1;pool_reap=manual;close_flush_"
+        "timeout_millis=0;"};
     auto conn = db.borrow_sender();
 
     auto col = pack_le<int64_t>({10, 20, 30});
@@ -275,8 +281,8 @@ TEST_CASE("borrowed_sender exposes Arrow FSN helper")
     auto sch = make_schema("l", "v");
     try
     {
-        const auto fsn =
-            conn.flush_arrow_batch_at_now_and_get_fsn("t_borrowed"_tn, arr, sch);
+        const auto fsn = conn.flush_arrow_batch_at_now_and_get_fsn(
+            "t_borrowed"_tn, arr, sch);
         REQUIRE(fsn.has_value());
         CHECK(conn.published_fsn() == fsn);
     }
@@ -299,14 +305,7 @@ TEST_CASE("qwp_sender_flush_arrow_batch_at_now_and_wait: C ABI happy path")
     line_sender_error* err = nullptr;
     line_sender_table_name tbl{6, "t_wait"};
     const bool ok = qwp_sender_flush_arrow_batch_at_now_and_wait(
-        mc.conn,
-        tbl,
-        &arr,
-        &sch,
-        nullptr,
-        0,
-        qwpws_ack_level_ok,
-        &err);
+        mc.conn, tbl, &arr, &sch, nullptr, 0, qwpws_ack_level_ok, &err);
     CHECK(ok);
     CHECK(err == nullptr);
     CHECK_FALSE(static_cast<bool>(arr.release));
@@ -314,14 +313,16 @@ TEST_CASE("qwp_sender_flush_arrow_batch_at_now_and_wait: C ABI happy path")
 
 TEST_CASE("borrowed_sender exposes Arrow ACKing helpers")
 {
-    qm::MockServer server(std::vector<qm::Script>{qm::Script{
-        qm::ActionAwaitClientFrame{0x51},
-        qm::ActionSendRaw{qm::ingress_ok_frame(0)},
-        qm::ActionAwaitClientFrame{0x51},
-        qm::ActionSendRaw{qm::ingress_ok_frame(1)}}});
+    qm::MockServer server(
+        std::vector<qm::Script>{qm::Script{
+            qm::ActionAwaitClientFrame{0x51},
+            qm::ActionSendRaw{qm::ingress_ok_frame(0)},
+            qm::ActionAwaitClientFrame{0x51},
+            qm::ActionSendRaw{qm::ingress_ok_frame(1)}}});
     questdb::pool db{
         "ws::addr=" + server.addr() +
-        ";lazy_connect=true;sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;"};
+        ";lazy_connect=true;sender_pool_min=1;pool_reap=manual;close_flush_"
+        "timeout_millis=0;"};
     auto conn = db.borrow_sender();
 
     auto col = pack_le<int64_t>({10, 20, 30});
@@ -337,8 +338,7 @@ TEST_CASE("borrowed_sender exposes Arrow ACKing helpers")
         FAIL("borrowed Arrow at-now ACKing flush threw: " << e.what());
     }
 
-    auto ts_col = pack_le<int64_t>(
-        {1700000000000000LL, 1700000000000001LL});
+    auto ts_col = pack_le<int64_t>({1700000000000000LL, 1700000000000001LL});
     auto v_col = pack_le<int64_t>({10, 20});
 
     auto ts_arr =
@@ -394,12 +394,12 @@ TEST_CASE("borrowed_sender exposes Arrow ACKing helpers")
 
 // Happy path for the second marshalling path: the designated timestamp is taken
 // from a named Timestamp column of a struct batch.
-TEST_CASE("flush_arrow_batch (at_column): happy path picks ts from named column")
+TEST_CASE(
+    "flush_arrow_batch (at_column): happy path picks ts from named column")
 {
     MockConn mc;
 
-    auto ts_col = pack_le<int64_t>(
-        {1700000000000000LL, 1700000000000001LL});
+    auto ts_col = pack_le<int64_t>({1700000000000000LL, 1700000000000001LL});
     auto v_col = pack_le<int64_t>({10, 20});
 
     auto ts_arr =

--- a/cpp_test/test_column_sender.cpp
+++ b/cpp_test/test_column_sender.cpp
@@ -42,7 +42,8 @@ namespace
 std::unique_ptr<qm::MockServer> spawn_mock(int slot_count)
 {
     qm::Script accept_one_frame = {qm::ActionAwaitClientFrame{0x51}};
-    std::vector<qm::Script> scripts(static_cast<size_t>(slot_count), accept_one_frame);
+    std::vector<qm::Script> scripts(
+        static_cast<size_t>(slot_count), accept_one_frame);
     return std::make_unique<qm::MockServer>(std::move(scripts));
 }
 
@@ -51,20 +52,21 @@ std::unique_ptr<qm::MockServer> spawn_acking_mock(int slot_count)
     qm::Script ack_one_frame = {
         qm::ActionAwaitClientFrame{0x51},
         qm::ActionSendRaw{qm::ingress_ok_frame()}};
-    std::vector<qm::Script> scripts(static_cast<size_t>(slot_count), ack_one_frame);
+    std::vector<qm::Script> scripts(
+        static_cast<size_t>(slot_count), ack_one_frame);
     return std::make_unique<qm::MockServer>(std::move(scripts));
 }
 
 std::string conf_for(const std::string& addr, const std::string& extras = {})
 {
     return "ws::addr=" + addr +
-           ";lazy_connect=true;sender_pool_min=1;pool_reap=manual;close_flush_timeout_millis=0;" +
+           ";lazy_connect=true;sender_pool_min=1;pool_reap=manual;close_flush_"
+           "timeout_millis=0;" +
            extras;
 }
 
 void check_db_config_error(
-    const std::string& conf,
-    const std::string& expected_message)
+    const std::string& conf, const std::string& expected_message)
 {
     questdb_error* err = nullptr;
     questdb_db* db = questdb_db_connect(conf.c_str(), conf.size(), &err);
@@ -75,8 +77,7 @@ void check_db_config_error(
     REQUIRE(db == nullptr);
     REQUIRE(err != nullptr);
     std::unique_ptr<questdb_error, decltype(&questdb_error_free)> owned_err{
-        err,
-        &questdb_error_free};
+        err, &questdb_error_free};
 
     CHECK(questdb_error_get_code(err) == questdb_error_config_error);
     size_t message_len = 0;
@@ -121,9 +122,8 @@ TEST_CASE("column_chunk fluent chaining returns the same chunk")
     int64_t v[] = {1, 2, 3};
     double f[] = {1.5, 2.5, 3.5};
     int64_t ts[] = {1, 2, 3};
-    auto& ref = chunk.column_i64("v", v, 3)
-                     .column_f64("f", f, 3)
-                     .at_nanos(ts, 3);
+    auto& ref =
+        chunk.column_i64("v", v, 3).column_f64("f", f, 3).at_nanos(ts, 3);
     CHECK(&ref == &chunk);
     CHECK(chunk.row_count() == 3);
 }
@@ -204,11 +204,11 @@ TEST_CASE("column_chunk flush round-trips through the mock")
 
     qdb::column_chunk chunk{"trades"};
     int64_t qty[] = {10, 20, 30};
-    int64_t ts[] = {1'700'000'000'000'000'000LL,
-                    1'700'000'000'000'000'001LL,
-                    1'700'000'000'000'000'002LL};
-    chunk.column_i64("qty", qty, 3)
-         .at_nanos(ts, 3);
+    int64_t ts[] = {
+        1'700'000'000'000'000'000LL,
+        1'700'000'000'000'000'001LL,
+        1'700'000'000'000'000'002LL};
+    chunk.column_i64("qty", qty, 3).at_nanos(ts, 3);
 
     CHECK_FALSE(conn.published_fsn().has_value());
     CHECK_FALSE(conn.acked_fsn().has_value());
@@ -227,8 +227,9 @@ TEST_CASE("column_chunk symbol column round-trips through the mock")
 {
     // Exercises the columnar symbol FFI (qwp_chunk_symbol_i32) end to
     // end: append a dictionary-encoded SYMBOL column, flush, and confirm the
-    // frame reaches the mock. Previously only the row API's .symbol() was covered
-    // in C/C++; the column-major symbol appender had no test on the C ABI.
+    // frame reaches the mock. Previously only the row API's .symbol() was
+    // covered in C/C++; the column-major symbol appender had no test on the C
+    // ABI.
     auto mock = spawn_mock(1);
     questdb::pool db{conf_for(mock->addr())};
     auto conn = db.borrow_sender();
@@ -257,8 +258,9 @@ TEST_CASE("column_chunk symbol_i8 / symbol_i16 round-trip through the mock")
     // The i32 case is covered above; the narrow-width appenders
     // (qwp_chunk_symbol_i8 / _i16) do their own code -> global-id
     // conversion and range check at the C boundary, so exercise them end to end
-    // too. Under the FFI `panic = "abort"` profile a width-specific bug (a bad cast
-    // or an out-of-range slot index) would abort the host rather than error.
+    // too. Under the FFI `panic = "abort"` profile a width-specific bug (a bad
+    // cast or an out-of-range slot index) would abort the host rather than
+    // error.
     const int32_t dict_offsets[] = {0, 4, 8};
     const uint8_t dict_bytes[] = {'A', 'A', 'P', 'L', 'M', 'S', 'F', 'T'};
     int64_t ts[] = {
@@ -300,8 +302,8 @@ TEST_CASE("column_chunk symbol_i8 / symbol_i16 round-trip through the mock")
 TEST_CASE("column_chunk symbol append validates codes and UTF-8 at the C ABI")
 {
     // The encoder relies on every non-null code being a valid dict index, and
-    // QuestDB SYMBOLs are UTF-8, so both are rejected eagerly at append -- a bad
-    // value would otherwise be interned, persisted to the store-and-forward
+    // QuestDB SYMBOLs are UTF-8, so both are rejected eagerly at append -- a
+    // bad value would otherwise be interned, persisted to the store-and-forward
     // side-file, and locally ACKed, then rejected by the server, stranding the
     // dependent queued frame.
     SUBCASE("out-of-range code is rejected")
@@ -311,7 +313,8 @@ TEST_CASE("column_chunk symbol append validates codes and UTF-8 at the C ABI")
         const int32_t dict_offsets[] = {0, 5};
         const uint8_t dict_bytes[] = {'a', 'l', 'p', 'h', 'a'};
         CHECK_THROWS_AS(
-            chunk.symbol_i32("sym", bad_codes, 2, dict_offsets, 2, dict_bytes, 5),
+            chunk.symbol_i32(
+                "sym", bad_codes, 2, dict_offsets, 2, dict_bytes, 5),
             qdb::line_sender_error);
     }
     SUBCASE("non-UTF-8 dictionary bytes are rejected")
@@ -334,11 +337,11 @@ TEST_CASE("column_chunk flush_and_wait round-trips through the mock")
 
     qdb::column_chunk chunk{"trades"};
     int64_t qty[] = {10, 20, 30};
-    int64_t ts[] = {1'700'000'000'000'000'000LL,
-                    1'700'000'000'000'000'001LL,
-                    1'700'000'000'000'000'002LL};
-    chunk.column_i64("qty", qty, 3)
-         .at_nanos(ts, 3);
+    int64_t ts[] = {
+        1'700'000'000'000'000'000LL,
+        1'700'000'000'000'000'001LL,
+        1'700'000'000'000'000'002LL};
+    chunk.column_i64("qty", qty, 3).at_nanos(ts, 3);
 
     conn.flush_and_wait(chunk);
     CHECK(chunk.row_count() == 0);
@@ -423,8 +426,7 @@ TEST_CASE("qwp_sender_flush_buffer_and_wait: NULL buffer -> invalid_api_call")
     CHECK_FALSE(ok);
     REQUIRE(err != nullptr);
     CHECK(
-        line_sender_error_get_code(err) ==
-        line_sender_error_invalid_api_call);
+        line_sender_error_get_code(err) == line_sender_error_invalid_api_call);
     line_sender_error_free(err);
 
     questdb_db_drop_sender(db, rs);
@@ -447,7 +449,8 @@ TEST_CASE("borrowed_sender::new_buffer preserves max_name_len on lazy reinit")
     {
         // 17 chars: rejected by the cap-16 re-init (pins cap <= 16).
         auto buf = rs.new_buffer();
-        auto moved = std::move(buf); // nulls buf._impl; table() triggers may_init
+        auto moved =
+            std::move(buf); // nulls buf._impl; table() triggers may_init
         CHECK(moved.row_count() == 0);
         try
         {
@@ -500,8 +503,9 @@ TEST_CASE("borrowed_sender::wait rejects durable ACK without opt-in")
     catch (const qdb::line_sender_error& e)
     {
         CHECK(e.code() == qdb::line_sender_error_code::invalid_api_call);
-        CHECK(std::string{e.what()}.find("request_durable_ack=on") !=
-              std::string::npos);
+        CHECK(
+            std::string{e.what()}.find("request_durable_ack=on") !=
+            std::string::npos);
     }
 
     rs.drop_on_return();

--- a/cpp_test/test_line_sender.cpp
+++ b/cpp_test/test_line_sender.cpp
@@ -60,11 +60,14 @@ using namespace std::string_literals;
 using namespace questdb::ingress::literals;
 
 constexpr auto qwp_decimal256_max_positive =
-    "57896044618658097711785492504343953926634992332820282019728792003956564819967";
+    "57896044618658097711785492504343953926634992332820282019728792003956564819"
+    "967";
 constexpr auto qwp_decimal256_min_negative =
-    "-57896044618658097711785492504343953926634992332820282019728792003956564819968";
+    "-5789604461865809771178549250434395392663499233282028201972879200395656481"
+    "9968";
 constexpr auto qwp_decimal256_positive_overflow =
-    "57896044618658097711785492504343953926634992332820282019728792003956564819968";
+    "57896044618658097711785492504343953926634992332820282019728792003956564819"
+    "968";
 constexpr uint8_t qwp_test_type_boolean = 0x01;
 constexpr uint8_t qwp_test_type_long = 0x05;
 constexpr uint8_t qwp_test_type_double = 0x07;
@@ -170,12 +173,13 @@ public:
         FD_SET(_socket, &read_set);
 
         timeval timeout{};
-        timeout.tv_sec = static_cast<decltype(timeout.tv_sec)>(wait_timeout_sec);
+        timeout.tv_sec =
+            static_cast<decltype(timeout.tv_sec)>(wait_timeout_sec);
         timeout.tv_usec = static_cast<decltype(timeout.tv_usec)>(
-            1000000.0 * (wait_timeout_sec - static_cast<double>(timeout.tv_sec)));
+            1000000.0 *
+            (wait_timeout_sec - static_cast<double>(timeout.tv_sec)));
         const int nfds = static_cast<int>(_socket) + 1;
-        const int ready =
-            ::select(nfds, &read_set, nullptr, nullptr, &timeout);
+        const int ready = ::select(nfds, &read_set, nullptr, nullptr, &timeout);
         REQUIRE(ready >= 0);
         REQUIRE(ready == 1);
 
@@ -201,12 +205,13 @@ public:
         FD_SET(_socket, &read_set);
 
         timeval timeout{};
-        timeout.tv_sec = static_cast<decltype(timeout.tv_sec)>(wait_timeout_sec);
+        timeout.tv_sec =
+            static_cast<decltype(timeout.tv_sec)>(wait_timeout_sec);
         timeout.tv_usec = static_cast<decltype(timeout.tv_usec)>(
-            1000000.0 * (wait_timeout_sec - static_cast<double>(timeout.tv_sec)));
+            1000000.0 *
+            (wait_timeout_sec - static_cast<double>(timeout.tv_sec)));
         const int nfds = static_cast<int>(_socket) + 1;
-        const int ready =
-            ::select(nfds, &read_set, nullptr, nullptr, &timeout);
+        const int ready = ::select(nfds, &read_set, nullptr, nullptr, &timeout);
         REQUIRE(ready >= 0);
         return ready == 1;
     }
@@ -218,8 +223,7 @@ private:
 
 bool datagram_starts_with_qwp1(const std::vector<std::byte>& datagram)
 {
-    return datagram.size() >= 4 &&
-        std::memcmp(datagram.data(), "QWP1", 4) == 0;
+    return datagram.size() >= 4 && std::memcmp(datagram.data(), "QWP1", 4) == 0;
 }
 
 struct qwp_test_decoded_column
@@ -314,11 +318,10 @@ public:
         std::array<uint8_t, 4> raw{};
         for (size_t i = 0; i < raw.size(); ++i)
             raw[i] = std::to_integer<uint8_t>(bytes[i]);
-        return
-            static_cast<uint32_t>(raw[0]) |
-            (static_cast<uint32_t>(raw[1]) << 8) |
-            (static_cast<uint32_t>(raw[2]) << 16) |
-            (static_cast<uint32_t>(raw[3]) << 24);
+        return static_cast<uint32_t>(raw[0]) |
+               (static_cast<uint32_t>(raw[1]) << 8) |
+               (static_cast<uint32_t>(raw[2]) << 16) |
+               (static_cast<uint32_t>(raw[3]) << 24);
     }
 
     uint64_t read_u64()
@@ -327,15 +330,14 @@ public:
         std::array<uint8_t, 8> raw{};
         for (size_t i = 0; i < raw.size(); ++i)
             raw[i] = std::to_integer<uint8_t>(bytes[i]);
-        return
-            static_cast<uint64_t>(raw[0]) |
-            (static_cast<uint64_t>(raw[1]) << 8) |
-            (static_cast<uint64_t>(raw[2]) << 16) |
-            (static_cast<uint64_t>(raw[3]) << 24) |
-            (static_cast<uint64_t>(raw[4]) << 32) |
-            (static_cast<uint64_t>(raw[5]) << 40) |
-            (static_cast<uint64_t>(raw[6]) << 48) |
-            (static_cast<uint64_t>(raw[7]) << 56);
+        return static_cast<uint64_t>(raw[0]) |
+               (static_cast<uint64_t>(raw[1]) << 8) |
+               (static_cast<uint64_t>(raw[2]) << 16) |
+               (static_cast<uint64_t>(raw[3]) << 24) |
+               (static_cast<uint64_t>(raw[4]) << 32) |
+               (static_cast<uint64_t>(raw[5]) << 40) |
+               (static_cast<uint64_t>(raw[6]) << 48) |
+               (static_cast<uint64_t>(raw[7]) << 56);
     }
 
     int32_t read_i32()
@@ -373,9 +375,7 @@ public:
     {
         const auto len = static_cast<size_t>(read_varint());
         const auto bytes = read_exact(len);
-        return {
-            reinterpret_cast<const char*>(bytes.data()),
-            bytes.size()};
+        return {reinterpret_cast<const char*>(bytes.data()), bytes.size()};
     }
 
     double read_f64()
@@ -417,7 +417,8 @@ std::vector<std::byte> qwp_test_payload_from_datagram(
         (static_cast<uint32_t>(std::to_integer<uint8_t>(datagram[11])) << 24);
     REQUIRE(datagram.size() == qwp_test_message_header_size + payload_len);
     return {
-        datagram.begin() + static_cast<std::ptrdiff_t>(qwp_test_message_header_size),
+        datagram.begin() +
+            static_cast<std::ptrdiff_t>(qwp_test_message_header_size),
         datagram.end()};
 }
 
@@ -451,8 +452,7 @@ qwp_test_decoded_value qwp_test_f64_value(double value)
 }
 
 qwp_test_decoded_value qwp_test_string_value(
-    qwp_test_decoded_value_kind kind,
-    std::string value)
+    qwp_test_decoded_value_kind kind, std::string value)
 {
     qwp_test_decoded_value out{};
     out.kind = kind;
@@ -461,8 +461,7 @@ qwp_test_decoded_value qwp_test_string_value(
 }
 
 qwp_test_decoded_value qwp_test_timestamp_value(
-    qwp_test_decoded_value_kind kind,
-    int64_t value)
+    qwp_test_decoded_value_kind kind, int64_t value)
 {
     qwp_test_decoded_value out{};
     out.kind = kind;
@@ -491,16 +490,14 @@ std::vector<qwp_test_decoded_value> qwp_test_read_column_values(
 
     switch (type_code)
     {
-    case qwp_test_type_boolean:
-    {
+    case qwp_test_type_boolean: {
         const size_t packed_size = (non_null_count + 7) / 8;
         const auto bytes = decoder.read_exact(packed_size);
         std::vector<bool> raw_values;
         raw_values.reserve(non_null_count);
         for (size_t value_idx = 0; value_idx < non_null_count; ++value_idx)
         {
-            const uint8_t byte =
-                std::to_integer<uint8_t>(bytes[value_idx / 8]);
+            const uint8_t byte = std::to_integer<uint8_t>(bytes[value_idx / 8]);
             raw_values.push_back((byte & (1u << (value_idx % 8))) != 0);
         }
 
@@ -518,8 +515,7 @@ std::vector<qwp_test_decoded_value> qwp_test_read_column_values(
         }
         return values;
     }
-    case qwp_test_type_symbol:
-    {
+    case qwp_test_type_symbol: {
         const size_t dict_size = static_cast<size_t>(decoder.read_varint());
         std::vector<std::string> dict;
         dict.reserve(dict_size);
@@ -544,13 +540,11 @@ std::vector<qwp_test_decoded_value> qwp_test_read_column_values(
             const size_t idx = indexes[next_index++];
             REQUIRE(idx < dict.size());
             values.push_back(qwp_test_string_value(
-                qwp_test_decoded_value_kind::symbol,
-                dict[idx]));
+                qwp_test_decoded_value_kind::symbol, dict[idx]));
         }
         return values;
     }
-    case qwp_test_type_long:
-    {
+    case qwp_test_type_long: {
         std::vector<qwp_test_decoded_value> raw_values;
         raw_values.reserve(non_null_count);
         for (size_t i = 0; i < non_null_count; ++i)
@@ -566,8 +560,7 @@ std::vector<qwp_test_decoded_value> qwp_test_read_column_values(
         }
         return values;
     }
-    case qwp_test_type_double:
-    {
+    case qwp_test_type_double: {
         std::vector<qwp_test_decoded_value> raw_values;
         raw_values.reserve(non_null_count);
         for (size_t i = 0; i < non_null_count; ++i)
@@ -583,15 +576,15 @@ std::vector<qwp_test_decoded_value> qwp_test_read_column_values(
         }
         return values;
     }
-    case qwp_test_type_varchar:
-    {
+    case qwp_test_type_varchar: {
         std::vector<int32_t> offsets;
         offsets.reserve(non_null_count + 1);
         for (size_t i = 0; i < non_null_count + 1; ++i)
             offsets.push_back(decoder.read_i32());
         REQUIRE(!offsets.empty());
         REQUIRE(offsets.back() >= 0);
-        const auto data = decoder.read_exact(static_cast<size_t>(offsets.back()));
+        const auto data =
+            decoder.read_exact(static_cast<size_t>(offsets.back()));
 
         size_t next_offset = 0;
         std::vector<qwp_test_decoded_value> values;
@@ -621,15 +614,15 @@ std::vector<qwp_test_decoded_value> qwp_test_read_column_values(
         return values;
     }
     case qwp_test_type_timestamp:
-    case qwp_test_type_timestamp_nanos:
-    {
-        const auto kind = type_code == qwp_test_type_timestamp ?
-            qwp_test_decoded_value_kind::timestamp_micros :
-            qwp_test_decoded_value_kind::timestamp_nanos;
+    case qwp_test_type_timestamp_nanos: {
+        const auto kind = type_code == qwp_test_type_timestamp
+                              ? qwp_test_decoded_value_kind::timestamp_micros
+                              : qwp_test_decoded_value_kind::timestamp_nanos;
         std::vector<qwp_test_decoded_value> raw_values;
         raw_values.reserve(non_null_count);
         for (size_t i = 0; i < non_null_count; ++i)
-            raw_values.push_back(qwp_test_timestamp_value(kind, decoder.read_i64()));
+            raw_values.push_back(
+                qwp_test_timestamp_value(kind, decoder.read_i64()));
 
         size_t next_value = 0;
         std::vector<qwp_test_decoded_value> values;
@@ -686,10 +679,8 @@ qwp_test_decoded_scalar_datagram decode_single_scalar_qwp_datagram(
                     has_value[row] = false;
             }
         }
-        column_values.push_back(qwp_test_read_column_values(
-            decoder,
-            column.type_code,
-            has_value));
+        column_values.push_back(
+            qwp_test_read_column_values(decoder, column.type_code, has_value));
     }
 
     decoded.rows.assign(row_count, {});
@@ -707,8 +698,7 @@ qwp_test_decoded_scalar_datagram decode_single_scalar_qwp_datagram(
 }
 
 size_t qwp_test_column_index(
-    const qwp_test_decoded_scalar_datagram& decoded,
-    const std::string& name)
+    const qwp_test_decoded_scalar_datagram& decoded, const std::string& name)
 {
     for (size_t i = 0; i < decoded.columns.size(); ++i)
     {
@@ -731,8 +721,7 @@ void qwp_check_column(
 }
 
 void qwp_check_column_count(
-    const qwp_test_decoded_scalar_datagram& decoded,
-    size_t expected)
+    const qwp_test_decoded_scalar_datagram& decoded, size_t expected)
 {
     CHECK(decoded.columns.size() == expected);
     for (const auto& row : decoded.rows)
@@ -757,8 +746,7 @@ void qwp_expect_bool(const qwp_test_decoded_value& value, bool expected)
 }
 
 void qwp_expect_symbol(
-    const qwp_test_decoded_value& value,
-    const std::string& expected)
+    const qwp_test_decoded_value& value, const std::string& expected)
 {
     REQUIRE(value.kind == qwp_test_decoded_value_kind::symbol);
     CHECK(value.string_value == expected);
@@ -783,24 +771,21 @@ void qwp_expect_f64_nan(const qwp_test_decoded_value& value)
 }
 
 void qwp_expect_string(
-    const qwp_test_decoded_value& value,
-    const std::string& expected)
+    const qwp_test_decoded_value& value, const std::string& expected)
 {
     REQUIRE(value.kind == qwp_test_decoded_value_kind::string);
     CHECK(value.string_value == expected);
 }
 
 void qwp_expect_timestamp_micros(
-    const qwp_test_decoded_value& value,
-    int64_t expected)
+    const qwp_test_decoded_value& value, int64_t expected)
 {
     REQUIRE(value.kind == qwp_test_decoded_value_kind::timestamp_micros);
     CHECK(value.i64_value == expected);
 }
 
 void qwp_expect_timestamp_nanos(
-    const qwp_test_decoded_value& value,
-    int64_t expected)
+    const qwp_test_decoded_value& value, int64_t expected)
 {
     REQUIRE(value.kind == qwp_test_decoded_value_kind::timestamp_nanos);
     CHECK(value.i64_value == expected);
@@ -822,9 +807,7 @@ qwp_test_decoded_array_datagram decode_single_array_qwp_datagram(
         (static_cast<uint32_t>(std::to_integer<uint8_t>(datagram[11])) << 24);
     REQUIRE(datagram.size() == 12u + payload_len);
 
-    std::vector<std::byte> payload{
-        datagram.begin() + 12,
-        datagram.end()};
+    std::vector<std::byte> payload{datagram.begin() + 12, datagram.end()};
     qwp_test_decoder decoder{payload};
     qwp_test_decoded_array_datagram decoded{};
     decoded.table_name = decoder.read_string();
@@ -872,16 +855,15 @@ std::vector<uint8_t> trim_signed_be_bytes(const std::vector<uint8_t>& bytes)
     {
         const uint8_t current = bytes[keep_from];
         const uint8_t next = bytes[keep_from + 1];
-        const bool should_trim = negative ?
-            (current == 0xffu && (next & 0x80u) != 0) :
-            (current == 0x00u && (next & 0x80u) == 0);
+        const bool should_trim =
+            negative ? (current == 0xffu && (next & 0x80u) != 0)
+                     : (current == 0x00u && (next & 0x80u) == 0);
         if (!should_trim)
             break;
         ++keep_from;
     }
     return {
-        bytes.begin() + static_cast<std::ptrdiff_t>(keep_from),
-        bytes.end()};
+        bytes.begin() + static_cast<std::ptrdiff_t>(keep_from), bytes.end()};
 }
 
 std::vector<uint8_t> trimmed_signed_i64_be(int64_t value)
@@ -928,9 +910,7 @@ qwp_test_decoded_decimal_datagram decode_single_decimal_qwp_datagram(
         (static_cast<uint32_t>(std::to_integer<uint8_t>(datagram[11])) << 24);
     REQUIRE(datagram.size() == 12u + payload_len);
 
-    std::vector<std::byte> payload{
-        datagram.begin() + 12,
-        datagram.end()};
+    std::vector<std::byte> payload{datagram.begin() + 12, datagram.end()};
     qwp_test_decoder decoder{payload};
     qwp_test_decoded_decimal_datagram decoded{};
     decoded.table_name = decoder.read_string();
@@ -948,9 +928,7 @@ qwp_test_decoded_decimal_datagram decode_single_decimal_qwp_datagram(
     REQUIRE(decimal_type_ok);
 
     decoded.nullable = decoder.read_u8() != 0;
-    std::vector<bool> has_value(
-        static_cast<size_t>(decoded.row_count),
-        true);
+    std::vector<bool> has_value(static_cast<size_t>(decoded.row_count), true);
     if (decoded.nullable)
     {
         const size_t bitmap_len = (has_value.size() + 7) / 8;
@@ -964,8 +942,10 @@ qwp_test_decoded_decimal_datagram decode_single_decimal_qwp_datagram(
     }
 
     decoded.scale = decoder.read_u8();
-    const size_t width = decoded.column.type_code == qwp_type_decimal64 ? 8 :
-        (decoded.column.type_code == qwp_type_decimal128 ? 16 : 32);
+    const size_t width =
+        decoded.column.type_code == qwp_type_decimal64
+            ? 8
+            : (decoded.column.type_code == qwp_type_decimal128 ? 16 : 32);
 
     decoded.values.reserve(has_value.size());
     for (bool present : has_value)
@@ -1023,12 +1003,12 @@ public:
         // single-threaded test code and the value is immediately
         // copied into a std::string, so it's safe here.
 #ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4996)
+#    pragma warning(push)
+#    pragma warning(disable : 4996)
 #endif
         if (const char* old_value = std::getenv(name))
 #ifdef _MSC_VER
-#pragma warning(pop)
+#    pragma warning(pop)
 #endif
             _old_value = old_value;
         REQUIRE(qdb_test_set_env_var(name, value.c_str()));
@@ -2102,8 +2082,7 @@ TEST_CASE("Test Bookmark")
     buffer.table("test").symbol("a", "c").at_now();
 
     CHECK_THROWS_AS(
-        buffer.rewind_to_bookmark(stale),
-        questdb::ingress::line_sender_error);
+        buffer.rewind_to_bookmark(stale), questdb::ingress::line_sender_error);
 
     buffer.rewind_to_bookmark(current);
     CHECK(buffer.peek() == "test,a=b\n");
@@ -2266,7 +2245,9 @@ TEST_CASE("line sender protocol throws after close")
     sender.close();
 
     CHECK_THROWS_WITH_AS(
-        sender.protocol(), "Sender closed.", questdb::ingress::line_sender_error);
+        sender.protocol(),
+        "Sender closed.",
+        questdb::ingress::line_sender_error);
 }
 
 TEST_CASE("line sender protocol version v2")
@@ -2308,8 +2289,8 @@ TEST_CASE("line_sender c api udp basics")
     }};
 
     const auto host = QDB_UTF8_LITERAL("127.0.0.1");
-    ::line_sender_opts* opts =
-        ::line_sender_opts_new(::line_sender_protocol_udp, host, receiver.port());
+    ::line_sender_opts* opts = ::line_sender_opts_new(
+        ::line_sender_protocol_udp, host, receiver.port());
     REQUIRE(opts != nullptr);
     on_scope_exit opts_free_guard{[&] { ::line_sender_opts_free(opts); }};
 
@@ -2366,8 +2347,8 @@ TEST_CASE("line_sender c api standalone udp buffer")
     }};
 
     const auto host = QDB_UTF8_LITERAL("127.0.0.1");
-    ::line_sender_opts* opts =
-        ::line_sender_opts_new(::line_sender_protocol_udp, host, receiver.port());
+    ::line_sender_opts* opts = ::line_sender_opts_new(
+        ::line_sender_protocol_udp, host, receiver.port());
     REQUIRE(opts != nullptr);
     on_scope_exit opts_free_guard{[&] { ::line_sender_opts_free(opts); }};
 
@@ -2408,8 +2389,8 @@ TEST_CASE("line_sender c api udp f64 array column")
     }};
 
     const auto host = QDB_UTF8_LITERAL("127.0.0.1");
-    ::line_sender_opts* opts =
-        ::line_sender_opts_new(::line_sender_protocol_udp, host, receiver.port());
+    ::line_sender_opts* opts = ::line_sender_opts_new(
+        ::line_sender_protocol_udp, host, receiver.port());
     REQUIRE(opts != nullptr);
     on_scope_exit opts_free_guard{[&] { ::line_sender_opts_free(opts); }};
 
@@ -2429,13 +2410,7 @@ TEST_CASE("line_sender c api udp f64 array column")
     CHECK(::line_sender_buffer_table(buffer, table, &err));
     CHECK(
         ::line_sender_buffer_column_f64_arr_c_major(
-            buffer,
-            arr_col,
-            2,
-            shape,
-            arr_data.data(),
-            arr_data.size(),
-            &err));
+            buffer, arr_col, 2, shape, arr_data.data(), arr_data.size(), &err));
     CHECK(::line_sender_buffer_at_now(buffer, &err));
     CHECK(::line_sender_flush(sender, buffer, &err));
     CHECK(::line_sender_buffer_row_count(buffer) == 0);
@@ -2460,8 +2435,8 @@ TEST_CASE("line_sender c api udp decimal column")
     }};
 
     const auto host = QDB_UTF8_LITERAL("127.0.0.1");
-    ::line_sender_opts* opts =
-        ::line_sender_opts_new(::line_sender_protocol_udp, host, receiver.port());
+    ::line_sender_opts* opts = ::line_sender_opts_new(
+        ::line_sender_protocol_udp, host, receiver.port());
     REQUIRE(opts != nullptr);
     on_scope_exit opts_free_guard{[&] { ::line_sender_opts_free(opts); }};
 
@@ -2478,7 +2453,8 @@ TEST_CASE("line_sender c api udp decimal column")
     const uint8_t neg_345[] = {0xfe, 0xa7};
 
     CHECK(::line_sender_buffer_table(buffer, table, &err));
-    CHECK(::line_sender_buffer_column_dec_str(buffer, price, "1.5e-3", 6, &err));
+    CHECK(
+        ::line_sender_buffer_column_dec_str(buffer, price, "1.5e-3", 6, &err));
     CHECK(::line_sender_buffer_at_now(buffer, &err));
 
     CHECK(::line_sender_buffer_table(buffer, table, &err));
@@ -2488,12 +2464,7 @@ TEST_CASE("line_sender c api udp decimal column")
     CHECK(::line_sender_buffer_table(buffer, table, &err));
     CHECK(
         ::line_sender_buffer_column_dec(
-            buffer,
-            price,
-            2,
-            neg_345,
-            sizeof(neg_345),
-            &err));
+            buffer, price, 2, neg_345, sizeof(neg_345), &err));
     CHECK(::line_sender_buffer_at_now(buffer, &err));
 
     CHECK(::line_sender_buffer_table(buffer, table, &err));
@@ -2531,8 +2502,8 @@ TEST_CASE("line_sender c api udp decimal signed boundaries")
     }};
 
     const auto host = QDB_UTF8_LITERAL("127.0.0.1");
-    ::line_sender_opts* opts =
-        ::line_sender_opts_new(::line_sender_protocol_udp, host, receiver.port());
+    ::line_sender_opts* opts = ::line_sender_opts_new(
+        ::line_sender_protocol_udp, host, receiver.port());
     REQUIRE(opts != nullptr);
     on_scope_exit opts_free_guard{[&] { ::line_sender_opts_free(opts); }};
 
@@ -2595,8 +2566,8 @@ TEST_CASE("line_sender c api udp decimal rejects signed overflow")
     }};
 
     const auto host = QDB_UTF8_LITERAL("127.0.0.1");
-    ::line_sender_opts* opts =
-        ::line_sender_opts_new(::line_sender_protocol_udp, host, receiver.port());
+    ::line_sender_opts* opts = ::line_sender_opts_new(
+        ::line_sender_protocol_udp, host, receiver.port());
     REQUIRE(opts != nullptr);
     on_scope_exit opts_free_guard{[&] { ::line_sender_opts_free(opts); }};
 
@@ -2677,7 +2648,8 @@ TEST_CASE("line_sender c api udp max name len and peek")
             ::line_sender_error_free(err);
     }};
 
-    ::line_sender_buffer* buffer = ::line_sender_buffer_new_qwp_with_max_name_len(4);
+    ::line_sender_buffer* buffer =
+        ::line_sender_buffer_new_qwp_with_max_name_len(4);
     REQUIRE(buffer != nullptr);
     on_scope_exit buffer_free_guard{[&] { ::line_sender_buffer_free(buffer); }};
 
@@ -2719,8 +2691,8 @@ TEST_CASE("line_sender c api udp from env")
 {
     udp_capture receiver;
     const std::string conf = "udp::addr=127.0.0.1:"s +
-        std::to_string(receiver.port()) +
-        ";max_datagram_size=256;multicast_ttl=1;";
+                             std::to_string(receiver.port()) +
+                             ";max_datagram_size=256;multicast_ttl=1;";
     scoped_env_var env_var{"QDB_CLIENT_CONF", conf};
 
     ::line_sender_error* err = nullptr;
@@ -2838,7 +2810,9 @@ TEST_CASE("line_sender_error c++ can carry qwpws diagnostic")
     CHECK(
         error.qwp_ws_diagnostic()->applied_policy ==
         questdb::ingress::qwp_ws_error_policy::terminal);
-    CHECK(error.qwp_ws_diagnostic()->status == std::optional<uint8_t>{uint8_t{2}});
+    CHECK(
+        error.qwp_ws_diagnostic()->status ==
+        std::optional<uint8_t>{uint8_t{2}});
     CHECK(error.qwp_ws_diagnostic()->message == "bad line");
     CHECK(
         error.qwp_ws_diagnostic()->message_sequence ==
@@ -2937,18 +2911,21 @@ TEST_CASE("line_sender c++ udp decimal column")
     buffer.table("cpp_decimals")
         .column(
             "price",
-            questdb::ingress::decimal::decimal_str_view{std::string_view{"1.5e-3"}})
+            questdb::ingress::decimal::decimal_str_view{
+                std::string_view{"1.5e-3"}})
         .at_now();
     buffer.table("cpp_decimals")
         .column(
             "price",
-            questdb::ingress::decimal::decimal_str_view{std::string_view{"NaN"}})
+            questdb::ingress::decimal::decimal_str_view{
+                std::string_view{"NaN"}})
         .at_now();
     buffer.table("cpp_decimals").column("price", neg_345_decimal).at_now();
     buffer.table("cpp_decimals")
         .column(
             "price",
-            questdb::ingress::decimal::decimal_str_view{std::string_view{"1.2"}})
+            questdb::ingress::decimal::decimal_str_view{
+                std::string_view{"1.2"}})
         .at_now();
 
     sender.flush(buffer);
@@ -3084,7 +3061,9 @@ TEST_CASE("line_sender c++ udp decimal rejects signed overflow")
     catch (const questdb::ingress::line_sender_error& ex)
     {
         threw = true;
-        CHECK(std::string{ex.what()}.find("signed DECIMAL256 range") != std::string::npos);
+        CHECK(
+            std::string{ex.what()}.find("signed DECIMAL256 range") !=
+            std::string::npos);
     }
     CHECK(threw);
     CHECK(buffer.row_count() == 1);
@@ -3100,9 +3079,7 @@ TEST_CASE("line_sender c++ udp rejects flush with incomplete row")
     questdb::ingress::line_sender sender{opts};
 
     questdb::ingress::line_sender_buffer buffer = sender.new_buffer();
-    buffer.table("trades")
-        .symbol("sym", "ETH-USD")
-        .column("qty", int64_t{4});
+    buffer.table("trades").symbol("sym", "ETH-USD").column("qty", int64_t{4});
 
     CHECK_THROWS_WITH_AS(
         sender.flush(buffer),
@@ -3126,7 +3103,8 @@ TEST_CASE("line_sender c++ udp rejects ilp buffer")
 
     CHECK_THROWS_WITH_AS(
         sender.flush(buffer),
-        "QWP/UDP sender requires a QWP buffer created by `Sender::new_buffer()`.",
+        "QWP/UDP sender requires a QWP buffer created by "
+        "`Sender::new_buffer()`.",
         questdb::ingress::line_sender_error);
 }
 
@@ -3192,8 +3170,9 @@ TEST_CASE("line_sender c api err_out may be null on failure")
 {
     ::line_sender_utf8 utf8{0, nullptr};
     const char invalid_utf8[] = {static_cast<char>(0xff)};
-    CHECK_FALSE(::line_sender_utf8_init(
-        &utf8, sizeof(invalid_utf8), invalid_utf8, nullptr));
+    CHECK_FALSE(
+        ::line_sender_utf8_init(
+            &utf8, sizeof(invalid_utf8), invalid_utf8, nullptr));
 
     const auto host = QDB_UTF8_LITERAL("127.0.0.1");
     ::line_sender_opts* opts =
@@ -3209,13 +3188,15 @@ TEST_CASE("line_sender c api err_out may be null on failure")
     on_scope_exit buffer_free_guard{[&] { ::line_sender_buffer_free(buffer); }};
 
     const auto col = QDB_COLUMN_NAME_LITERAL("x");
-    CHECK_FALSE(::line_sender_buffer_column_dec_str(
-        buffer, col, "not_decimal?", 12, nullptr));
+    CHECK_FALSE(
+        ::line_sender_buffer_column_dec_str(
+            buffer, col, "not_decimal?", 12, nullptr));
 
     uintptr_t shape[] = {1};
     double data[] = {1.0};
-    CHECK_FALSE(::line_sender_buffer_column_f64_arr_c_major(
-        buffer, col, 0, shape, data, 1, nullptr));
+    CHECK_FALSE(
+        ::line_sender_buffer_column_f64_arr_c_major(
+            buffer, col, 0, shape, data, 1, nullptr));
 
     ::line_sender_bookmark bookmark{};
     CHECK(::line_sender_buffer_bookmark(buffer, &bookmark, nullptr));
@@ -3284,13 +3265,17 @@ TEST_CASE("line_sender c api max_datagram_size rejected for tcp opts")
 
     CHECK_FALSE(::line_sender_opts_max_datagram_size(opts, 256, &err));
     REQUIRE(err != nullptr);
-    CHECK(line_sender_error_message(err).find("only supported for QWP/UDP") != std::string::npos);
+    CHECK(
+        line_sender_error_message(err).find("only supported for QWP/UDP") !=
+        std::string::npos);
     ::line_sender_error_free(err);
     err = nullptr;
 
     CHECK_FALSE(::line_sender_opts_multicast_ttl(opts, 3, &err));
     REQUIRE(err != nullptr);
-    CHECK(line_sender_error_message(err).find("only supported for QWP/UDP") != std::string::npos);
+    CHECK(
+        line_sender_error_message(err).find("only supported for QWP/UDP") !=
+        std::string::npos);
 }
 
 TEST_CASE("line_sender c api udp opts reject invalid datagram settings")
@@ -3340,8 +3325,9 @@ TEST_CASE("line_sender c api udp array rank bounds are rejected")
 
     uintptr_t shape_one[] = {1};
     double data[] = {1.0};
-    CHECK_FALSE(::line_sender_buffer_column_f64_arr_c_major(
-        buffer, col, 0, shape_one, data, 1, &err));
+    CHECK_FALSE(
+        ::line_sender_buffer_column_f64_arr_c_major(
+            buffer, col, 0, shape_one, data, 1, &err));
     REQUIRE(err != nullptr);
     CHECK(
         line_sender_error_message(err).find("Zero-dimensional arrays") !=
@@ -3351,8 +3337,9 @@ TEST_CASE("line_sender c api udp array rank bounds are rejected")
 
     std::array<uintptr_t, 33> shape_33{};
     shape_33.fill(1);
-    CHECK_FALSE(::line_sender_buffer_column_f64_arr_c_major(
-        buffer, col, shape_33.size(), shape_33.data(), data, 1, &err));
+    CHECK_FALSE(
+        ::line_sender_buffer_column_f64_arr_c_major(
+            buffer, col, shape_33.size(), shape_33.data(), data, 1, &err));
     REQUIRE(err != nullptr);
     CHECK(
         line_sender_error_message(err).find("expected at most") !=
@@ -3390,8 +3377,7 @@ TEST_CASE("line_sender c++ udp bookmark rewind and clear")
     buffer.table("t").symbol("s", "d").column("x", int64_t{4}).at_now();
     buffer.clear_bookmark(bm2);
     CHECK_THROWS_AS(
-        buffer.rewind_to_bookmark(bm2),
-        questdb::ingress::line_sender_error);
+        buffer.rewind_to_bookmark(bm2), questdb::ingress::line_sender_error);
 }
 
 TEST_CASE("line_sender c api flush empty udp buffer is noop")
@@ -3404,8 +3390,8 @@ TEST_CASE("line_sender c api flush empty udp buffer is noop")
     }};
 
     const auto host = QDB_UTF8_LITERAL("127.0.0.1");
-    ::line_sender_opts* opts =
-        ::line_sender_opts_new(::line_sender_protocol_udp, host, receiver.port());
+    ::line_sender_opts* opts = ::line_sender_opts_new(
+        ::line_sender_protocol_udp, host, receiver.port());
     REQUIRE(opts != nullptr);
     on_scope_exit opts_free_guard{[&] { ::line_sender_opts_free(opts); }};
 
@@ -3457,8 +3443,8 @@ TEST_CASE("line_sender c api qwp buffer rejected by tcp sender")
     CHECK_FALSE(::line_sender_flush(sender, buffer, &err));
     REQUIRE(err != nullptr);
     CHECK(
-        line_sender_error_message(err).find("ILP sender requires an ILP buffer") !=
-        std::string::npos);
+        line_sender_error_message(err).find(
+            "ILP sender requires an ILP buffer") != std::string::npos);
 }
 
 TEST_CASE("line_sender c++ udp opts reusable after protocol_version error")
@@ -3514,11 +3500,7 @@ TEST_CASE("line_sender c++ udp all column types with designated timestamp")
     qwp_check_column(decoded, "count", qwp_test_type_long, false);
     qwp_check_column(decoded, "temperature", qwp_test_type_double, false);
     qwp_check_column(decoded, "label", qwp_test_type_varchar, false);
-    qwp_check_column(
-        decoded,
-        "event_ts",
-        qwp_test_type_timestamp_nanos,
-        false);
+    qwp_check_column(decoded, "event_ts", qwp_test_type_timestamp_nanos, false);
     qwp_check_column(decoded, "sample_ts", qwp_test_type_timestamp, false);
     qwp_check_column(decoded, "", qwp_test_type_timestamp_nanos, false);
     qwp_expect_symbol(qwp_cell(decoded, 0, "location"), "NYC");
@@ -3606,8 +3588,7 @@ TEST_CASE("line_sender c++ udp sparse columns across rows")
     qwp_expect_f64_nan(qwp_cell(decoded, 0, "px"));
     qwp_expect_symbol(qwp_cell(decoded, 1, "sym"), "BTC-USD");
     qwp_expect_i64(
-        qwp_cell(decoded, 1, "qty"),
-        std::numeric_limits<int64_t>::min());
+        qwp_cell(decoded, 1, "qty"), std::numeric_limits<int64_t>::min());
     qwp_expect_bool(qwp_cell(decoded, 1, "active"), false);
     qwp_expect_f64(qwp_cell(decoded, 1, "px"), 45000.0);
     qwp_expect_symbol(qwp_cell(decoded, 2, "sym"), "SOL-USD");
@@ -3728,8 +3709,8 @@ TEST_CASE("line_sender c api udp marker rewind rows")
     }};
 
     const auto host = QDB_UTF8_LITERAL("127.0.0.1");
-    ::line_sender_opts* opts =
-        ::line_sender_opts_new(::line_sender_protocol_udp, host, receiver.port());
+    ::line_sender_opts* opts = ::line_sender_opts_new(
+        ::line_sender_protocol_udp, host, receiver.port());
     REQUIRE(opts != nullptr);
     on_scope_exit opts_free_guard{[&] { ::line_sender_opts_free(opts); }};
 
@@ -3747,7 +3728,9 @@ TEST_CASE("line_sender c api udp marker rewind rows")
     const auto qty = QDB_COLUMN_NAME_LITERAL("qty");
 
     CHECK(::line_sender_buffer_table(buffer, trades, &err));
-    CHECK(::line_sender_buffer_symbol(buffer, sym, QDB_UTF8_LITERAL("ETH-USD"), &err));
+    CHECK(
+        ::line_sender_buffer_symbol(
+            buffer, sym, QDB_UTF8_LITERAL("ETH-USD"), &err));
     CHECK(::line_sender_buffer_column_i64(buffer, qty, 1, &err));
     CHECK(::line_sender_buffer_at_now(buffer, &err));
     CHECK(::line_sender_buffer_row_count(buffer) == 1);
@@ -3755,7 +3738,9 @@ TEST_CASE("line_sender c api udp marker rewind rows")
 
     CHECK(::line_sender_buffer_set_marker(buffer, &err));
     CHECK(::line_sender_buffer_table(buffer, quotes, &err));
-    CHECK(::line_sender_buffer_symbol(buffer, sym, QDB_UTF8_LITERAL("BTC-USD"), &err));
+    CHECK(
+        ::line_sender_buffer_symbol(
+            buffer, sym, QDB_UTF8_LITERAL("BTC-USD"), &err));
     CHECK(::line_sender_buffer_column_i64(buffer, qty, 2, &err));
     CHECK(::line_sender_buffer_at_now(buffer, &err));
     CHECK(::line_sender_buffer_row_count(buffer) == 2);
@@ -3765,7 +3750,9 @@ TEST_CASE("line_sender c api udp marker rewind rows")
     CHECK_FALSE(::line_sender_buffer_transactional(buffer));
 
     CHECK(::line_sender_buffer_table(buffer, trades, &err));
-    CHECK(::line_sender_buffer_symbol(buffer, sym, QDB_UTF8_LITERAL("SOL-USD"), &err));
+    CHECK(
+        ::line_sender_buffer_symbol(
+            buffer, sym, QDB_UTF8_LITERAL("SOL-USD"), &err));
     CHECK(::line_sender_buffer_column_i64(buffer, qty, 3, &err));
     CHECK(::line_sender_buffer_at_now(buffer, &err));
     CHECK(::line_sender_buffer_row_count(buffer) == 2);
@@ -3780,8 +3767,7 @@ TEST_CASE("line_sender c api udp marker rewind rows")
     const auto datagram = receiver.recv_datagram();
     CHECK(datagram_starts_with_qwp1(datagram));
     const std::string datagram_text{
-        reinterpret_cast<const char*>(datagram.data()),
-        datagram.size()};
+        reinterpret_cast<const char*>(datagram.data()), datagram.size()};
     CHECK(datagram_text.find("trades") != std::string::npos);
     CHECK(datagram_text.find("ETH-USD") != std::string::npos);
     CHECK(datagram_text.find("SOL-USD") != std::string::npos);
@@ -3800,8 +3786,8 @@ TEST_CASE("line_sender c api udp bookmark rewind and stale rejection")
     }};
 
     const auto host = QDB_UTF8_LITERAL("127.0.0.1");
-    ::line_sender_opts* opts =
-        ::line_sender_opts_new(::line_sender_protocol_udp, host, receiver.port());
+    ::line_sender_opts* opts = ::line_sender_opts_new(
+        ::line_sender_protocol_udp, host, receiver.port());
     REQUIRE(opts != nullptr);
     on_scope_exit opts_free_guard{[&] { ::line_sender_opts_free(opts); }};
 
@@ -3857,8 +3843,8 @@ TEST_CASE("line_sender c api udp flush_and_keep via c api")
     }};
 
     const auto host = QDB_UTF8_LITERAL("127.0.0.1");
-    ::line_sender_opts* opts =
-        ::line_sender_opts_new(::line_sender_protocol_udp, host, receiver.port());
+    ::line_sender_opts* opts = ::line_sender_opts_new(
+        ::line_sender_protocol_udp, host, receiver.port());
     REQUIRE(opts != nullptr);
     on_scope_exit opts_free_guard{[&] { ::line_sender_opts_free(opts); }};
 
@@ -3904,8 +3890,8 @@ TEST_CASE("line_sender c api udp all column types with at_nanos")
     }};
 
     const auto host = QDB_UTF8_LITERAL("127.0.0.1");
-    ::line_sender_opts* opts =
-        ::line_sender_opts_new(::line_sender_protocol_udp, host, receiver.port());
+    ::line_sender_opts* opts = ::line_sender_opts_new(
+        ::line_sender_protocol_udp, host, receiver.port());
     REQUIRE(opts != nullptr);
     on_scope_exit opts_free_guard{[&] { ::line_sender_opts_free(opts); }};
 
@@ -3933,7 +3919,9 @@ TEST_CASE("line_sender c api udp all column types with at_nanos")
     CHECK(::line_sender_buffer_column_i64(buffer, count, 100, &err));
     CHECK(::line_sender_buffer_column_f64(buffer, temp, 22.75, &err));
     CHECK(::line_sender_buffer_column_str(buffer, label, label_value, &err));
-    CHECK(::line_sender_buffer_column_ts_nanos(buffer, event_ts, 123456789, &err));
+    CHECK(
+        ::line_sender_buffer_column_ts_nanos(
+            buffer, event_ts, 123456789, &err));
     CHECK(::line_sender_buffer_at_nanos(buffer, 1000000000, &err));
 
     CHECK(::line_sender_flush(sender, buffer, &err));
@@ -3947,11 +3935,7 @@ TEST_CASE("line_sender c api udp all column types with at_nanos")
     qwp_check_column(decoded, "count", qwp_test_type_long, false);
     qwp_check_column(decoded, "temp", qwp_test_type_double, false);
     qwp_check_column(decoded, "label", qwp_test_type_varchar, false);
-    qwp_check_column(
-        decoded,
-        "event_ts",
-        qwp_test_type_timestamp_nanos,
-        false);
+    qwp_check_column(decoded, "event_ts", qwp_test_type_timestamp_nanos, false);
     qwp_check_column(decoded, "", qwp_test_type_timestamp_nanos, false);
     qwp_expect_symbol(qwp_cell(decoded, 0, "loc"), "NYC");
     qwp_expect_bool(qwp_cell(decoded, 0, "active"), true);
@@ -3972,8 +3956,8 @@ TEST_CASE("line_sender c api udp at_micros designated timestamp")
     }};
 
     const auto host = QDB_UTF8_LITERAL("127.0.0.1");
-    ::line_sender_opts* opts =
-        ::line_sender_opts_new(::line_sender_protocol_udp, host, receiver.port());
+    ::line_sender_opts* opts = ::line_sender_opts_new(
+        ::line_sender_protocol_udp, host, receiver.port());
     REQUIRE(opts != nullptr);
     on_scope_exit opts_free_guard{[&] { ::line_sender_opts_free(opts); }};
 
@@ -4014,8 +3998,8 @@ TEST_CASE("line_sender c api udp sparse columns across rows")
     }};
 
     const auto host = QDB_UTF8_LITERAL("127.0.0.1");
-    ::line_sender_opts* opts =
-        ::line_sender_opts_new(::line_sender_protocol_udp, host, receiver.port());
+    ::line_sender_opts* opts = ::line_sender_opts_new(
+        ::line_sender_protocol_udp, host, receiver.port());
     REQUIRE(opts != nullptr);
     on_scope_exit opts_free_guard{[&] { ::line_sender_opts_free(opts); }};
 
@@ -4035,21 +4019,27 @@ TEST_CASE("line_sender c api udp sparse columns across rows")
 
     // Row 1: has qty and active, no px.
     CHECK(::line_sender_buffer_table(buffer, table, &err));
-    CHECK(::line_sender_buffer_symbol(buffer, sym, QDB_UTF8_LITERAL("ETH"), &err));
+    CHECK(
+        ::line_sender_buffer_symbol(
+            buffer, sym, QDB_UTF8_LITERAL("ETH"), &err));
     CHECK(::line_sender_buffer_column_i64(buffer, qty, 10, &err));
     CHECK(::line_sender_buffer_column_bool(buffer, active, true, &err));
     CHECK(::line_sender_buffer_at_now(buffer, &err));
 
     // Row 2: has px and active, no qty.
     CHECK(::line_sender_buffer_table(buffer, table, &err));
-    CHECK(::line_sender_buffer_symbol(buffer, sym, QDB_UTF8_LITERAL("BTC"), &err));
+    CHECK(
+        ::line_sender_buffer_symbol(
+            buffer, sym, QDB_UTF8_LITERAL("BTC"), &err));
     CHECK(::line_sender_buffer_column_f64(buffer, px, 45000.0, &err));
     CHECK(::line_sender_buffer_column_bool(buffer, active, false, &err));
     CHECK(::line_sender_buffer_at_now(buffer, &err));
 
     // Row 3: only qty.
     CHECK(::line_sender_buffer_table(buffer, table, &err));
-    CHECK(::line_sender_buffer_symbol(buffer, sym, QDB_UTF8_LITERAL("SOL"), &err));
+    CHECK(
+        ::line_sender_buffer_symbol(
+            buffer, sym, QDB_UTF8_LITERAL("SOL"), &err));
     CHECK(::line_sender_buffer_column_i64(buffer, qty, 99, &err));
     CHECK(::line_sender_buffer_at_now(buffer, &err));
 
@@ -4071,8 +4061,7 @@ TEST_CASE("line_sender c api udp sparse columns across rows")
     qwp_expect_f64_nan(qwp_cell(decoded, 0, "px"));
     qwp_expect_symbol(qwp_cell(decoded, 1, "sym"), "BTC");
     qwp_expect_i64(
-        qwp_cell(decoded, 1, "qty"),
-        std::numeric_limits<int64_t>::min());
+        qwp_cell(decoded, 1, "qty"), std::numeric_limits<int64_t>::min());
     qwp_expect_bool(qwp_cell(decoded, 1, "active"), false);
     qwp_expect_f64(qwp_cell(decoded, 1, "px"), 45000.0);
     qwp_expect_symbol(qwp_cell(decoded, 2, "sym"), "SOL");
@@ -4088,8 +4077,7 @@ TEST_CASE("line_sender c++ udp rejects duplicate column name")
 
     buffer.table("t").column("x", int64_t{1});
     CHECK_THROWS_AS(
-        buffer.column("x", int64_t{2}),
-        questdb::ingress::line_sender_error);
+        buffer.column("x", int64_t{2}), questdb::ingress::line_sender_error);
 }
 
 TEST_CASE("line_sender c++ udp new_buffer inherits max_name_len")
@@ -4105,8 +4093,7 @@ TEST_CASE("line_sender c++ udp new_buffer inherits max_name_len")
     questdb::ingress::line_sender_buffer buffer = sender.new_buffer();
     // Name with 17 chars should exceed the inherited max_name_len of 16.
     CHECK_THROWS_AS(
-        buffer.table("abcdefghijklmnopq"),
-        questdb::ingress::line_sender_error);
+        buffer.table("abcdefghijklmnopq"), questdb::ingress::line_sender_error);
 
     // Name with exactly 16 chars should be fine.
     buffer.table("abcdefghijklmnop").column("x", int64_t{1}).at_now();
@@ -4122,7 +4109,9 @@ TEST_CASE("line_sender c qwp narrow integer + decimal columns happy path")
     line_sender_utf8 host = QDB_UTF8_LITERAL("127.0.0.1");
     line_sender_utf8 port_str{0, nullptr};
     auto port_s = std::to_string(receiver.port());
-    CHECK(::line_sender_utf8_init(&port_str, port_s.size(), port_s.c_str(), &err));
+    CHECK(
+        ::line_sender_utf8_init(
+            &port_str, port_s.size(), port_s.c_str(), &err));
     line_sender_opts* opts = ::line_sender_opts_new_service(
         line_sender_protocol_udp, host, port_str);
     line_sender* sender = ::line_sender_build(opts, &err);
@@ -4141,15 +4130,20 @@ TEST_CASE("line_sender c qwp narrow integer + decimal columns happy path")
 
     CHECK(::line_sender_buffer_table(buffer, tbl, &err));
     CHECK(::line_sender_buffer_column_i8(buffer, b_name, int8_t{-12}, &err));
-    CHECK(::line_sender_buffer_column_i16(buffer, s_name, int16_t{12345}, &err));
-    CHECK(::line_sender_buffer_column_i32(buffer, i_name, int32_t{-1234567}, &err));
+    CHECK(
+        ::line_sender_buffer_column_i16(buffer, s_name, int16_t{12345}, &err));
+    CHECK(
+        ::line_sender_buffer_column_i32(
+            buffer, i_name, int32_t{-1234567}, &err));
 
     const char* d64_str = "1.25";
-    CHECK(::line_sender_buffer_column_dec64_str(
-        buffer, d64_name, const_cast<char*>(d64_str), 4, &err));
+    CHECK(
+        ::line_sender_buffer_column_dec64_str(
+            buffer, d64_name, const_cast<char*>(d64_str), 4, &err));
     const char* d128_str = "170141183460469231731687303715884105727";
-    CHECK(::line_sender_buffer_column_dec128_str(
-        buffer, d128_name, const_cast<char*>(d128_str), 39, &err));
+    CHECK(
+        ::line_sender_buffer_column_dec128_str(
+            buffer, d128_name, const_cast<char*>(d128_str), 39, &err));
 
     CHECK(::line_sender_buffer_at_nanos(buffer, 1000, &err));
     CHECK(::line_sender_flush(sender, buffer, &err));
@@ -4167,7 +4161,9 @@ TEST_CASE("line_sender c narrow column methods reject ilp buffer")
     line_sender_utf8 host = QDB_UTF8_LITERAL("127.0.0.1");
     line_sender_utf8 port_str{0, nullptr};
     auto port_s = std::to_string(server.port());
-    CHECK(::line_sender_utf8_init(&port_str, port_s.size(), port_s.c_str(), &err));
+    CHECK(
+        ::line_sender_utf8_init(
+            &port_str, port_s.size(), port_s.c_str(), &err));
     line_sender_opts* opts = ::line_sender_opts_new_service(
         line_sender_protocol_tcp, host, port_str);
     line_sender* sender = ::line_sender_build(opts, &err);
@@ -4185,8 +4181,9 @@ TEST_CASE("line_sender c narrow column methods reject ilp buffer")
     auto expect_qwp_only = [&](bool ok, const char* method) {
         CHECK_FALSE(ok);
         REQUIRE(err != nullptr);
-        CHECK(::line_sender_error_get_code(err)
-              == line_sender_error_invalid_api_call);
+        CHECK(
+            ::line_sender_error_get_code(err) ==
+            line_sender_error_invalid_api_call);
         size_t msg_len = 0;
         const char* msg = ::line_sender_error_msg(err, &msg_len);
         const std::string msg_str(msg, msg_len);
@@ -4240,9 +4237,8 @@ TEST_CASE("line_sender c++ narrow column methods reject ilp buffer")
         catch (const questdb::ingress::line_sender_error& e)
         {
             CHECK(
-                e.code()
-                == questdb::ingress::line_sender_error_code::
-                       invalid_api_call);
+                e.code() ==
+                questdb::ingress::line_sender_error_code::invalid_api_call);
             CHECK(std::string{e.what()}.find(method) != std::string::npos);
         }
     };
@@ -4256,12 +4252,14 @@ TEST_CASE("line_sender c++ narrow column methods reject ilp buffer")
     using questdb::ingress::decimal::decimal_str_view;
     expects_qwp_only(
         [&]() {
-            buffer.column_dec64("v", decimal_str_view{std::string_view{"1.25"}});
+            buffer.column_dec64(
+                "v", decimal_str_view{std::string_view{"1.25"}});
         },
         "column_dec64");
     expects_qwp_only(
         [&]() {
-            buffer.column_dec128("v", decimal_str_view{std::string_view{"1.25"}});
+            buffer.column_dec128(
+                "v", decimal_str_view{std::string_view{"1.25"}});
         },
         "column_dec128");
 }
@@ -4281,7 +4279,8 @@ TEST_CASE("line_sender c++ udp narrow integer + decimal happy path")
         .column_i32("i", int32_t{-1234567})
         .column_dec64(
             "d64",
-            questdb::ingress::decimal::decimal_str_view{std::string_view{"1.25"}})
+            questdb::ingress::decimal::decimal_str_view{
+                std::string_view{"1.25"}})
         .column_dec128(
             "d128",
             questdb::ingress::decimal::decimal_str_view{
@@ -4300,7 +4299,9 @@ TEST_CASE("line_sender c qwp uuid+long256+ipv4 happy path")
     line_sender_utf8 host = QDB_UTF8_LITERAL("127.0.0.1");
     line_sender_utf8 port_str{0, nullptr};
     auto port_s = std::to_string(receiver.port());
-    CHECK(::line_sender_utf8_init(&port_str, port_s.size(), port_s.c_str(), &err));
+    CHECK(
+        ::line_sender_utf8_init(
+            &port_str, port_s.size(), port_s.c_str(), &err));
     line_sender_opts* opts = ::line_sender_opts_new_service(
         line_sender_protocol_udp, host, port_str);
     line_sender* sender = ::line_sender_build(opts, &err);
@@ -4310,20 +4311,26 @@ TEST_CASE("line_sender c qwp uuid+long256+ipv4 happy path")
     line_sender_buffer* buffer = line_sender_buffer_new_for_sender(sender);
     REQUIRE(buffer != nullptr);
 
-    line_sender_table_name tbl = QDB_TABLE_NAME_LITERAL("qwp_uuid_long256_ipv4");
+    line_sender_table_name tbl =
+        QDB_TABLE_NAME_LITERAL("qwp_uuid_long256_ipv4");
     line_sender_column_name uuid_name = QDB_COLUMN_NAME_LITERAL("id");
     line_sender_column_name long256_name = QDB_COLUMN_NAME_LITERAL("hash");
     line_sender_column_name ipv4_name = QDB_COLUMN_NAME_LITERAL("addr");
 
     CHECK(::line_sender_buffer_table(buffer, tbl, &err));
-    CHECK(::line_sender_buffer_column_uuid(
-        buffer, uuid_name, uint64_t{0x0123456789abcdefULL},
-        uint64_t{0xfedcba9876543210ULL}, &err));
+    CHECK(
+        ::line_sender_buffer_column_uuid(
+            buffer,
+            uuid_name,
+            uint64_t{0x0123456789abcdefULL},
+            uint64_t{0xfedcba9876543210ULL},
+            &err));
 
     uint8_t hash[32];
     for (int i = 0; i < 32; ++i)
         hash[i] = static_cast<uint8_t>(i);
-    CHECK(::line_sender_buffer_column_long256(buffer, long256_name, hash, &err));
+    CHECK(
+        ::line_sender_buffer_column_long256(buffer, long256_name, hash, &err));
 
     uint32_t addr = (192u << 24) | (168u << 16) | (1u << 8) | 1u;
     CHECK(::line_sender_buffer_column_ipv4(buffer, ipv4_name, addr, &err));
@@ -4432,8 +4439,8 @@ TEST_CASE("line_sender c++ float reject ilp buffer")
     catch (const questdb::ingress::line_sender_error& e)
     {
         CHECK(
-            e.code()
-            == questdb::ingress::line_sender_error_code::invalid_api_call);
+            e.code() ==
+            questdb::ingress::line_sender_error_code::invalid_api_call);
         CHECK(std::string{e.what()}.find("column_f32") != std::string::npos);
     }
 }
@@ -4475,9 +4482,10 @@ TEST_CASE("line_sender c++ geohash reject ilp buffer")
     catch (const questdb::ingress::line_sender_error& e)
     {
         CHECK(
-            e.code()
-            == questdb::ingress::line_sender_error_code::invalid_api_call);
-        CHECK(std::string{e.what()}.find("column_geohash") != std::string::npos);
+            e.code() ==
+            questdb::ingress::line_sender_error_code::invalid_api_call);
+        CHECK(
+            std::string{e.what()}.find("column_geohash") != std::string::npos);
     }
 }
 
@@ -4501,9 +4509,8 @@ TEST_CASE("line_sender c++ date+char+binary reject ilp buffer")
         catch (const questdb::ingress::line_sender_error& e)
         {
             CHECK(
-                e.code()
-                == questdb::ingress::line_sender_error_code::
-                       invalid_api_call);
+                e.code() ==
+                questdb::ingress::line_sender_error_code::invalid_api_call);
             CHECK(std::string{e.what()}.find(method) != std::string::npos);
         }
     };
@@ -4525,7 +4532,9 @@ TEST_CASE("line_sender c uuid+long256+ipv4 reject ilp buffer")
     line_sender_utf8 host = QDB_UTF8_LITERAL("127.0.0.1");
     line_sender_utf8 port_str{0, nullptr};
     auto port_s = std::to_string(server.port());
-    CHECK(::line_sender_utf8_init(&port_str, port_s.size(), port_s.c_str(), &err));
+    CHECK(
+        ::line_sender_utf8_init(
+            &port_str, port_s.size(), port_s.c_str(), &err));
     line_sender_opts* opts = ::line_sender_opts_new_service(
         line_sender_protocol_tcp, host, port_str);
     line_sender* sender = ::line_sender_build(opts, &err);
@@ -4542,8 +4551,9 @@ TEST_CASE("line_sender c uuid+long256+ipv4 reject ilp buffer")
     auto expect_qwp_only = [&](bool ok, const char* method) {
         CHECK_FALSE(ok);
         REQUIRE(err != nullptr);
-        CHECK(::line_sender_error_get_code(err)
-              == line_sender_error_invalid_api_call);
+        CHECK(
+            ::line_sender_error_get_code(err) ==
+            line_sender_error_invalid_api_call);
         size_t msg_len = 0;
         const char* msg = ::line_sender_error_msg(err, &msg_len);
         CHECK(std::string(msg, msg_len).find(method) != std::string::npos);

--- a/cpp_test/test_reader.cpp
+++ b/cpp_test/test_reader.cpp
@@ -55,14 +55,14 @@
 #include <thread>
 
 #ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#pragma comment(lib, "Ws2_32.lib")
+#    include <winsock2.h>
+#    include <ws2tcpip.h>
+#    pragma comment(lib, "Ws2_32.lib")
 #else
-#include <netdb.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <unistd.h>
+#    include <netdb.h>
+#    include <sys/socket.h>
+#    include <sys/types.h>
+#    include <unistd.h>
 #endif
 
 using namespace questdb::ingress::literals;
@@ -73,15 +73,15 @@ namespace
 // MSVC flags `std::getenv` as deprecated (C4996) in favour of `_dupenv_s`,
 // but the function is standard C/C++ and the test's usage is single-threaded.
 #ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4996)
+#    pragma warning(push)
+#    pragma warning(disable : 4996)
 #endif
 inline const char* env_or_null(const char* name)
 {
     return std::getenv(name);
 }
 #ifdef _MSC_VER
-#pragma warning(pop)
+#    pragma warning(pop)
 #endif
 
 std::string broker_host()
@@ -127,14 +127,20 @@ bool broker_reachable()
     bool ok = false;
     for (addrinfo* p = res; p != nullptr; p = p->ai_next)
     {
-        int fd = static_cast<int>(::socket(p->ai_family, p->ai_socktype, p->ai_protocol));
-        if (fd < 0) continue;
+        int fd = static_cast<int>(
+            ::socket(p->ai_family, p->ai_socktype, p->ai_protocol));
+        if (fd < 0)
+            continue;
         // Best-effort short timeout. On non-blocking it'd be nicer; but
         // a 500ms blocking connect attempt is fine for a one-time gate.
 #ifdef _WIN32
         DWORD timeout_ms = 500;
-        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO,
-                   reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms));
+        setsockopt(
+            fd,
+            SOL_SOCKET,
+            SO_SNDTIMEO,
+            reinterpret_cast<const char*>(&timeout_ms),
+            sizeof(timeout_ms));
 #else
         timeval tv{};
         tv.tv_sec = 0;
@@ -150,7 +156,8 @@ bool broker_reachable()
 #else
         ::close(fd);
 #endif
-        if (ok) break;
+        if (ok)
+            break;
     }
     freeaddrinfo(res);
 #ifdef _WIN32
@@ -240,8 +247,7 @@ TEST_CASE("multi-row literal: long_sequence(5)")
     REQUIRE_LIVE_BROKER();
 
     auto reader = make_reader();
-    auto cur = reader.execute(
-        "select x as n from long_sequence(5)"_utf8);
+    auto cur = reader.execute("select x as n from long_sequence(5)"_utf8);
 
     size_t total_rows = 0;
     int64_t expected = 1;
@@ -302,13 +308,13 @@ TEST_CASE("bind: i32 + varchar")
     // Cast the result to LONG so the column kind is server-version-
     // independent (otherwise the server may surface int*long as INT or
     // LONG depending on its widening rules).
-    auto cur =
-        reader
-            .prepare("select ($1::int * x)::long as scaled, "
-                     "$2 as label from long_sequence(3)"_utf8)
-            .bind_i32(7)
-            .bind_varchar("widgets"_utf8)
-            .execute();
+    auto cur = reader
+                   .prepare(
+                       "select ($1::int * x)::long as scaled, "
+                       "$2 as label from long_sequence(3)"_utf8)
+                   .bind_i32(7)
+                   .bind_varchar("widgets"_utf8)
+                   .execute();
 
     auto batch_opt = cur.next_batch();
     REQUIRE(batch_opt);
@@ -368,8 +374,8 @@ TEST_CASE("column_validity: bitmap matches null pattern, empty when no nulls")
             "v "
             "from long_sequence(5)"_utf8);
         auto batch_opt = cur.next_batch();
-    REQUIRE(batch_opt);
-    auto& batch = *batch_opt;
+        REQUIRE(batch_opt);
+        auto& batch = *batch_opt;
         REQUIRE(batch.row_count() == 5);
         REQUIRE(batch.column_count() == 1);
         REQUIRE(batch.column_kind(0) == qwp_reader_column_kind_long);
@@ -397,8 +403,7 @@ TEST_CASE("column_validity: bitmap matches null pattern, empty when no nulls")
     }
 
     // No-nulls case: every row is non-null, so the validity pointer is null.
-    auto cur2 =
-        reader.execute("select x from long_sequence(3)"_utf8);
+    auto cur2 = reader.execute("select x from long_sequence(3)"_utf8);
     auto bo2 = cur2.next_batch();
     REQUIRE(bo2);
     REQUIRE(bo2->row_count() == 3);
@@ -436,10 +441,7 @@ TEST_CASE("bind: decimal128 sign-extension round-trip")
     // silently, which would mask a real bind regression).
     auto reader = make_reader();
     auto cur = reader.prepare("select $1::decimal(38, 0) as v"_utf8)
-                   .bind_decimal128(
-                       static_cast<uint64_t>(-1LL),
-                       -1,
-                       0)
+                   .bind_decimal128(static_cast<uint64_t>(-1LL), -1, 0)
                    .execute();
     auto batch_opt = cur.next_batch();
     REQUIRE(batch_opt);
@@ -489,7 +491,9 @@ TEST_CASE("cursor reusable after explicit close")
     auto reader = make_reader();
     {
         auto cur = reader.execute("select 1 as v"_utf8);
-        while (cur.next_batch()) {}
+        while (cur.next_batch())
+        {
+        }
     } // cur dtor closes
     // The reader's active flag should be cleared; a second cursor opens
     // without throwing.
@@ -562,7 +566,9 @@ TEST_CASE("terminal_kind reaches end after stream completes")
 
     auto reader = make_reader();
     auto cur = reader.execute("select x from long_sequence(2)"_utf8);
-    while (cur.next_batch()) {}
+    while (cur.next_batch())
+    {
+    }
     // SELECT streams terminate with `end` carrying total_rows; `exec_done`
     // is the terminator for non-result statements (DDL/DML), so a SELECT
     // here must always land on `end`.
@@ -611,8 +617,9 @@ TEST_CASE("invalid SQL surfaces a server error")
     // (e.g.) `socket_error`, `cancelled`, or any client-side code
     // would fail this check loudly instead of being masked by an
     // any-message-is-fine assertion.
-    CHECK((code == questdb_error_server_parse_error
-        || code == questdb_error_server_internal_error));
+    CHECK(
+        (code == questdb_error_server_parse_error ||
+         code == questdb_error_server_internal_error));
 }
 
 TEST_CASE("get_i64 type-mismatch on string column is reported, not a crash")
@@ -684,8 +691,7 @@ TEST_CASE("ingress sender → egress reader round-trip for primitives")
         {
             std::ostringstream sql_s;
             sql_s << "select count(*) as c from \"" << table << "\"";
-            auto cur = reader.execute(
-                questdb::ingress::utf8_view{sql_s.str()});
+            auto cur = reader.execute(questdb::ingress::utf8_view{sql_s.str()});
             int64_t n = -1;
             if (auto bo = cur.next_batch())
             {
@@ -696,19 +702,23 @@ TEST_CASE("ingress sender → egress reader round-trip for primitives")
                     if (k == qwp_reader_column_kind_long)
                     {
                         auto v = batch.column(0).get<int64_t>(0);
-                        if (v) n = *v;
+                        if (v)
+                            n = *v;
                     }
                     else if (k == qwp_reader_column_kind_int)
                     {
                         auto v = batch.column(0).get<int32_t>(0);
-                        if (v) n = *v;
+                        if (v)
+                            n = *v;
                     }
                 }
             }
             // Drain to terminal so the cursor isn't dropped mid-stream —
             // otherwise `~cursor()` sends CANCEL and tears down the WS
             // transport, and the next iteration writes into a dead pipe.
-            while (cur.next_batch()) {}
+            while (cur.next_batch())
+            {
+            }
             if (n >= 3)
             {
                 ready = true;

--- a/cpp_test/test_reader_mock.cpp
+++ b/cpp_test/test_reader_mock.cpp
@@ -129,14 +129,16 @@ TEST_CASE("mock: handshake + immediate ResultEnd drives cursor terminus")
 TEST_CASE("mock: column getter — i32 (Int) round-trip")
 {
     qm::ColumnSpec c{
-        "v", qm::COL_INT,
+        "v",
+        qm::COL_INT,
         qm::fixed_column_bytes(3, pack_le<int32_t>({100, 200, 300}))};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 3, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 3, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -165,35 +167,39 @@ TEST_CASE("mock: column getter — i32 (Int) round-trip")
 TEST_CASE("mock: column getter — i64 / f64 / bool / i8 / i16 / f32")
 {
     qm::ColumnSpec c_i64{
-        "l", qm::COL_LONG,
-        qm::fixed_column_bytes(2, pack_le<int64_t>({-1, 9223372036854775807LL}))};
+        "l",
+        qm::COL_LONG,
+        qm::fixed_column_bytes(
+            2, pack_le<int64_t>({-1, 9223372036854775807LL}))};
     qm::ColumnSpec c_f64{
-        "d", qm::COL_DOUBLE,
+        "d",
+        qm::COL_DOUBLE,
         qm::fixed_column_bytes(2, pack_le<double>({1.5, -3.14}))};
     // BOOLEAN: validity then bit-packed values (1 row -> 1 bit).
     std::vector<uint8_t> bool_body;
-    bool_body.push_back(0x00);              // no validity
-    bool_body.push_back(0b00000010);        // bit0=0 (false), bit1=1 (true)
+    bool_body.push_back(0x00);       // no validity
+    bool_body.push_back(0b00000010); // bit0=0 (false), bit1=1 (true)
     qm::ColumnSpec c_bool{"b", qm::COL_BOOLEAN, std::move(bool_body)};
     qm::ColumnSpec c_i8{
-        "i8", qm::COL_BYTE,
+        "i8",
+        qm::COL_BYTE,
         qm::fixed_column_bytes(2, pack_le<int8_t>({-7, 42}))};
     qm::ColumnSpec c_i16{
-        "i16", qm::COL_SHORT,
+        "i16",
+        qm::COL_SHORT,
         qm::fixed_column_bytes(2, pack_le<int16_t>({-1234, 31000}))};
     qm::ColumnSpec c_f32{
-        "f32", qm::COL_FLOAT,
+        "f32",
+        qm::COL_FLOAT,
         qm::fixed_column_bytes(2, pack_le<float>({1.25f, -0.5f}))};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[=](int64_t rid)
-                            {
-                                return qm::result_batch_frame(
-                                    rid, 0, 2,
-                                    {c_i64, c_f64, c_bool, c_i8, c_i16, c_f32});
-                            }},
+        qm::ActionSendBuilt{[=](int64_t rid) {
+            return qm::result_batch_frame(
+                rid, 0, 2, {c_i64, c_f64, c_bool, c_i8, c_i16, c_f32});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -205,7 +211,8 @@ TEST_CASE("mock: column getter — i64 / f64 / bool / i8 / i16 / f32")
     REQUIRE(batch.row_count() == 2);
 
     REQUIRE(batch.column(0).get<int64_t>(0).value_or(0) == -1);
-    REQUIRE(batch.column(0).get<int64_t>(1).value_or(0) == 9223372036854775807LL);
+    REQUIRE(
+        batch.column(0).get<int64_t>(1).value_or(0) == 9223372036854775807LL);
     CHECK(batch.column(1).get<double>(0).value_or(0) == doctest::Approx(1.5));
     CHECK(batch.column(1).get<double>(1).value_or(0) == doctest::Approx(-3.14));
     CHECK(batch.column(2).get<bool>(0).value_or(true) == false);
@@ -214,20 +221,24 @@ TEST_CASE("mock: column getter — i64 / f64 / bool / i8 / i16 / f32")
     CHECK(batch.column(3).get<int8_t>(1).value_or(0) == 42);
     CHECK(batch.column(4).get<int16_t>(0).value_or(0) == -1234);
     CHECK(batch.column(4).get<int16_t>(1).value_or(0) == 31000);
-    CHECK(batch.column(5).get<float>(0).value_or(0.0f) == doctest::Approx(1.25f));
-    CHECK(batch.column(5).get<float>(1).value_or(0.0f) == doctest::Approx(-0.5f));
+    CHECK(
+        batch.column(5).get<float>(0).value_or(0.0f) == doctest::Approx(1.25f));
+    CHECK(
+        batch.column(5).get<float>(1).value_or(0.0f) == doctest::Approx(-0.5f));
 }
 
 TEST_CASE("mock: column getter — varchar")
 {
-    auto body = qm::varlen_column_bytes({{'h', 'i'}, {'h', 'e', 'l', 'l', 'o'}});
+    auto body =
+        qm::varlen_column_bytes({{'h', 'i'}, {'h', 'e', 'l', 'l', 'o'}});
     qm::ColumnSpec c{"s", qm::COL_VARCHAR, std::move(body)};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 2, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 2, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -250,14 +261,14 @@ TEST_CASE("mock: column getter — uuid (16 raw bytes, big-endian on wire)")
     std::vector<uint8_t> uuid_bytes(16);
     for (int i = 0; i < 16; ++i)
         uuid_bytes[i] = uint8_t(0xA0 + i);
-    qm::ColumnSpec c{"u", qm::COL_UUID,
-                     qm::fixed_column_bytes(1, uuid_bytes)};
+    qm::ColumnSpec c{"u", qm::COL_UUID, qm::fixed_column_bytes(1, uuid_bytes)};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -280,8 +291,9 @@ TEST_CASE("mock: column getter — decimal64 with non-zero scale")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 2, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 2, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -311,8 +323,9 @@ TEST_CASE("mock: column getter — decimal128 with negative i128 mantissa")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -345,8 +358,9 @@ TEST_CASE("mock: column validity bitmap matches null pattern from server")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 5, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 5, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -361,7 +375,8 @@ TEST_CASE("mock: column validity bitmap matches null pattern from server")
     const uint8_t* vbits = col.validity();
     REQUIRE(vbits != nullptr);
     REQUIRE(col.validity_bytes() >= 1);
-    // Bit pattern: rows 1 and 3 set, others clear → low 5 bits = 0b01010 = 0x0A.
+    // Bit pattern: rows 1 and 3 set, others clear → low 5 bits = 0b01010 =
+    // 0x0A.
     CHECK((vbits[0] & 0x1F) == 0x0A);
 
     CHECK(col.get<int64_t>(0).value_or(-1) == 10);
@@ -380,12 +395,10 @@ TEST_CASE("mock: QueryError(parse) surfaces as ServerParseError")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{
-            [](int64_t rid)
-            {
-                return qm::query_error_frame(
-                    rid, qm::STATUS_PARSE_ERROR, "bad sql at line 1");
-            }},
+        qm::ActionSendBuilt{[](int64_t rid) {
+            return qm::query_error_frame(
+                rid, qm::STATUS_PARSE_ERROR, "bad sql at line 1");
+        }},
     };
     qm::MockServer srv({s});
     auto reader = connect_to(srv);
@@ -394,7 +407,9 @@ TEST_CASE("mock: QueryError(parse) surfaces as ServerParseError")
     try
     {
         auto cur = reader.execute("nonsense"_utf8);
-        while (cur.next_batch()) {}
+        while (cur.next_batch())
+        {
+        }
     }
     catch (const questdb::error& e)
     {
@@ -410,12 +425,10 @@ TEST_CASE("mock: QueryError(internal) surfaces as ServerInternalError")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{
-            [](int64_t rid)
-            {
-                return qm::query_error_frame(
-                    rid, qm::STATUS_INTERNAL_ERROR, "boom");
-            }},
+        qm::ActionSendBuilt{[](int64_t rid) {
+            return qm::query_error_frame(
+                rid, qm::STATUS_INTERNAL_ERROR, "boom");
+        }},
     };
     qm::MockServer srv({s});
     auto reader = connect_to(srv);
@@ -424,7 +437,9 @@ TEST_CASE("mock: QueryError(internal) surfaces as ServerInternalError")
     try
     {
         auto cur = reader.execute("x"_utf8);
-        while (cur.next_batch()) {}
+        while (cur.next_batch())
+        {
+        }
     }
     catch (const questdb::error& e)
     {
@@ -439,12 +454,10 @@ TEST_CASE("mock: QueryError(security) surfaces as ServerSecurityError")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{
-            [](int64_t rid)
-            {
-                return qm::query_error_frame(
-                    rid, qm::STATUS_SECURITY_ERROR, "forbidden");
-            }},
+        qm::ActionSendBuilt{[](int64_t rid) {
+            return qm::query_error_frame(
+                rid, qm::STATUS_SECURITY_ERROR, "forbidden");
+        }},
     };
     qm::MockServer srv({s});
     auto reader = connect_to(srv);
@@ -452,7 +465,9 @@ TEST_CASE("mock: QueryError(security) surfaces as ServerSecurityError")
     try
     {
         auto cur = reader.execute("x"_utf8);
-        while (cur.next_batch()) {}
+        while (cur.next_batch())
+        {
+        }
     }
     catch (const questdb::error& e)
     {
@@ -494,7 +509,9 @@ TEST_CASE("mock: captured QueryRequest carries SQL and request_id")
     qm::MockServer srv({s});
     auto reader = connect_to(srv);
     auto cur = reader.execute("select 42"_utf8);
-    while (cur.next_batch()) {}
+    while (cur.next_batch())
+    {
+    }
 
     auto reqs = srv.captured_requests();
     REQUIRE(reqs.size() == 1);
@@ -526,21 +543,25 @@ TEST_CASE("mock: bind_i32 + bind_varchar appears verbatim in captured request")
                    .bind_i32(7)
                    .bind_varchar("widgets"_utf8)
                    .execute();
-    while (cur.next_batch()) {}
+    while (cur.next_batch())
+    {
+    }
 
     auto reqs = srv.captured_requests();
     REQUIRE(reqs.size() == 1);
     const auto& req = reqs[0];
-    // Layout: 0x10 | i64 rid | varint(1) sql_len | 'X' | varint(0) credit | varint(2) bind_count
+    // Layout: 0x10 | i64 rid | varint(1) sql_len | 'X' | varint(0) credit |
+    // varint(2) bind_count
     //         | bind1: 0x04 (Int) 0x00 (not null) i32 LE 7
-    //         | bind2: 0x0F (Varchar) 0x00 (not null) [u32_le 0][u32_le 7] "widgets"
+    //         | bind2: 0x0F (Varchar) 0x00 (not null) [u32_le 0][u32_le 7]
+    //         "widgets"
     REQUIRE(req.size() >= 1 + 8 + 1 + 1 + 1 + 1);
     CHECK(req[0] == 0x10);
     size_t p = 9;
     CHECK(req[p++] == 1); // sql_len varint
     CHECK(req[p++] == 'X');
-    CHECK(req[p++] == 0); // initial_credit varint
-    CHECK(req[p++] == 2); // bind_count varint
+    CHECK(req[p++] == 0);    // initial_credit varint
+    CHECK(req[p++] == 2);    // bind_count varint
     CHECK(req[p++] == 0x04); // Int
     CHECK(req[p++] == 0x00); // not null
     int32_t v_i32 = int32_t(req[p]) | (int32_t(req[p + 1]) << 8) |
@@ -571,13 +592,14 @@ TEST_CASE("mock: bind_i32 + bind_varchar appears verbatim in captured request")
 
 TEST_CASE("mock: bytes_received increases after a batch is consumed")
 {
-    qm::ColumnSpec c{"v", qm::COL_INT,
-                     qm::fixed_column_bytes(1, pack_le<int32_t>({42}))};
+    qm::ColumnSpec c{
+        "v", qm::COL_INT, qm::fixed_column_bytes(1, pack_le<int32_t>({42}))};
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -585,7 +607,9 @@ TEST_CASE("mock: bytes_received increases after a batch is consumed")
     const uint64_t before_query = reader.bytes_received();
 
     auto cur = reader.execute("select v"_utf8);
-    while (cur.next_batch()) {}
+    while (cur.next_batch())
+    {
+    }
     const uint64_t after = reader.bytes_received();
 
     CHECK(after > before_query);
@@ -603,8 +627,9 @@ void run_query_error_test(uint8_t status, ::questdb_error_code expected)
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[status](int64_t rid)
-                            { return qm::query_error_frame(rid, status, "x"); }},
+        qm::ActionSendBuilt{[status](int64_t rid) {
+            return qm::query_error_frame(rid, status, "x");
+        }},
     };
     qm::MockServer srv({s});
     auto reader = connect_to(srv);
@@ -612,7 +637,9 @@ void run_query_error_test(uint8_t status, ::questdb_error_code expected)
     try
     {
         auto cur = reader.execute("x"_utf8);
-        while (cur.next_batch()) {}
+        while (cur.next_batch())
+        {
+        }
     }
     catch (const questdb::error& e)
     {
@@ -626,22 +653,18 @@ void run_query_error_test(uint8_t status, ::questdb_error_code expected)
 TEST_CASE("mock: QueryError(schema_mismatch) surfaces as ServerSchemaMismatch")
 {
     run_query_error_test(
-        qm::STATUS_SCHEMA_MISMATCH,
-        questdb_error_server_schema_mismatch);
+        qm::STATUS_SCHEMA_MISMATCH, questdb_error_server_schema_mismatch);
 }
 
 TEST_CASE("mock: QueryError(limit_exceeded) surfaces as ServerLimitExceeded")
 {
     run_query_error_test(
-        qm::STATUS_LIMIT_EXCEEDED,
-        questdb_error_server_limit_exceeded);
+        qm::STATUS_LIMIT_EXCEEDED, questdb_error_server_limit_exceeded);
 }
 
 TEST_CASE("mock: QueryError(cancelled) surfaces as Cancelled")
 {
-    run_query_error_test(
-        qm::STATUS_CANCELLED,
-        questdb_error_cancelled);
+    run_query_error_test(qm::STATUS_CANCELLED, questdb_error_cancelled);
 }
 
 // ---------------------------------------------------------------------------
@@ -658,8 +681,9 @@ TEST_CASE("mock: cursor::cancel writes MSG_CANCEL and surfaces Cancelled")
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
         qm::ActionAwaitClientFrame{qm::MSG_CANCEL},
-        qm::ActionSendBuilt{[](int64_t rid)
-                            { return qm::query_error_frame(rid, qm::STATUS_CANCELLED, "user"); }},
+        qm::ActionSendBuilt{[](int64_t rid) {
+            return qm::query_error_frame(rid, qm::STATUS_CANCELLED, "user");
+        }},
     };
     qm::MockServer srv({s});
     auto reader = connect_to(srv);
@@ -702,7 +726,8 @@ TEST_CASE("mock: cursor::cancel writes MSG_CANCEL and surfaces Cancelled")
 // was sent, since the WS close already breaks the next query).
 // ---------------------------------------------------------------------------
 
-TEST_CASE("mock: dropping cursor without draining writes MSG_CANCEL on the wire")
+TEST_CASE(
+    "mock: dropping cursor without draining writes MSG_CANCEL on the wire")
 {
     qm::ColumnSpec c{
         "v", qm::COL_INT, qm::fixed_column_bytes(1, pack_le<int32_t>({42}))};
@@ -741,8 +766,7 @@ TEST_CASE("mock: dropping cursor without draining writes MSG_CANCEL on the wire"
     // synchronously when the destructor returns; the mock's
     // `read_until_kind` reads it within microseconds.
     bool saw_cancel = false;
-    auto deadline =
-        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
     while (std::chrono::steady_clock::now() < deadline)
     {
         auto reqs = srv.captured_requests();
@@ -767,13 +791,14 @@ TEST_CASE("mock: dropping cursor without draining writes MSG_CANCEL on the wire"
 
 TEST_CASE("mock: cursor::add_credit writes MSG_CREDIT")
 {
-    qm::ColumnSpec c{"v", qm::COL_INT,
-                     qm::fixed_column_bytes(1, pack_le<int32_t>({1}))};
+    qm::ColumnSpec c{
+        "v", qm::COL_INT, qm::fixed_column_bytes(1, pack_le<int32_t>({1}))};
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c});
+        }},
         qm::ActionAwaitClientFrame{qm::MSG_CREDIT},
         qm::ActionSendResultEnd{},
     };
@@ -782,7 +807,9 @@ TEST_CASE("mock: cursor::add_credit writes MSG_CREDIT")
     auto cur = reader.prepare("select v"_utf8).initial_credit(64).execute();
     REQUIRE(cur.next_batch());
     cur.add_credit(1024);
-    while (cur.next_batch()) {}
+    while (cur.next_batch())
+    {
+    }
 
     auto reqs = srv.captured_requests();
     bool saw_credit = false;
@@ -869,7 +896,8 @@ TEST_CASE("mock: add_credit failover on write failure replays credit on B")
     qm::MockServer srv_a({s_a});
     qm::MockServer srv_b({s_b});
 
-    const std::string conf = "ws::addr=" + srv_a.addr() + "," + srv_b.addr() +
+    const std::string conf =
+        "ws::addr=" + srv_a.addr() + "," + srv_b.addr() +
         ";failover_backoff_initial_ms=1;failover_backoff_max_ms=10";
     questdb::egress::reader reader{questdb::ingress::utf8_view{conf}};
 
@@ -982,26 +1010,26 @@ TEST_CASE("mock: failover trampoline fires once with populated event fields")
     };
     auto cap = std::make_shared<Capture>();
 
-    auto cur = reader.prepare("select 1"_utf8)
-                   .on_failover_reset(
-                       [cap](const questdb::egress::failover_reset_event_view& ev)
-                       {
-                           cap->count.fetch_add(1);
-                           cap->failed_host = std::string(ev.failed_host());
-                           cap->failed_port = ev.failed_port();
-                           cap->new_host = std::string(ev.new_host());
-                           cap->new_port = ev.new_port();
-                           cap->attempts = ev.attempts();
-                           cap->trigger_code = ev.trigger_code();
-                           auto si = ev.server_info();
-                           cap->server_info_snapshot = si.snapshot();
-                           if (static_cast<bool>(si))
-                           {
-                               cap->server_info_present = true;
-                               cap->new_node_id = std::string(si.node_id());
-                           }
-                       })
-                   .execute();
+    auto cur =
+        reader.prepare("select 1"_utf8)
+            .on_failover_reset(
+                [cap](const questdb::egress::failover_reset_event_view& ev) {
+                    cap->count.fetch_add(1);
+                    cap->failed_host = std::string(ev.failed_host());
+                    cap->failed_port = ev.failed_port();
+                    cap->new_host = std::string(ev.new_host());
+                    cap->new_port = ev.new_port();
+                    cap->attempts = ev.attempts();
+                    cap->trigger_code = ev.trigger_code();
+                    auto si = ev.server_info();
+                    cap->server_info_snapshot = si.snapshot();
+                    if (static_cast<bool>(si))
+                    {
+                        cap->server_info_present = true;
+                        cap->new_node_id = std::string(si.node_id());
+                    }
+                })
+            .execute();
     // First next_batch sees A close, fails over to B, gets RESULT_END.
     CHECK_FALSE(cur.next_batch());
     CHECK(cur.failover_resets() == 1);
@@ -1015,8 +1043,9 @@ TEST_CASE("mock: failover trampoline fires once with populated event fields")
     CHECK(cap->new_host == "127.0.0.1");
     CHECK(cap->attempts >= 1);
     // Trigger is a transport-class error.
-    CHECK((cap->trigger_code == questdb_error_socket_error ||
-           cap->trigger_code == questdb_error_protocol_error));
+    CHECK(
+        (cap->trigger_code == questdb_error_socket_error ||
+         cap->trigger_code == questdb_error_protocol_error));
     REQUIRE(cap->server_info_present);
     CHECK(cap->new_node_id == "b");
     REQUIRE(cap->server_info_snapshot.has_value());
@@ -1040,12 +1069,16 @@ TEST_CASE("mock: failover callback NOT invoked on the happy path")
     auto reader = connect_to(srv);
 
     std::atomic<int> count{0};
-    auto cur = reader.prepare("select 1"_utf8)
-                   .on_failover_reset(
-                       [&count](const questdb::egress::failover_reset_event_view&)
-                       { count.fetch_add(1); })
-                   .execute();
-    while (cur.next_batch()) {}
+    auto cur =
+        reader.prepare("select 1"_utf8)
+            .on_failover_reset(
+                [&count](const questdb::egress::failover_reset_event_view&) {
+                    count.fetch_add(1);
+                })
+            .execute();
+    while (cur.next_batch())
+    {
+    }
     CHECK(count.load() == 0);
     CHECK(cur.failover_resets() == 0);
 }
@@ -1065,8 +1098,9 @@ TEST_CASE("mock: column::shape + elements<double> round-trip")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 2, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 2, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1113,8 +1147,9 @@ TEST_CASE("mock: LONG_ARRAY column rejected (not supported in this revision)")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1123,8 +1158,7 @@ TEST_CASE("mock: LONG_ARRAY column rejected (not supported in this revision)")
     auto batch_opt = cur.next_batch();
     REQUIRE(batch_opt);
     auto& batch = *batch_opt;
-    CHECK_THROWS_AS(
-        (void)batch.column(0), questdb::error);
+    CHECK_THROWS_AS((void)batch.column(0), questdb::error);
 }
 
 TEST_CASE("mock: non-null empty-data array row exposes data_offsets symmetry")
@@ -1133,15 +1167,16 @@ TEST_CASE("mock: non-null empty-data array row exposes data_offsets symmetry")
     // is empty (data_offsets[r+1] - data_offsets[r] == 0). Pin the
     // contract: the row is reported non-null but yields zero elements.
     using Row = qm::ArrayRow;
-    Row r0{{2, 0, 3}, {}};                  // non-null, zero bytes of data
+    Row r0{{2, 0, 3}, {}}; // non-null, zero bytes of data
     auto body = qm::array_column_bytes({r0});
     qm::ColumnSpec c{"a", qm::COL_DOUBLE_ARRAY, std::move(body)};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1151,7 +1186,7 @@ TEST_CASE("mock: non-null empty-data array row exposes data_offsets symmetry")
     REQUIRE(batch_opt);
     auto& batch = *batch_opt;
     auto col = batch.column(0);
-    CHECK_FALSE(col.is_null(0));            // non-null
+    CHECK_FALSE(col.is_null(0)); // non-null
     size_t rank = 0;
     const uint32_t* shape = col.shape(0, &rank);
     REQUIRE(rank == 3);
@@ -1173,8 +1208,9 @@ TEST_CASE("mock: NULL array row surfaces via is_null")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 2, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 2, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1200,13 +1236,16 @@ TEST_CASE("mock: NULL array row surfaces via is_null")
 
 TEST_CASE("mock: get_char round-trip (u16 codepoint)")
 {
-    qm::ColumnSpec c{"c", qm::COL_CHAR,
-                     qm::fixed_column_bytes(2, pack_le<uint16_t>({u'A', u'\u00E9'}))};
+    qm::ColumnSpec c{
+        "c",
+        qm::COL_CHAR,
+        qm::fixed_column_bytes(2, pack_le<uint16_t>({u'A', u'\u00E9'}))};
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 2, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 2, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1226,14 +1265,15 @@ TEST_CASE("mock: get_char round-trip (u16 codepoint)")
 TEST_CASE("mock: get_long256 round-trip (32 raw bytes)")
 {
     std::vector<uint8_t> bytes(32);
-    for (int i = 0; i < 32; ++i) bytes[i] = uint8_t(i + 1);
-    qm::ColumnSpec c{"l", qm::COL_LONG256,
-                     qm::fixed_column_bytes(1, bytes)};
+    for (int i = 0; i < 32; ++i)
+        bytes[i] = uint8_t(i + 1);
+    qm::ColumnSpec c{"l", qm::COL_LONG256, qm::fixed_column_bytes(1, bytes)};
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1250,14 +1290,14 @@ TEST_CASE("mock: get_long256 round-trip (32 raw bytes)")
 
 TEST_CASE("mock: get_binary round-trip (zero-copy bytes)")
 {
-    auto body = qm::varlen_column_bytes(
-        {{0x00, 0x01, 0x02}, {0xFF, 0xEE}});
+    auto body = qm::varlen_column_bytes({{0x00, 0x01, 0x02}, {0xFF, 0xEE}});
     qm::ColumnSpec c{"b", qm::COL_BINARY, std::move(body)};
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 2, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 2, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1282,14 +1322,17 @@ TEST_CASE("mock: get_binary round-trip (zero-copy bytes)")
 TEST_CASE("mock: get_decimal256 round-trip (32-byte mantissa + scale)")
 {
     std::array<uint8_t, 32> raw{};
-    raw[0] = 0xFE; raw[1] = 0xCA; raw[31] = 0x80;  // arbitrary pattern
+    raw[0] = 0xFE;
+    raw[1] = 0xCA;
+    raw[31] = 0x80; // arbitrary pattern
     auto body = qm::decimal256_column_bytes({raw}, /*scale=*/4);
     qm::ColumnSpec c{"d", qm::COL_DECIMAL256, std::move(body)};
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1309,14 +1352,15 @@ TEST_CASE("mock: get_geohash round-trip (precision_bits + bits)")
 {
     // 8-bit precision: one byte per row.
     std::vector<uint8_t> packed = {0xAB, 0xCD};
-    auto body = qm::geohash_column_bytes(
-        {false, false}, packed, /*precision_bits=*/8);
+    auto body =
+        qm::geohash_column_bytes({false, false}, packed, /*precision_bits=*/8);
     qm::ColumnSpec c{"g", qm::COL_GEOHASH, std::move(body)};
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 2, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 2, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1344,13 +1388,14 @@ TEST_CASE("mock: get_geohash round-trip (precision_bits + bits)")
 
 TEST_CASE("mock: stats and cursor introspection getters return live values")
 {
-    qm::ColumnSpec c{"v", qm::COL_INT,
-                     qm::fixed_column_bytes(1, pack_le<int32_t>({99}))};
+    qm::ColumnSpec c{
+        "v", qm::COL_INT, qm::fixed_column_bytes(1, pack_le<int32_t>({99}))};
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, /*batch_seq=*/0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, /*batch_seq=*/0, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1367,7 +1412,8 @@ TEST_CASE("mock: stats and cursor introspection getters return live values")
     // host but never negative; saturating semantics).
     const uint64_t r0 = reader.read_ns();
     const uint64_t d0 = reader.decode_ns();
-    (void)r0; (void)d0;
+    (void)r0;
+    (void)d0;
 
     auto cur = reader.prepare("select v"_utf8).initial_credit(1024).execute();
     auto batch_opt = cur.next_batch();
@@ -1396,7 +1442,9 @@ TEST_CASE("mock: stats and cursor introspection getters return live values")
     CHECK(cur.credit_granted_total() == r_credit_before);
 
     // Drain remaining batches.
-    while (cur.next_batch()) {}
+    while (cur.next_batch())
+    {
+    }
 
     // After at least one read, read_ns / decode_ns should have advanced
     // (or stayed equal on extremely fast hosts — saturating arithmetic
@@ -1436,7 +1484,9 @@ void run_bind_round_trip(Fn&& bind_apply)
     auto q = reader.prepare("X"_utf8);
     bind_apply(q);
     auto cur = q.execute();
-    while (cur.next_batch()) {}
+    while (cur.next_batch())
+    {
+    }
     auto reqs = srv.captured_requests();
     REQUIRE(reqs.size() == 1);
     CHECK(reqs[0][0] == qm::MSG_QUERY_REQUEST);
@@ -1479,7 +1529,8 @@ void run_bind_rejection(Fn&& bind_apply)
 // a clean error rather than crash. Exercises ActionReject401.
 // ---------------------------------------------------------------------------
 
-TEST_CASE("mock: WebSocket upgrade rejected with 401 surfaces a connect-time error")
+TEST_CASE(
+    "mock: WebSocket upgrade rejected with 401 surfaces a connect-time error")
 {
     qm::Script s = {qm::ActionReject401{}};
     qm::MockServer srv({s});
@@ -1496,8 +1547,9 @@ TEST_CASE("mock: WebSocket upgrade rejected with 401 surfaces a connect-time err
     // depending on which layer caught it; both are correct
     // connection-establishment failures. Anything else (e.g.
     // socket_error, config_error, success) is a regression.
-    CHECK((code == questdb_error_auth_error
-        || code == questdb_error_handshake_error));
+    CHECK(
+        (code == questdb_error_auth_error ||
+         code == questdb_error_handshake_error));
     questdb_error_free(err);
 }
 
@@ -1524,8 +1576,9 @@ TEST_CASE("mock: multi-addr walk aggregates per-endpoint 401 rejections")
     // class). The aggregated-message check below is the part that
     // actually pins the new behaviour.
     const auto code = questdb_error_get_code(err);
-    CHECK((code == questdb_error_auth_error
-        || code == questdb_error_handshake_error));
+    CHECK(
+        (code == questdb_error_auth_error ||
+         code == questdb_error_handshake_error));
     size_t mlen = 0;
     const char* msg = questdb_error_msg(err, &mlen);
     const std::string m{msg, mlen};
@@ -1547,12 +1600,13 @@ TEST_CASE("mock: multi-addr walk aggregates per-endpoint 401 rejections")
 // ActionSendCacheReset.
 // ---------------------------------------------------------------------------
 
-TEST_CASE("mock: CACHE_RESET mid-stream is consumed without breaking the cursor")
+TEST_CASE(
+    "mock: CACHE_RESET mid-stream is consumed without breaking the cursor")
 {
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendCacheReset{},  // server invalidates symbol/schema caches
+        qm::ActionSendCacheReset{}, // server invalidates symbol/schema caches
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1581,12 +1635,18 @@ namespace
 {
 ::qwp_reader* raw_handle(questdb::egress::reader& r) noexcept
 {
-    struct reader_layout { ::qwp_reader* impl; };
+    struct reader_layout
+    {
+        ::qwp_reader* impl;
+    };
     return reinterpret_cast<reader_layout*>(&r)->impl;
 }
 ::qwp_reader_query* raw_handle(questdb::egress::query& q) noexcept
 {
-    struct query_layout { ::qwp_reader_query* impl; };
+    struct query_layout
+    {
+        ::qwp_reader_query* impl;
+    };
     return reinterpret_cast<query_layout*>(&q)->impl;
 }
 } // namespace
@@ -1600,8 +1660,7 @@ TEST_CASE("mock: query_new rejects invalid UTF-8 SQL with InvalidUtf8")
     static const unsigned char bad[] = {'s', 'e', 'l', 'e', 'c', 't', 0xFF};
     line_sender_utf8 sql{7, reinterpret_cast<const char*>(bad)};
     questdb_error* err = nullptr;
-    qwp_reader_query* q =
-        qwp_reader_prepare(raw_handle(reader), sql, &err);
+    qwp_reader_query* q = qwp_reader_prepare(raw_handle(reader), sql, &err);
     REQUIRE(q == nullptr);
     REQUIRE(err != nullptr);
     CHECK(questdb_error_get_code(err) == questdb_error_invalid_utf8);
@@ -1610,7 +1669,8 @@ TEST_CASE("mock: query_new rejects invalid UTF-8 SQL with InvalidUtf8")
     CHECK(srv.captured_requests().empty());
 }
 
-TEST_CASE("mock: bind_varchar with invalid UTF-8 surfaces InvalidUtf8 at execute")
+TEST_CASE(
+    "mock: bind_varchar with invalid UTF-8 surfaces InvalidUtf8 at execute")
 {
     qm::Script s = {
         qm::ActionSendServerInfo{},
@@ -1620,7 +1680,7 @@ TEST_CASE("mock: bind_varchar with invalid UTF-8 surfaces InvalidUtf8 at execute
     auto reader = connect_to(srv);
 
     auto q = reader.prepare("X"_utf8);
-    static const unsigned char bad[] = {0xC3, 0x28};  // invalid 2-byte UTF-8
+    static const unsigned char bad[] = {0xC3, 0x28}; // invalid 2-byte UTF-8
     line_sender_utf8 v{2, reinterpret_cast<const char*>(bad)};
     qwp_reader_query_bind_varchar(raw_handle(q), v);
     // bind_varchar stashes the deferred error; execute() must surface
@@ -1672,47 +1732,80 @@ TEST_CASE("mock: bind variants round-trip without crashing")
 {
     using questdb::egress::query;
 
-    SUBCASE("bind_bool")           { run_bind_round_trip([](query& q){ q.bind_bool(true); }); }
-    SUBCASE("bind_i8")             { run_bind_round_trip([](query& q){ q.bind_i8(-7); }); }
-    SUBCASE("bind_i16")            { run_bind_round_trip([](query& q){ q.bind_i16(-31000); }); }
-    SUBCASE("bind_i64")            { run_bind_round_trip([](query& q){ q.bind_i64(-1); }); }
-    SUBCASE("bind_f32")            { run_bind_round_trip([](query& q){ q.bind_f32(1.5f); }); }
-    SUBCASE("bind_f64")            { run_bind_round_trip([](query& q){ q.bind_f64(-2.25); }); }
-    SUBCASE("bind_timestamp_micros"){ run_bind_round_trip([](query& q){ q.bind_timestamp_micros(1234567890); }); }
-    SUBCASE("bind_timestamp_nanos"){ run_bind_round_trip([](query& q){ q.bind_timestamp_nanos(1234567890123); }); }
-    SUBCASE("bind_date_millis")    { run_bind_round_trip([](query& q){ q.bind_date_millis(1234567890); }); }
-    SUBCASE("bind_char")           { run_bind_round_trip([](query& q){ q.bind_char(uint16_t(u'Z')); }); }
-    SUBCASE("bind_decimal64")      { run_bind_round_trip([](query& q){ q.bind_decimal64(12345, 2); }); }
+    SUBCASE("bind_bool")
+    {
+        run_bind_round_trip([](query& q) { q.bind_bool(true); });
+    }
+    SUBCASE("bind_i8")
+    {
+        run_bind_round_trip([](query& q) { q.bind_i8(-7); });
+    }
+    SUBCASE("bind_i16")
+    {
+        run_bind_round_trip([](query& q) { q.bind_i16(-31000); });
+    }
+    SUBCASE("bind_i64")
+    {
+        run_bind_round_trip([](query& q) { q.bind_i64(-1); });
+    }
+    SUBCASE("bind_f32")
+    {
+        run_bind_round_trip([](query& q) { q.bind_f32(1.5f); });
+    }
+    SUBCASE("bind_f64")
+    {
+        run_bind_round_trip([](query& q) { q.bind_f64(-2.25); });
+    }
+    SUBCASE("bind_timestamp_micros")
+    {
+        run_bind_round_trip(
+            [](query& q) { q.bind_timestamp_micros(1234567890); });
+    }
+    SUBCASE("bind_timestamp_nanos")
+    {
+        run_bind_round_trip(
+            [](query& q) { q.bind_timestamp_nanos(1234567890123); });
+    }
+    SUBCASE("bind_date_millis")
+    {
+        run_bind_round_trip([](query& q) { q.bind_date_millis(1234567890); });
+    }
+    SUBCASE("bind_char")
+    {
+        run_bind_round_trip([](query& q) { q.bind_char(uint16_t(u'Z')); });
+    }
+    SUBCASE("bind_decimal64")
+    {
+        run_bind_round_trip([](query& q) { q.bind_decimal64(12345, 2); });
+    }
     SUBCASE("bind_decimal256")
     {
-        run_bind_round_trip(
-            [](query& q)
-            {
-                std::array<uint8_t, 32> b{};
-                b[0] = 0xAB;
-                q.bind_decimal256(b, 4);
-            });
+        run_bind_round_trip([](query& q) {
+            std::array<uint8_t, 32> b{};
+            b[0] = 0xAB;
+            q.bind_decimal256(b, 4);
+        });
     }
-    SUBCASE("bind_geohash")        { run_bind_round_trip([](query& q){ q.bind_geohash(0xAB, 8); }); }
+    SUBCASE("bind_geohash")
+    {
+        run_bind_round_trip([](query& q) { q.bind_geohash(0xAB, 8); });
+    }
     SUBCASE("bind_uuid")
     {
-        run_bind_round_trip(
-            [](query& q)
-            {
-                std::array<uint8_t, 16> u{};
-                for (int i = 0; i < 16; ++i) u[i] = uint8_t(i);
-                q.bind_uuid(u);
-            });
+        run_bind_round_trip([](query& q) {
+            std::array<uint8_t, 16> u{};
+            for (int i = 0; i < 16; ++i)
+                u[i] = uint8_t(i);
+            q.bind_uuid(u);
+        });
     }
     SUBCASE("bind_long256")
     {
-        run_bind_round_trip(
-            [](query& q)
-            {
-                std::array<uint8_t, 32> l{};
-                l[31] = 0x80;
-                q.bind_long256(l);
-            });
+        run_bind_round_trip([](query& q) {
+            std::array<uint8_t, 32> l{};
+            l[31] = 0x80;
+            q.bind_long256(l);
+        });
     }
     // bind_ipv4 / bind_binary / bind_null_binary are exposed on the FFI
     // surface but the upstream encoder rejects them (see binds.rs
@@ -1721,33 +1814,47 @@ TEST_CASE("mock: bind variants round-trip without crashing")
     // an InvalidBind error rather than a panic / abort.
     SUBCASE("bind_ipv4 → InvalidBind")
     {
-        run_bind_rejection([](query& q){ q.bind_ipv4(0x7F000001); });
+        run_bind_rejection([](query& q) { q.bind_ipv4(0x7F000001); });
     }
     SUBCASE("bind_binary → InvalidBind")
     {
-        run_bind_rejection(
-            [](query& q)
-            {
-                const uint8_t buf[] = {0xDE, 0xAD, 0xBE, 0xEF};
-                q.bind_binary(buf, sizeof(buf));
-            });
+        run_bind_rejection([](query& q) {
+            const uint8_t buf[] = {0xDE, 0xAD, 0xBE, 0xEF};
+            q.bind_binary(buf, sizeof(buf));
+        });
     }
     SUBCASE("bind_binary empty → InvalidBind")
     {
-        run_bind_rejection([](query& q){ q.bind_binary(nullptr, 0); });
+        run_bind_rejection([](query& q) { q.bind_binary(nullptr, 0); });
     }
     SUBCASE("bind_null_binary → InvalidBind")
     {
-        run_bind_rejection([](query& q){ q.bind_null_binary(); });
+        run_bind_rejection([](query& q) { q.bind_null_binary(); });
     }
-    SUBCASE("bind_null_varchar")     { run_bind_round_trip([](query& q){ q.bind_null_varchar(); }); }
-    SUBCASE("bind_null_decimal64")   { run_bind_round_trip([](query& q){ q.bind_null_decimal64(2); }); }
-    SUBCASE("bind_null_decimal128")  { run_bind_round_trip([](query& q){ q.bind_null_decimal128(2); }); }
-    SUBCASE("bind_null_decimal256")  { run_bind_round_trip([](query& q){ q.bind_null_decimal256(2); }); }
-    SUBCASE("bind_null_geohash")     { run_bind_round_trip([](query& q){ q.bind_null_geohash(8); }); }
+    SUBCASE("bind_null_varchar")
+    {
+        run_bind_round_trip([](query& q) { q.bind_null_varchar(); });
+    }
+    SUBCASE("bind_null_decimal64")
+    {
+        run_bind_round_trip([](query& q) { q.bind_null_decimal64(2); });
+    }
+    SUBCASE("bind_null_decimal128")
+    {
+        run_bind_round_trip([](query& q) { q.bind_null_decimal128(2); });
+    }
+    SUBCASE("bind_null_decimal256")
+    {
+        run_bind_round_trip([](query& q) { q.bind_null_decimal256(2); });
+    }
+    SUBCASE("bind_null_geohash")
+    {
+        run_bind_round_trip([](query& q) { q.bind_null_geohash(8); });
+    }
     SUBCASE("bind_null(kind)")
     {
-        run_bind_round_trip([](query& q){ q.bind_null(questdb::egress::column_kind::int_); });
+        run_bind_round_trip(
+            [](query& q) { q.bind_null(questdb::egress::column_kind::int_); });
     }
 }
 
@@ -1768,8 +1875,9 @@ TEST_CASE("mock: column_name returns the schema's column name")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c0, c1](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c0, c1}); }},
+        qm::ActionSendBuilt{[c0, c1](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c0, c1});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1788,15 +1896,14 @@ TEST_CASE("mock: column_name returns the schema's column name")
 TEST_CASE("mock: column_name fails cleanly on out-of-range index")
 {
     qm::ColumnSpec c{
-        "v",
-        qm::COL_LONG,
-        qm::fixed_column_bytes(1, pack_le<int64_t>({0}))};
+        "v", qm::COL_LONG, qm::fixed_column_bytes(1, pack_le<int64_t>({0}))};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1834,14 +1941,14 @@ TEST_CASE("mock: get_ipv4 round-trips high-bit IPs without sign-flipping")
         "ip",
         qm::COL_IPV4,
         qm::fixed_column_bytes(
-            3,
-            pack_le<uint32_t>({0xC0A80001u, 0x0A000001u, 0xF0010203u}))};
+            3, pack_le<uint32_t>({0xC0A80001u, 0x0A000001u, 0xF0010203u}))};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 3, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 3, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1875,8 +1982,9 @@ TEST_CASE("mock: get_i32 rejects an IPV4 column with a type-mismatch error")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1906,15 +2014,14 @@ TEST_CASE("mock: get_i32 rejects an IPV4 column with a type-mismatch error")
 TEST_CASE("mock: get_ipv4 rejects an INT column with a type-mismatch error")
 {
     qm::ColumnSpec c{
-        "n",
-        qm::COL_INT,
-        qm::fixed_column_bytes(1, pack_le<int32_t>({42}))};
+        "n", qm::COL_INT, qm::fixed_column_bytes(1, pack_le<int32_t>({42}))};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1962,8 +2069,9 @@ TEST_CASE("mock: typed getters reject mismatched column kind")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[int_col](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {int_col}); }},
+        qm::ActionSendBuilt{[int_col](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {int_col});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -1990,26 +2098,81 @@ TEST_CASE("mock: typed getters reject mismatched column kind")
         CHECK(code == questdb_error_invalid_api_call);
     };
 
-    SUBCASE("get_bool")        { expect_throws([&]{ (void)batch.column(0).get<bool>(0); }); }
-    SUBCASE("get_i8")          { expect_throws([&]{ (void)batch.column(0).get<int8_t>(0); }); }
-    SUBCASE("get_i16")         { expect_throws([&]{ (void)batch.column(0).get<int16_t>(0); }); }
-    SUBCASE("get_i64")         { expect_throws([&]{ (void)batch.column(0).get<int64_t>(0); }); }
-    SUBCASE("get_f32")         { expect_throws([&]{ (void)batch.column(0).get<float>(0); }); }
-    SUBCASE("get_f64")         { expect_throws([&]{ (void)batch.column(0).get<double>(0); }); }
-    SUBCASE("get_char")        { expect_throws([&]{ (void)batch.column(0).get<uint16_t>(0); }); }
-    SUBCASE("get_uuid")        { expect_throws([&]{ (void)batch.column(0).get_uuid(0); }); }
-    SUBCASE("get_long256")     { expect_throws([&]{ (void)batch.column(0).get_long256(0); }); }
-    SUBCASE("get_varchar")     { expect_throws([&]{ (void)batch.column(0).varchar(0); }); }
-    SUBCASE("get_binary")      { expect_throws([&]{ (void)batch.column(0).binary(0); }); }
-    SUBCASE("get_symbol")      { expect_throws([&]{ (void)batch.column(0).symbol(0); }); }
-    SUBCASE("get_decimal64")   { expect_throws([&]{ (void)batch.column(0).get_decimal64(0); }); }
-    SUBCASE("get_decimal128")  { expect_throws([&]{ (void)batch.column(0).get_decimal128(0); }); }
-    SUBCASE("get_decimal256")  { expect_throws([&]{ (void)batch.column(0).get_decimal256(0); }); }
-    SUBCASE("get_geohash")     { expect_throws([&]{ (void)batch.column(0).get_geohash(0); }); }
-    SUBCASE("array shape on scalar col") {
-        expect_throws([&]{ size_t r=0; (void)batch.column(0).shape(0, &r); });
+    SUBCASE("get_bool")
+    {
+        expect_throws([&] { (void)batch.column(0).get<bool>(0); });
     }
-    SUBCASE("get_ipv4")        { expect_throws([&]{ (void)batch.column(0).get<uint32_t>(0); }); }
+    SUBCASE("get_i8")
+    {
+        expect_throws([&] { (void)batch.column(0).get<int8_t>(0); });
+    }
+    SUBCASE("get_i16")
+    {
+        expect_throws([&] { (void)batch.column(0).get<int16_t>(0); });
+    }
+    SUBCASE("get_i64")
+    {
+        expect_throws([&] { (void)batch.column(0).get<int64_t>(0); });
+    }
+    SUBCASE("get_f32")
+    {
+        expect_throws([&] { (void)batch.column(0).get<float>(0); });
+    }
+    SUBCASE("get_f64")
+    {
+        expect_throws([&] { (void)batch.column(0).get<double>(0); });
+    }
+    SUBCASE("get_char")
+    {
+        expect_throws([&] { (void)batch.column(0).get<uint16_t>(0); });
+    }
+    SUBCASE("get_uuid")
+    {
+        expect_throws([&] { (void)batch.column(0).get_uuid(0); });
+    }
+    SUBCASE("get_long256")
+    {
+        expect_throws([&] { (void)batch.column(0).get_long256(0); });
+    }
+    SUBCASE("get_varchar")
+    {
+        expect_throws([&] { (void)batch.column(0).varchar(0); });
+    }
+    SUBCASE("get_binary")
+    {
+        expect_throws([&] { (void)batch.column(0).binary(0); });
+    }
+    SUBCASE("get_symbol")
+    {
+        expect_throws([&] { (void)batch.column(0).symbol(0); });
+    }
+    SUBCASE("get_decimal64")
+    {
+        expect_throws([&] { (void)batch.column(0).get_decimal64(0); });
+    }
+    SUBCASE("get_decimal128")
+    {
+        expect_throws([&] { (void)batch.column(0).get_decimal128(0); });
+    }
+    SUBCASE("get_decimal256")
+    {
+        expect_throws([&] { (void)batch.column(0).get_decimal256(0); });
+    }
+    SUBCASE("get_geohash")
+    {
+        expect_throws([&] { (void)batch.column(0).get_geohash(0); });
+    }
+    SUBCASE("array shape on scalar col")
+    {
+        expect_throws([&] {
+            size_t r = 0;
+            (void)batch.column(0).shape(0, &r);
+        });
+    }
+    SUBCASE("get_ipv4")
+    {
+        expect_throws([&] { (void)batch.column(0).get<uint32_t>(0); });
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2018,12 +2181,15 @@ TEST_CASE("mock: typed getters reject mismatched column kind")
 TEST_CASE("mock: column accessors reject out-of-range indices")
 {
     qm::ColumnSpec int_col{
-        "n", qm::COL_INT, qm::fixed_column_bytes(2, pack_le<int32_t>({10, 20}))};
+        "n",
+        qm::COL_INT,
+        qm::fixed_column_bytes(2, pack_le<int32_t>({10, 20}))};
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[int_col](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 2, {int_col}); }},
+        qm::ActionSendBuilt{[int_col](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 2, {int_col});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -2054,19 +2220,19 @@ TEST_CASE("mock: column accessors reject out-of-range indices")
 
     SUBCASE("column_kind out-of-range column")
     {
-        expect_invalid_api([&]{ (void)batch.column_kind(99); });
+        expect_invalid_api([&] { (void)batch.column_kind(99); });
     }
     SUBCASE("column_name out-of-range column")
     {
-        expect_invalid_api([&]{ (void)batch.column_name(99); });
+        expect_invalid_api([&] { (void)batch.column_name(99); });
     }
     SUBCASE("get_i32 out-of-range column")
     {
-        expect_invalid_api([&]{ (void)batch.column(99).get<int32_t>(0); });
+        expect_invalid_api([&] { (void)batch.column(99).get<int32_t>(0); });
     }
     SUBCASE("get_i32 out-of-range row")
     {
-        expect_invalid_api([&]{ (void)batch.column(0).get<int32_t>(99); });
+        expect_invalid_api([&] { (void)batch.column(0).get<int32_t>(99); });
     }
 }
 
@@ -2082,23 +2248,24 @@ TEST_CASE("mock: get_i64 round-trips TIMESTAMP / DATE / TIMESTAMP_NANOS")
     const int64_t ts_ns = 1'700'000'000'123'456'789LL; // 2023-11-14, ns
 
     qm::ColumnSpec c_ts{
-        "ts", qm::COL_TIMESTAMP,
+        "ts",
+        qm::COL_TIMESTAMP,
         qm::fixed_column_bytes(1, pack_le<int64_t>({ts_us}))};
     qm::ColumnSpec c_date{
-        "d", qm::COL_DATE,
+        "d",
+        qm::COL_DATE,
         qm::fixed_column_bytes(1, pack_le<int64_t>({date_ms}))};
     qm::ColumnSpec c_tn{
-        "tn", qm::COL_TIMESTAMP_NANOS,
+        "tn",
+        qm::COL_TIMESTAMP_NANOS,
         qm::fixed_column_bytes(1, pack_le<int64_t>({ts_ns}))};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c_ts, c_date, c_tn](int64_t rid)
-                            {
-                                return qm::result_batch_frame(
-                                    rid, 0, 1, {c_ts, c_date, c_tn});
-                            }},
+        qm::ActionSendBuilt{[c_ts, c_date, c_tn](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c_ts, c_date, c_tn});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -2134,19 +2301,20 @@ TEST_CASE("mock: get_i64 round-trips TIMESTAMP / DATE / TIMESTAMP_NANOS")
 // raising ProtocolError is acceptable; what matters is that NO call path
 // returns a valid-looking view from misaligned bytes.
 // ---------------------------------------------------------------------------
-TEST_CASE(
-    "mock: DOUBLE_ARRAY misaligned data_len surfaces as ProtocolError")
+TEST_CASE("mock: DOUBLE_ARRAY misaligned data_len surfaces as ProtocolError")
 {
     qm::ArrayRow row{{1u, 1u}, std::vector<uint8_t>(11, 0xCC)};
     qm::ColumnSpec c{
-        "a", qm::COL_DOUBLE_ARRAY,
+        "a",
+        qm::COL_DOUBLE_ARRAY,
         qm::array_column_bytes({std::optional<qm::ArrayRow>{std::move(row)}})};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -2189,8 +2357,9 @@ TEST_CASE("mock: C++ wrapper move semantics — reader / cursor")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -2203,8 +2372,8 @@ TEST_CASE("mock: C++ wrapper move semantics — reader / cursor")
         // r2 still owns the impl and must work normally.
         auto cur = r2.execute("select v from t"_utf8);
         auto batch_opt = cur.next_batch();
-    REQUIRE(batch_opt);
-    auto& batch = *batch_opt;
+        REQUIRE(batch_opt);
+        auto& batch = *batch_opt;
         auto v = batch.column(0).get<int32_t>(0);
         REQUIRE(v.has_value());
         CHECK(*v == 1);
@@ -2275,19 +2444,20 @@ TEST_CASE(
 TEST_CASE("mock: server_info exposes role / epoch / capabilities / wall_ns")
 {
     constexpr uint64_t expected_epoch = 0xCAFEBABEDEADBEEFULL;
-    constexpr uint32_t expected_caps  = 0x12345678u | qm::CAP_ZONE;
-    constexpr int64_t  expected_wall  = 1'700'000'000'000'000'000LL;
+    constexpr uint32_t expected_caps = 0x12345678u | qm::CAP_ZONE;
+    constexpr int64_t expected_wall = 1'700'000'000'000'000'000LL;
 
     qm::ActionSendServerInfo si{};
-    si.role           = qm::ROLE_PRIMARY;
-    si.cluster_id     = "cluster-x";
-    si.node_id        = "node-x";
-    si.epoch          = expected_epoch;
-    si.capabilities   = expected_caps;
+    si.role = qm::ROLE_PRIMARY;
+    si.cluster_id = "cluster-x";
+    si.node_id = "node-x";
+    si.epoch = expected_epoch;
+    si.capabilities = expected_caps;
     si.server_wall_ns = expected_wall;
-    si.zone_id        = "eu-west-1a";
+    si.zone_id = "eu-west-1a";
 
-    qm::Script s = {si, qm::ActionAwaitQueryRequest{}, qm::ActionSendResultEnd{}};
+    qm::Script s = {
+        si, qm::ActionAwaitQueryRequest{}, qm::ActionSendResultEnd{}};
     qm::MockServer srv({s});
 
     auto reader = connect_to(srv);
@@ -2306,13 +2476,12 @@ TEST_CASE("mock: server_info exposes role / epoch / capabilities / wall_ns")
     // the by-value server_info result therefore cannot refer into a destroyed
     // temporary.
     static_assert(std::is_same_v<
-        decltype(std::declval<eg::server_info&&>().cluster_id()),
-        std::string>);
+                  decltype(std::declval<eg::server_info&&>().cluster_id()),
+                  std::string>);
     static_assert(std::is_same_v<
-        decltype(std::declval<eg::server_info&&>().zone_id()),
-        std::optional<std::string>>);
-    const std::string& temporary_cluster =
-        reader.server_info().cluster_id();
+                  decltype(std::declval<eg::server_info&&>().zone_id()),
+                  std::optional<std::string>>);
+    const std::string& temporary_cluster = reader.server_info().cluster_id();
     const auto& temporary_zone = reader.server_info().zone_id();
     CHECK(temporary_cluster == "cluster-x");
     REQUIRE(temporary_zone.has_value());
@@ -2334,7 +2503,8 @@ TEST_CASE("mock: owning server_info preserves unknown role and outlives reader")
     }
 
     // The reader and its Rust-owned strings are gone. The C++ snapshot keeps
-    // independent storage rather than a dangling qwp_reader_server_info pointer.
+    // independent storage rather than a dangling qwp_reader_server_info
+    // pointer.
     REQUIRE(captured.has_value());
     CHECK(captured->cluster_id() == "cluster-owned");
     CHECK(captured->node_id() == "node-owned");
@@ -2350,7 +2520,7 @@ TEST_CASE("mock: owning server_info preserves unknown role and outlives reader")
 TEST_CASE("mock: cursor::terminal_exec_done returns op_type and rows_affected")
 {
     qm::ActionSendExecDone done{};
-    done.op_type       = 0x42;     // arbitrary non-zero, opaque to the client
+    done.op_type = 0x42; // arbitrary non-zero, opaque to the client
     done.rows_affected = 1'234'567ULL;
 
     qm::Script s = {
@@ -2379,7 +2549,8 @@ TEST_CASE("mock: cursor::terminal_exec_done returns op_type and rows_affected")
 // `new_request_id`, `elapsed_ns`, and `trigger_msg`, which the original
 // trampoline test left unobserved.
 // ---------------------------------------------------------------------------
-TEST_CASE("mock: failover event exposes new_request_id, elapsed_ns, trigger_msg")
+TEST_CASE(
+    "mock: failover event exposes new_request_id, elapsed_ns, trigger_msg")
 {
     qm::Script s_a = {
         qm::ActionSendServerInfo{qm::ROLE_STANDALONE, "c", "a"},
@@ -2404,22 +2575,22 @@ TEST_CASE("mock: failover event exposes new_request_id, elapsed_ns, trigger_msg"
     struct Capture
     {
         std::atomic<int> count{0};
-        int64_t  new_request_id{0};
+        int64_t new_request_id{0};
         uint64_t elapsed_ns{0};
         std::string trigger_msg;
     };
     auto cap = std::make_shared<Capture>();
 
-    auto cur = reader.prepare("select 1"_utf8)
-                   .on_failover_reset(
-                       [cap](const questdb::egress::failover_reset_event_view& ev)
-                       {
-                           cap->count.fetch_add(1);
-                           cap->new_request_id = ev.new_request_id();
-                           cap->elapsed_ns = ev.elapsed_ns();
-                           cap->trigger_msg = std::string(ev.trigger_msg());
-                       })
-                   .execute();
+    auto cur =
+        reader.prepare("select 1"_utf8)
+            .on_failover_reset(
+                [cap](const questdb::egress::failover_reset_event_view& ev) {
+                    cap->count.fetch_add(1);
+                    cap->new_request_id = ev.new_request_id();
+                    cap->elapsed_ns = ev.elapsed_ns();
+                    cap->trigger_msg = std::string(ev.trigger_msg());
+                })
+            .execute();
     CHECK_FALSE(cur.next_batch());
     REQUIRE(cap->count.load() == 1);
 
@@ -2454,21 +2625,21 @@ TEST_CASE("mock: C++ wrapper move-assignment — reader / query / cursor")
         qm::Script s2 = {
             qm::ActionSendServerInfo{},
             qm::ActionAwaitQueryRequest{},
-            qm::ActionSendBuilt{
-                [c](int64_t rid)
-                { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+            qm::ActionSendBuilt{[c](int64_t rid) {
+                return qm::result_batch_frame(rid, 0, 1, {c});
+            }},
             qm::ActionSendResultEnd{},
         };
         qm::MockServer srv1({s1});
         qm::MockServer srv2({s2});
 
         auto r = connect_to(srv1);
-        r = connect_to(srv2);  // move-assign — must close srv1's socket
+        r = connect_to(srv2); // move-assign — must close srv1's socket
         // The new reader works against srv2.
         auto cur = r.execute("select v from t"_utf8);
         auto batch_opt = cur.next_batch();
-    REQUIRE(batch_opt);
-    auto& batch = *batch_opt;
+        REQUIRE(batch_opt);
+        auto& batch = *batch_opt;
         auto v = batch.column(0).get<int32_t>(0);
         REQUIRE(v.has_value());
         CHECK(*v == 7);
@@ -2484,9 +2655,9 @@ TEST_CASE("mock: C++ wrapper move-assignment — reader / query / cursor")
         qm::Script s2 = {
             qm::ActionSendServerInfo{},
             qm::ActionAwaitQueryRequest{},
-            qm::ActionSendBuilt{
-                [c](int64_t rid)
-                { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+            qm::ActionSendBuilt{[c](int64_t rid) {
+                return qm::result_batch_frame(rid, 0, 1, {c});
+            }},
             qm::ActionSendResultEnd{},
         };
         qm::MockServer srv1({s1});
@@ -2497,11 +2668,11 @@ TEST_CASE("mock: C++ wrapper move-assignment — reader / query / cursor")
         q1.bind_i32(1);
         auto q2 = reader2.prepare("Y"_utf8);
         q2.bind_i32(7);
-        q1 = std::move(q2);  // move-assign — frees q1's old impl
+        q1 = std::move(q2); // move-assign — frees q1's old impl
         auto cur = q1.execute();
         auto batch_opt = cur.next_batch();
-    REQUIRE(batch_opt);
-    auto& batch = *batch_opt;
+        REQUIRE(batch_opt);
+        auto& batch = *batch_opt;
         auto v = batch.column(0).get<int32_t>(0);
         REQUIRE(v.has_value());
         CHECK(*v == 7);
@@ -2517,21 +2688,21 @@ TEST_CASE("mock: C++ wrapper move-assignment — reader / query / cursor")
         qm::Script s = {
             qm::ActionSendServerInfo{},
             qm::ActionAwaitQueryRequest{},
-            qm::ActionSendBuilt{
-                [c](int64_t rid)
-                { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+            qm::ActionSendBuilt{[c](int64_t rid) {
+                return qm::result_batch_frame(rid, 0, 1, {c});
+            }},
             qm::ActionSendResultEnd{},
         };
         qm::MockServer srv({s});
         auto reader = connect_to(srv);
         auto q_a = reader.prepare("X"_utf8);
-        auto q_b = std::move(q_a);   // q_a empty
-        q_a = std::move(q_b);        // assign into empty — must not crash
+        auto q_b = std::move(q_a); // q_a empty
+        q_a = std::move(q_b);      // assign into empty — must not crash
         q_a.bind_i32(7);
         auto cur = q_a.execute();
         auto batch_opt = cur.next_batch();
-    REQUIRE(batch_opt);
-    auto& batch = *batch_opt;
+        REQUIRE(batch_opt);
+        auto& batch = *batch_opt;
         auto v = batch.column(0).get<int32_t>(0);
         REQUIRE(v.has_value());
         CHECK(*v == 7);
@@ -2549,9 +2720,9 @@ TEST_CASE("mock: C++ wrapper move-assignment — reader / query / cursor")
         qm::Script s2 = {
             qm::ActionSendServerInfo{},
             qm::ActionAwaitQueryRequest{},
-            qm::ActionSendBuilt{
-                [c](int64_t rid)
-                { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+            qm::ActionSendBuilt{[c](int64_t rid) {
+                return qm::result_batch_frame(rid, 0, 1, {c});
+            }},
             qm::ActionSendResultEnd{},
         };
         qm::MockServer srv1({s1});
@@ -2563,11 +2734,13 @@ TEST_CASE("mock: C++ wrapper move-assignment — reader / query / cursor")
         // before we overwrite it (the move-assign would call _close on
         // the live cursor regardless, but draining keeps the lifecycle
         // observable).
-        while (cur.next_batch()) {}
-        cur = r2.execute("select v from t"_utf8);  // move-assign
+        while (cur.next_batch())
+        {
+        }
+        cur = r2.execute("select v from t"_utf8); // move-assign
         auto batch_opt = cur.next_batch();
-    REQUIRE(batch_opt);
-    auto& batch = *batch_opt;
+        REQUIRE(batch_opt);
+        auto& batch = *batch_opt;
         auto v = batch.column(0).get<int32_t>(0);
         REQUIRE(v.has_value());
         CHECK(*v == 7);
@@ -2610,7 +2783,8 @@ TEST_CASE("mock: next_batch is idempotent after the stream terminus")
 // `reader.rs::target_matches`; the positive half is exercised by every
 // other test that uses ROLE_STANDALONE/_PRIMARY without a target filter.
 // ---------------------------------------------------------------------------
-TEST_CASE("mock: target=primary against replica-only endpoint surfaces role_mismatch")
+TEST_CASE(
+    "mock: target=primary against replica-only endpoint surfaces role_mismatch")
 {
     qm::Script s = {
         qm::ActionSendServerInfo{qm::ROLE_REPLICA, "cluster-x", "replica-1"},
@@ -2649,10 +2823,8 @@ void run_malformed_batch(
     // so the client would otherwise reconnect to the (now scriptless)
     // mock and hang. Disabling makes the malformed-frame error
     // surface directly on `next_batch`.
-    const std::string conf =
-        "ws::addr=" + srv.addr() + ";failover=off;";
-    questdb::egress::reader reader{
-        questdb::ingress::utf8_view{conf}};
+    const std::string conf = "ws::addr=" + srv.addr() + ";failover=off;";
+    questdb::egress::reader reader{questdb::ingress::utf8_view{conf}};
     auto cur = reader.execute("select 1"_utf8);
     bool threw = false;
     try
@@ -2670,7 +2842,9 @@ void run_malformed_batch(
 
 } // anonymous namespace
 
-TEST_CASE("mock: protocol_error — header.payload_length lies (claims more bytes than sent)")
+TEST_CASE(
+    "mock: protocol_error — header.payload_length lies (claims more bytes than "
+    "sent)")
 {
     // Build a valid-looking RESULT_BATCH then overwrite the 4-byte
     // payload_length in the header with a value larger than the actual
@@ -2685,7 +2859,7 @@ TEST_CASE("mock: protocol_error — header.payload_length lies (claims more byte
             // Bump declared payload_length by 1024 — the actual bytes
             // are unchanged, so the frame parser sees a mismatch.
             uint32_t plen = uint32_t(f[8]) | (uint32_t(f[9]) << 8) |
-                (uint32_t(f[10]) << 16) | (uint32_t(f[11]) << 24);
+                            (uint32_t(f[10]) << 16) | (uint32_t(f[11]) << 24);
             uint32_t bumped = plen + 1024;
             f[8] = uint8_t(bumped);
             f[9] = uint8_t(bumped >> 8);
@@ -2770,17 +2944,22 @@ TEST_CASE("mock: continuation batch decodes against the batch-0 schema")
     // asserted here by row *values* through the C API, not just by the
     // drain not throwing.
     qm::ColumnSpec c0{
-        "v", qm::COL_LONG, qm::fixed_column_bytes(2, pack_le<int64_t>({10, 20}))};
+        "v",
+        qm::COL_LONG,
+        qm::fixed_column_bytes(2, pack_le<int64_t>({10, 20}))};
     qm::ColumnSpec c1{
-        "v", qm::COL_LONG,
+        "v",
+        qm::COL_LONG,
         qm::fixed_column_bytes(3, pack_le<int64_t>({30, 40, 50}))};
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c0](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 2, {c0}); }},
-        qm::ActionSendBuilt{[c1](int64_t rid)
-                            { return qm::result_batch_frame(rid, 1, 3, {c1}); }},
+        qm::ActionSendBuilt{[c0](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 2, {c0});
+        }},
+        qm::ActionSendBuilt{[c1](int64_t rid) {
+            return qm::result_batch_frame(rid, 1, 3, {c1});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -2817,7 +2996,8 @@ TEST_CASE("mock: continuation batch decodes against the batch-0 schema")
     CHECK_FALSE(cur.next_batch());
 }
 
-TEST_CASE("mock: protocol_error — continuation batch before schema-bearing batch 0")
+TEST_CASE(
+    "mock: protocol_error — continuation batch before schema-bearing batch 0")
 {
     // A query whose *first* frame is a continuation (batch_seq > 0) has
     // no schema to bind rows to and must surface a protocol error
@@ -2827,9 +3007,9 @@ TEST_CASE("mock: protocol_error — continuation batch before schema-bearing bat
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(
-                                  rid, /*batch_seq=*/1, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, /*batch_seq=*/1, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     run_malformed_batch(s);
@@ -2865,12 +3045,16 @@ TEST_CASE("mock: SERVER_INFO zone trailer presence must match CAP_ZONE")
 {
     CHECK_THROWS_AS(
         (qm::server_info_frame(
-            qm::ROLE_PRIMARY, "c", "n", 0, 0, 0,
+            qm::ROLE_PRIMARY,
+            "c",
+            "n",
+            0,
+            0,
+            0,
             std::optional<std::string>{"zone-A"})),
         std::invalid_argument);
     CHECK_THROWS_AS(
-        (qm::server_info_frame(
-            qm::ROLE_PRIMARY, "c", "n", 0, qm::CAP_ZONE, 0)),
+        (qm::server_info_frame(qm::ROLE_PRIMARY, "c", "n", 0, qm::CAP_ZONE, 0)),
         std::invalid_argument);
 }
 
@@ -2881,7 +3065,8 @@ TEST_CASE("mock: SERVER_INFO zone trailer presence must match CAP_ZONE")
 // UB across a C frame — so it leaks the old reader (with a stderr
 // diagnostic) and adopts the source, rather than throwing or freeing under
 // the cursor. The cursor stays valid against the leaked reader.
-TEST_CASE("mock: reader move-assign over a live cursor leaks safely without throwing")
+TEST_CASE(
+    "mock: reader move-assign over a live cursor leaks safely without throwing")
 {
     qm::Script s_a = {
         qm::ActionSendServerInfo{},
@@ -2969,8 +3154,7 @@ TEST_CASE("mock: reader metadata getters reject while a cursor is live")
     {
         auto cur = reader.execute("select 1"_utf8);
 
-        const auto expect_live_cursor_error = [](auto&& fn)
-        {
+        const auto expect_live_cursor_error = [](auto&& fn) {
             bool threw = false;
             try
             {
@@ -2980,15 +3164,15 @@ TEST_CASE("mock: reader metadata getters reject while a cursor is live")
             {
                 threw = true;
                 CHECK(e.code() == questdb_error_invalid_api_call);
-                CHECK(std::string{e.what()}.find("cursor") !=
-                      std::string::npos);
+                CHECK(
+                    std::string{e.what()}.find("cursor") != std::string::npos);
             }
             CHECK(threw);
         };
-        expect_live_cursor_error([&]{ (void)reader.server_version(); });
-        expect_live_cursor_error([&]{ (void)reader.server_info(); });
-        expect_live_cursor_error([&]{ (void)reader.current_host(); });
-        expect_live_cursor_error([&]{ (void)reader.current_port(); });
+        expect_live_cursor_error([&] { (void)reader.server_version(); });
+        expect_live_cursor_error([&] { (void)reader.server_info(); });
+        expect_live_cursor_error([&] { (void)reader.current_host(); });
+        expect_live_cursor_error([&] { (void)reader.current_port(); });
 
         // The cursor handle owns the borrow — its mirror getters are the
         // sound path for the same metadata.
@@ -3030,8 +3214,7 @@ TEST_CASE("mock: reader metadata getters reject while a cursor is live")
 // frame is sent.
 // ---------------------------------------------------------------------------
 
-TEST_CASE(
-    "mock: every supported bind variant marshals through the FFI ABI")
+TEST_CASE("mock: every supported bind variant marshals through the FFI ABI")
 {
     qm::Script s = {
         qm::ActionSendServerInfo{},
@@ -3042,63 +3225,73 @@ TEST_CASE(
     auto reader = connect_to(srv);
 
     const std::array<uint8_t, 16> kUuid = {
-        0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7,
-        0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF,
+        0xA0,
+        0xA1,
+        0xA2,
+        0xA3,
+        0xA4,
+        0xA5,
+        0xA6,
+        0xA7,
+        0xA8,
+        0xA9,
+        0xAA,
+        0xAB,
+        0xAC,
+        0xAD,
+        0xAE,
+        0xAF,
     };
     const std::array<uint8_t, 32> kLong256 = {
-        0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87,
-        0x88, 0x89, 0x8A, 0x8B, 0x8C, 0x8D, 0x8E, 0x8F,
-        0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97,
-        0x98, 0x99, 0x9A, 0x9B, 0x9C, 0x9D, 0x9E, 0x9F,
+        0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8A,
+        0x8B, 0x8C, 0x8D, 0x8E, 0x8F, 0x90, 0x91, 0x92, 0x93, 0x94, 0x95,
+        0x96, 0x97, 0x98, 0x99, 0x9A, 0x9B, 0x9C, 0x9D, 0x9E, 0x9F,
     };
     const std::array<uint8_t, 32> kDecimal256 = {
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-        0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
-        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
-        0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
+        0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+        0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
     };
 
-    auto cur = reader.prepare("X"_utf8)
-                   .bind_bool(true)
-                   .bind_i8(static_cast<int8_t>(-13))
-                   .bind_i16(static_cast<int16_t>(0x1234))
-                   .bind_i32(static_cast<int32_t>(0x01020304))
-                   .bind_i64(static_cast<int64_t>(0x0102030405060708LL))
-                   .bind_f32(1.0f)
-                   .bind_f64(1.0)
-                   .bind_timestamp_micros(
-                       static_cast<int64_t>(0x1100AABBCCDDEEFFLL))
-                   .bind_timestamp_nanos(
-                       static_cast<int64_t>(0x2200AABBCCDDEEFFLL))
-                   .bind_date_millis(
-                       static_cast<int64_t>(0x3300AABBCCDDEEFFLL))
-                   .bind_uuid(kUuid)
-                   .bind_long256(kLong256)
-                   .bind_char(static_cast<uint16_t>(0xCAFE))
-                   .bind_decimal64(
-                       static_cast<int64_t>(0x4400AABBCCDDEEFFLL),
-                       static_cast<int8_t>(5))
-                   // `mantissa_lo` is u64 (low limb), `mantissa_hi` is i64
-                   // (sign-extends into the i128). The wire form is the
-                   // i128 in little-endian, so the captured bytes are
-                   // `lo_le` followed by `hi_le`.
-                   .bind_decimal128(
-                       static_cast<uint64_t>(0x1122334455667788ULL),
-                       static_cast<int64_t>(0x6655443322110000LL),
-                       static_cast<int8_t>(7))
-                   .bind_decimal256(kDecimal256, static_cast<int8_t>(9))
-                   .bind_geohash(
-                       static_cast<uint64_t>(0x1F),
-                       static_cast<uint8_t>(5))
-                   .bind_varchar("hello"_utf8)
-                   .bind_null(::questdb::egress::column_kind::int_)
-                   .bind_null_varchar()
-                   .bind_null_decimal64(static_cast<int8_t>(3))
-                   .bind_null_decimal128(static_cast<int8_t>(11))
-                   .bind_null_decimal256(static_cast<int8_t>(13))
-                   .bind_null_geohash(static_cast<uint8_t>(7))
-                   .execute();
-    while (cur.next_batch()) {}
+    auto cur =
+        reader.prepare("X"_utf8)
+            .bind_bool(true)
+            .bind_i8(static_cast<int8_t>(-13))
+            .bind_i16(static_cast<int16_t>(0x1234))
+            .bind_i32(static_cast<int32_t>(0x01020304))
+            .bind_i64(static_cast<int64_t>(0x0102030405060708LL))
+            .bind_f32(1.0f)
+            .bind_f64(1.0)
+            .bind_timestamp_micros(static_cast<int64_t>(0x1100AABBCCDDEEFFLL))
+            .bind_timestamp_nanos(static_cast<int64_t>(0x2200AABBCCDDEEFFLL))
+            .bind_date_millis(static_cast<int64_t>(0x3300AABBCCDDEEFFLL))
+            .bind_uuid(kUuid)
+            .bind_long256(kLong256)
+            .bind_char(static_cast<uint16_t>(0xCAFE))
+            .bind_decimal64(
+                static_cast<int64_t>(0x4400AABBCCDDEEFFLL),
+                static_cast<int8_t>(5))
+            // `mantissa_lo` is u64 (low limb), `mantissa_hi` is i64
+            // (sign-extends into the i128). The wire form is the
+            // i128 in little-endian, so the captured bytes are
+            // `lo_le` followed by `hi_le`.
+            .bind_decimal128(
+                static_cast<uint64_t>(0x1122334455667788ULL),
+                static_cast<int64_t>(0x6655443322110000LL),
+                static_cast<int8_t>(7))
+            .bind_decimal256(kDecimal256, static_cast<int8_t>(9))
+            .bind_geohash(static_cast<uint64_t>(0x1F), static_cast<uint8_t>(5))
+            .bind_varchar("hello"_utf8)
+            .bind_null(::questdb::egress::column_kind::int_)
+            .bind_null_varchar()
+            .bind_null_decimal64(static_cast<int8_t>(3))
+            .bind_null_decimal128(static_cast<int8_t>(11))
+            .bind_null_decimal256(static_cast<int8_t>(13))
+            .bind_null_geohash(static_cast<uint8_t>(7))
+            .execute();
+    while (cur.next_batch())
+    {
+    }
 
     auto reqs = srv.captured_requests();
     REQUIRE(reqs.size() == 1);
@@ -3109,7 +3302,8 @@ TEST_CASE(
     // post-preamble offset.
     std::vector<uint8_t> exp;
     auto put = [&](std::initializer_list<uint8_t> bs) {
-        for (auto b : bs) exp.push_back(b);
+        for (auto b : bs)
+            exp.push_back(b);
     };
     auto put_bytes = [&](const uint8_t* p, size_t n) {
         exp.insert(exp.end(), p, p + n);
@@ -3138,43 +3332,53 @@ TEST_CASE(
     };
 
     // Type codes mirror `ColumnKind::as_u8` in `column_kind.rs`.
-    constexpr uint8_t kBool = 0x01, kByte = 0x02, kShort = 0x03,
-                      kInt = 0x04, kLong = 0x05, kFloat = 0x06,
-                      kDouble = 0x07, kTimestamp = 0x0A, kDate = 0x0B,
-                      kUuidKind = 0x0C, kLong256Kind = 0x0D,
-                      kGeohash = 0x0E, kVarchar = 0x0F,
+    constexpr uint8_t kBool = 0x01, kByte = 0x02, kShort = 0x03, kInt = 0x04,
+                      kLong = 0x05, kFloat = 0x06, kDouble = 0x07,
+                      kTimestamp = 0x0A, kDate = 0x0B, kUuidKind = 0x0C,
+                      kLong256Kind = 0x0D, kGeohash = 0x0E, kVarchar = 0x0F,
                       kTimestampNanos = 0x10, kDecimal64 = 0x13,
-                      kDecimal128 = 0x14, kDecimal256Kind = 0x15,
-                      kChar = 0x16;
+                      kDecimal128 = 0x14, kDecimal256Kind = 0x15, kChar = 0x16;
 
     // 1. bool(true) -> [kBool, 0x00, 0x01]
     put({kBool, 0x00, 0x01});
     // 2. i8(-13)
     put({kByte, 0x00, static_cast<uint8_t>(int8_t(-13))});
     // 3. i16(0x1234)
-    put({kShort, 0x00}); put_u16_le(0x1234);
+    put({kShort, 0x00});
+    put_u16_le(0x1234);
     // 4. i32(0x01020304)
-    put({kInt, 0x00}); put_u32_le(0x01020304U);
+    put({kInt, 0x00});
+    put_u32_le(0x01020304U);
     // 5. i64(0x0102030405060708)
-    put({kLong, 0x00}); put_u64_le(0x0102030405060708ULL);
+    put({kLong, 0x00});
+    put_u64_le(0x0102030405060708ULL);
     // 6. f32(1.0)
-    put({kFloat, 0x00}); put_f32_le(1.0f);
+    put({kFloat, 0x00});
+    put_f32_le(1.0f);
     // 7. f64(1.0)
-    put({kDouble, 0x00}); put_f64_le(1.0);
+    put({kDouble, 0x00});
+    put_f64_le(1.0);
     // 8. timestamp_micros
-    put({kTimestamp, 0x00}); put_u64_le(0x1100AABBCCDDEEFFULL);
+    put({kTimestamp, 0x00});
+    put_u64_le(0x1100AABBCCDDEEFFULL);
     // 9. timestamp_nanos
-    put({kTimestampNanos, 0x00}); put_u64_le(0x2200AABBCCDDEEFFULL);
+    put({kTimestampNanos, 0x00});
+    put_u64_le(0x2200AABBCCDDEEFFULL);
     // 10. date_millis
-    put({kDate, 0x00}); put_u64_le(0x3300AABBCCDDEEFFULL);
+    put({kDate, 0x00});
+    put_u64_le(0x3300AABBCCDDEEFFULL);
     // 11. uuid (16 raw bytes, verbatim)
-    put({kUuidKind, 0x00}); put_bytes(kUuid.data(), kUuid.size());
+    put({kUuidKind, 0x00});
+    put_bytes(kUuid.data(), kUuid.size());
     // 12. long256 (32 raw bytes, verbatim)
-    put({kLong256Kind, 0x00}); put_bytes(kLong256.data(), kLong256.size());
+    put({kLong256Kind, 0x00});
+    put_bytes(kLong256.data(), kLong256.size());
     // 13. char(0xCAFE) - u16 LE
-    put({kChar, 0x00}); put_u16_le(0xCAFE);
+    put({kChar, 0x00});
+    put_u16_le(0xCAFE);
     // 14. decimal64(value, scale=5): [type, 0x00, scale, ...8 LE...]
-    put({kDecimal64, 0x00, 0x05}); put_u64_le(0x4400AABBCCDDEEFFULL);
+    put({kDecimal64, 0x00, 0x05});
+    put_u64_le(0x4400AABBCCDDEEFFULL);
     // 15. decimal128(lo, hi, scale=7): [type, 0x00, scale, lo_le(8), hi_le(8)]
     put({kDecimal128, 0x00, 0x07});
     put_u64_le(0x1122334455667788ULL);
@@ -3184,7 +3388,8 @@ TEST_CASE(
     put_bytes(kDecimal256.data(), kDecimal256.size());
     // 17. geohash(0x1F, prec=5): [type, 0x00, varint(5), ceil(5/8)=1 byte LE]
     put({kGeohash, 0x00, 0x05, 0x1F});
-    // 18. varchar("hello"): [type, 0x00, u32_le(0), u32_le(5), 'h','e','l','l','o']
+    // 18. varchar("hello"): [type, 0x00, u32_le(0), u32_le(5),
+    // 'h','e','l','l','o']
     put({kVarchar, 0x00});
     put_u32_le(0);
     put_u32_le(5);
@@ -3208,16 +3413,17 @@ TEST_CASE(
     REQUIRE(req.size() == kPreambleLen + exp.size());
     CHECK(req[0] == qm::MSG_QUERY_REQUEST);
     // req[1..9] is the request_id (i64 LE); non-deterministic, skip.
-    CHECK(req[9] == 0x01);           // sql_len varint
-    CHECK(req[10] == 'X');           // sql byte
-    CHECK(req[11] == 0x00);          // initial_credit varint
-    CHECK(req[12] == kBindCount);    // bind_count varint
+    CHECK(req[9] == 0x01);        // sql_len varint
+    CHECK(req[10] == 'X');        // sql byte
+    CHECK(req[11] == 0x00);       // initial_credit varint
+    CHECK(req[12] == kBindCount); // bind_count varint
 
     for (size_t i = 0; i < exp.size(); ++i)
     {
         // Per-byte CHECK so a diff localises to the failing bind.
-        CHECK_MESSAGE(req[kPreambleLen + i] == exp[i],
-                      "bind payload mismatch at byte " << i);
+        CHECK_MESSAGE(
+            req[kPreambleLen + i] == exp[i],
+            "bind payload mismatch at byte " << i);
     }
 }
 
@@ -3260,7 +3466,8 @@ TEST_CASE(
     // observe motion in `bytes_received`.
     constexpr int kBatches = 32;
     qm::ColumnSpec col{
-        "v", qm::COL_INT,
+        "v",
+        qm::COL_INT,
         qm::fixed_column_bytes(4, pack_le<int32_t>({1, 2, 3, 4}))};
     // `emplace_back` (not `push_back`) forwards the alternative directly
     // to `qm::Action`'s converting variant constructor, constructing in
@@ -3277,10 +3484,10 @@ TEST_CASE(
     s.emplace_back(qm::ActionAwaitQueryRequest{});
     for (int i = 0; i < kBatches; ++i)
     {
-        s.emplace_back(qm::ActionSendBuilt{
-            [col, i](int64_t rid)
-            { return qm::result_batch_frame(
-                  rid, static_cast<uint64_t>(i), 4, {col}); }});
+        s.emplace_back(qm::ActionSendBuilt{[col, i](int64_t rid) {
+            return qm::result_batch_frame(
+                rid, static_cast<uint64_t>(i), 4, {col});
+        }});
     }
     s.emplace_back(qm::ActionSendResultEnd{});
 
@@ -3296,25 +3503,23 @@ TEST_CASE(
     // `Arc<ReaderStats>` field — no overlapping non-atomic accesses,
     // so the C++ object model permits concurrent const + non-const
     // method calls on this specific reader.
-    std::thread worker(
-        [&reader, &done, &worker_err]()
+    std::thread worker([&reader, &done, &worker_err]() {
+        try
         {
-            try
+            auto cur = reader.execute("select v"_utf8);
+            // Drain every batch + the terminal RESULT_END.
+            while (cur.next_batch())
             {
-                auto cur = reader.execute("select v"_utf8);
-                // Drain every batch + the terminal RESULT_END.
-                while (cur.next_batch())
-                {
-                }
             }
-            catch (...)
-            {
-                // doctest macros are reserved for the main thread;
-                // surface the failure by rethrowing post-join.
-                worker_err = std::current_exception();
-            }
-            done.store(true, std::memory_order_release);
-        });
+        }
+        catch (...)
+        {
+            // doctest macros are reserved for the main thread;
+            // surface the failure by rethrowing post-join.
+            worker_err = std::current_exception();
+        }
+        done.store(true, std::memory_order_release);
+    });
 
     uint64_t last_bytes = 0;
     uint64_t max_observed_bytes = 0;
@@ -3364,7 +3569,8 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "mock: query and cursor migrate across threads with callbacks and destruction")
+    "mock: query and cursor migrate across threads with callbacks and "
+    "destruction")
 {
     qm::Script s_a = {
         qm::ActionSendServerInfo{qm::ROLE_STANDALONE, "c", "a"},
@@ -3418,16 +3624,13 @@ TEST_CASE(
     auto progress_payload = std::make_shared<ProgressCallbackPayload>();
     progress_payload->record = record;
     auto query = reader.prepare("select 1"_utf8);
-    query.on_failover_reset(
-        [reset_payload](const eg::failover_reset_event_view&)
-        {
-            std::lock_guard<std::mutex> guard{reset_payload->record->mutex};
-            reset_payload->record->reset_callback_on =
-                std::this_thread::get_id();
-        });
+    query.on_failover_reset([reset_payload](
+                                const eg::failover_reset_event_view&) {
+        std::lock_guard<std::mutex> guard{reset_payload->record->mutex};
+        reset_payload->record->reset_callback_on = std::this_thread::get_id();
+    });
     query.on_failover_progress(
-        [progress_payload](const eg::failover_progress_event_view&)
-        {
+        [progress_payload](const eg::failover_progress_event_view&) {
             std::lock_guard<std::mutex> guard{progress_payload->record->mutex};
             progress_payload->record->progress_callback_on =
                 std::this_thread::get_id();
@@ -3441,22 +3644,20 @@ TEST_CASE(
     std::optional<eg::cursor> cursor;
     std::thread::id execute_thread;
     std::exception_ptr execute_error;
-    std::thread execute_worker(
-        [query = std::move(query),
-         &cursor,
-         &execute_thread,
-         &execute_error]() mutable
+    std::thread execute_worker([query = std::move(query),
+                                &cursor,
+                                &execute_thread,
+                                &execute_error]() mutable {
+        execute_thread = std::this_thread::get_id();
+        try
         {
-            execute_thread = std::this_thread::get_id();
-            try
-            {
-                cursor.emplace(query.execute());
-            }
-            catch (...)
-            {
-                execute_error = std::current_exception();
-            }
-        });
+            cursor.emplace(query.execute());
+        }
+        catch (...)
+        {
+            execute_error = std::current_exception();
+        }
+    });
     execute_worker.join();
     if (execute_error)
         std::rethrow_exception(execute_error);
@@ -3467,24 +3668,22 @@ TEST_CASE(
     cursor.reset();
     std::thread::id drive_thread;
     std::exception_ptr drive_error;
-    std::thread drive_worker(
-        [cursor = std::move(migrated_cursor),
-         &drive_thread,
-         &drive_error]() mutable
+    std::thread drive_worker([cursor = std::move(migrated_cursor),
+                              &drive_thread,
+                              &drive_error]() mutable {
+        drive_thread = std::this_thread::get_id();
+        try
         {
-            drive_thread = std::this_thread::get_id();
-            try
+            while (cursor.next_batch())
             {
-                while (cursor.next_batch())
-                {
-                }
             }
-            catch (...)
-            {
-                drive_error = std::current_exception();
-            }
-            // `cursor` and its heap-stored callbacks are destroyed here.
-        });
+        }
+        catch (...)
+        {
+            drive_error = std::current_exception();
+        }
+        // `cursor` and its heap-stored callbacks are destroyed here.
+    });
     drive_worker.join();
     if (drive_error)
         std::rethrow_exception(drive_error);
@@ -3508,7 +3707,9 @@ TEST_CASE(
 // Rust mock can't drive (no synthetic RESULT_BATCH helper).
 // ---------------------------------------------------------------------------
 
-TEST_CASE("mock: progress callback observes Disconnected -> Retrying -> Reset on successful failover")
+TEST_CASE(
+    "mock: progress callback observes Disconnected -> Retrying -> Reset on "
+    "successful failover")
 {
     qm::Script s_a = {
         qm::ActionSendServerInfo{qm::ROLE_STANDALONE, "c", "a"},
@@ -3544,39 +3745,40 @@ TEST_CASE("mock: progress callback observes Disconnected -> Retrying -> Reset on
     };
     auto events = std::make_shared<std::vector<Capture>>();
 
-    auto cur = reader.prepare("select 1"_utf8)
-                   .on_failover_progress(
-                       [events](const questdb::egress::failover_progress_event_view& ev)
-                       {
-                           const auto server_info = ev.server_info();
-                           events->push_back({
-                               ev.phase(),
-                               ev.attempt(),
-                               std::string(ev.failed_host()),
-                               ev.failed_port(),
-                               std::string(ev.new_host()),
-                               ev.new_port(),
-                               ev.new_request_id(),
-                               ev.final_error_code().has_value(),
-                               static_cast<bool>(server_info),
-                               server_info.role(),
-                               server_info.snapshot().has_value(),
-                           });
-                       })
-                   .execute();
+    auto cur =
+        reader.prepare("select 1"_utf8)
+            .on_failover_progress(
+                [events](
+                    const questdb::egress::failover_progress_event_view& ev) {
+                    const auto server_info = ev.server_info();
+                    events->push_back({
+                        ev.phase(),
+                        ev.attempt(),
+                        std::string(ev.failed_host()),
+                        ev.failed_port(),
+                        std::string(ev.new_host()),
+                        ev.new_port(),
+                        ev.new_request_id(),
+                        ev.final_error_code().has_value(),
+                        static_cast<bool>(server_info),
+                        server_info.role(),
+                        server_info.snapshot().has_value(),
+                    });
+                })
+            .execute();
     CHECK_FALSE(cur.next_batch());
     CHECK(cur.failover_resets() == 1);
 
     REQUIRE(events->size() >= 3);
     // First event: Disconnected with attempt=0, no new_addr.
-    CHECK(events->front().phase == questdb::egress::failover_phase::disconnected);
+    CHECK(
+        events->front().phase == questdb::egress::failover_phase::disconnected);
     CHECK(events->front().attempt == 0);
     CHECK(events->front().new_port == 0);
     CHECK_FALSE(events->front().new_request_id.has_value());
     CHECK_FALSE(events->front().has_final_error);
     CHECK_FALSE(events->front().server_info_present);
-    CHECK(events->front().server_role ==
-          questdb::egress::server_role::other);
+    CHECK(events->front().server_role == questdb::egress::server_role::other);
     CHECK_FALSE(events->front().snapshot_present);
 
     // At least one Retrying event with attempt >= 1.
@@ -3619,7 +3821,9 @@ TEST_CASE("mock: progress callback observes Disconnected -> Retrying -> Reset on
     }
 }
 
-TEST_CASE("mock: progress callback fires GaveUp with final_error on budget exhaustion")
+TEST_CASE(
+    "mock: progress callback fires GaveUp with final_error on budget "
+    "exhaustion")
 {
     qm::Script s_initial = {
         qm::ActionSendServerInfo{qm::ROLE_STANDALONE, "c", "lonely"},
@@ -3629,7 +3833,8 @@ TEST_CASE("mock: progress callback fires GaveUp with final_error on budget exhau
     qm::Script s_dead = {qm::ActionHardDrop{}};
     qm::MockServer srv({s_initial, s_dead});
 
-    const std::string conf = "ws::addr=" + srv.addr() +
+    const std::string conf =
+        "ws::addr=" + srv.addr() +
         ";failover_max_attempts=3;failover_backoff_initial_ms=1;"
         "failover_backoff_max_ms=2";
     questdb::egress::reader reader{questdb::ingress::utf8_view{conf}};
@@ -3644,27 +3849,28 @@ TEST_CASE("mock: progress callback fires GaveUp with final_error on budget exhau
     };
     auto cap = std::make_shared<GaveUp>();
 
-    auto cur = reader.prepare("select 1"_utf8)
-                   .on_failover_progress(
-                       [cap](const questdb::egress::failover_progress_event_view& ev)
-                       {
-                           if (ev.phase() ==
-                               questdb::egress::failover_phase::gave_up)
-                           {
-                               cap->fired = true;
-                               cap->attempt = ev.attempt();
-                               if (auto c = ev.final_error_code())
-                                   cap->final_code =
-                                       static_cast<questdb_error_code>(*c);
-                               cap->final_msg = std::string(ev.final_error_msg());
-                               cap->elapsed_ns = ev.elapsed_ns();
-                           }
-                       })
-                   .execute();
+    auto cur =
+        reader.prepare("select 1"_utf8)
+            .on_failover_progress(
+                [cap](const questdb::egress::failover_progress_event_view& ev) {
+                    if (ev.phase() == questdb::egress::failover_phase::gave_up)
+                    {
+                        cap->fired = true;
+                        cap->attempt = ev.attempt();
+                        if (auto c = ev.final_error_code())
+                            cap->final_code =
+                                static_cast<questdb_error_code>(*c);
+                        cap->final_msg = std::string(ev.final_error_msg());
+                        cap->elapsed_ns = ev.elapsed_ns();
+                    }
+                })
+            .execute();
     bool threw = false;
     try
     {
-        while (cur.next_batch()) {}
+        while (cur.next_batch())
+        {
+        }
     }
     catch (const questdb::error&)
     {
@@ -3675,13 +3881,16 @@ TEST_CASE("mock: progress callback fires GaveUp with final_error on budget exhau
     CHECK(cap->fired);
     CHECK(cap->attempt >= 1);
     REQUIRE(cap->final_code.has_value());
-    CHECK((*cap->final_code == questdb_error_socket_error ||
-           *cap->final_code == questdb_error_protocol_error));
+    CHECK(
+        (*cap->final_code == questdb_error_socket_error ||
+         *cap->final_code == questdb_error_protocol_error));
     CHECK_FALSE(cap->final_msg.empty());
     CHECK(cap->elapsed_ns > 0);
 }
 
-TEST_CASE("mock: progress callback alone does not authorize replay-after-data-delivered")
+TEST_CASE(
+    "mock: progress callback alone does not authorize "
+    "replay-after-data-delivered")
 {
     // The Rust mock has no helper to emit a synthetic RESULT_BATCH; the
     // C++ mock does. This pins the distinction between telemetry and the
@@ -3691,8 +3900,9 @@ TEST_CASE("mock: progress callback alone does not authorize replay-after-data-de
     qm::Script s_a = {
         qm::ActionSendServerInfo{qm::ROLE_STANDALONE, "c", "a"},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[col](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {col}); }},
+        qm::ActionSendBuilt{[col](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {col});
+        }},
         qm::ActionHardDrop{},
     };
     qm::Script s_b = {
@@ -3709,18 +3919,17 @@ TEST_CASE("mock: progress callback alone does not authorize replay-after-data-de
     questdb::egress::reader reader{questdb::ingress::utf8_view{conf}};
 
     std::atomic<int> reset_phase_count{0};
-    auto cur = reader.prepare("select v"_utf8)
-                   .on_failover_progress(
-                       [&reset_phase_count](
-                           const questdb::egress::failover_progress_event_view& ev)
-                       {
-                           if (ev.phase() ==
-                               questdb::egress::failover_phase::reset)
-                           {
-                               reset_phase_count.fetch_add(1);
-                           }
-                       })
-                   .execute();
+    auto cur =
+        reader.prepare("select v"_utf8)
+            .on_failover_progress(
+                [&reset_phase_count](
+                    const questdb::egress::failover_progress_event_view& ev) {
+                    if (ev.phase() == questdb::egress::failover_phase::reset)
+                    {
+                        reset_phase_count.fetch_add(1);
+                    }
+                })
+            .execute();
     // First batch lands cleanly on A.
     REQUIRE(cur.next_batch());
     // The progress callback observes lifecycle events but cannot discard the
@@ -3740,7 +3949,8 @@ TEST_CASE("mock: progress callback alone does not authorize replay-after-data-de
     CHECK(reset_phase_count.load() == 0);
 }
 
-TEST_CASE("mock: progress callback noexcept trampoline swallows user exceptions")
+TEST_CASE(
+    "mock: progress callback noexcept trampoline swallows user exceptions")
 {
     qm::Script s_a = {
         qm::ActionSendServerInfo{qm::ROLE_STANDALONE, "c", "a"},
@@ -3763,11 +3973,13 @@ TEST_CASE("mock: progress callback noexcept trampoline swallows user exceptions"
     // Throwing from inside the callback would unwind into the Rust FFI
     // frame and abort the process if the trampoline didn't swallow it.
     // Asserting we reach the post-execute code proves the swallow ran.
-    auto cur = reader.prepare("select 1"_utf8)
-                   .on_failover_progress(
-                       [](const questdb::egress::failover_progress_event_view&)
-                       { throw std::runtime_error("boom"); })
-                   .execute();
+    auto cur =
+        reader.prepare("select 1"_utf8)
+            .on_failover_progress(
+                [](const questdb::egress::failover_progress_event_view&) {
+                    throw std::runtime_error("boom");
+                })
+            .execute();
     CHECK_FALSE(cur.next_batch());
     CHECK(cur.failover_resets() == 1);
 }
@@ -3843,13 +4055,15 @@ TEST_CASE(
 TEST_CASE("mock: batch::column<int32_t> dense values match get_i32 per cell")
 {
     qm::ColumnSpec c{
-        "v", qm::COL_INT,
+        "v",
+        qm::COL_INT,
         qm::fixed_column_bytes(4, pack_le<int32_t>({-1, 0, 42, 2147483647}))};
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 4, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 4, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -3876,7 +4090,8 @@ TEST_CASE("mock: batch::column<int32_t> dense values match get_i32 per cell")
         CHECK(load_le(values + r) == batch.column(0).get<int32_t>(r).value());
 }
 
-TEST_CASE("mock: batch::column<varchar> offsets/data match get_varchar per cell")
+TEST_CASE(
+    "mock: batch::column<varchar> offsets/data match get_varchar per cell")
 {
     std::string a = "alpha";
     std::string bb = "beta-beta";
@@ -3893,17 +4108,20 @@ TEST_CASE("mock: batch::column<varchar> offsets/data match get_varchar per cell"
         for (int i = 0; i < 4; ++i)
             body.push_back(static_cast<uint8_t>(o >> (i * 8)));
     }
-    for (char ch : a) body.push_back(static_cast<uint8_t>(ch));
-    for (char ch : bb) body.push_back(static_cast<uint8_t>(ch));
-    for (char ch : c) body.push_back(static_cast<uint8_t>(ch));
+    for (char ch : a)
+        body.push_back(static_cast<uint8_t>(ch));
+    for (char ch : bb)
+        body.push_back(static_cast<uint8_t>(ch));
+    for (char ch : c)
+        body.push_back(static_cast<uint8_t>(ch));
 
     qm::ColumnSpec col_spec{"s", qm::COL_VARCHAR, std::move(body)};
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{
-            [col_spec](int64_t rid)
-            { return qm::result_batch_frame(rid, 0, 3, {col_spec}); }},
+        qm::ActionSendBuilt{[col_spec](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 3, {col_spec});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -3936,7 +4154,8 @@ TEST_CASE("mock: batch::column INT validity bitmap matches is_null per cell")
     // INT can, so use it to exercise the validity-bitmap path. 4 rows,
     // rows 1 and 3 NULL.
     qm::ColumnSpec c{
-        "v", qm::COL_INT,
+        "v",
+        qm::COL_INT,
         qm::fixed_column_bytes_nullable(
             /*row_count=*/4,
             /*is_null=*/std::vector<bool>{false, true, false, true},
@@ -3946,8 +4165,9 @@ TEST_CASE("mock: batch::column INT validity bitmap matches is_null per cell")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 4, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 4, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -3981,61 +4201,122 @@ TEST_CASE("mock: batch::column — every fixed-width scalar kind round-trip")
     using qm::ColumnSpec;
     using qm::fixed_column_bytes;
 
-    const std::array<uint8_t, 16> u0{{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-                                       0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E,
-                                       0x0F, 0x10}};
-    const std::array<uint8_t, 16> u1{{0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9,
-                                       0xF8, 0xF7, 0xF6, 0xF5, 0xF4, 0xF3, 0xF2,
-                                       0xF1, 0xF0}};
+    const std::array<uint8_t, 16> u0{
+        {0x01,
+         0x02,
+         0x03,
+         0x04,
+         0x05,
+         0x06,
+         0x07,
+         0x08,
+         0x09,
+         0x0A,
+         0x0B,
+         0x0C,
+         0x0D,
+         0x0E,
+         0x0F,
+         0x10}};
+    const std::array<uint8_t, 16> u1{
+        {0xFF,
+         0xFE,
+         0xFD,
+         0xFC,
+         0xFB,
+         0xFA,
+         0xF9,
+         0xF8,
+         0xF7,
+         0xF6,
+         0xF5,
+         0xF4,
+         0xF3,
+         0xF2,
+         0xF1,
+         0xF0}};
     std::vector<uint8_t> uuid_bytes;
     uuid_bytes.insert(uuid_bytes.end(), u0.begin(), u0.end());
     uuid_bytes.insert(uuid_bytes.end(), u1.begin(), u1.end());
 
     std::vector<uint8_t> long256_bytes(64, 0);
-    for (size_t i = 0; i < 32; ++i) long256_bytes[i] = static_cast<uint8_t>(i);
-    for (size_t i = 0; i < 32; ++i) long256_bytes[32 + i] = static_cast<uint8_t>(0x80 + i);
+    for (size_t i = 0; i < 32; ++i)
+        long256_bytes[i] = static_cast<uint8_t>(i);
+    for (size_t i = 0; i < 32; ++i)
+        long256_bytes[32 + i] = static_cast<uint8_t>(0x80 + i);
 
     // BOOLEAN: validity (1B: none) + bit-packed values (2 rows -> 1 byte).
     std::vector<uint8_t> bool_body{0x00, 0b00000010}; // row0=false, row1=true
     ColumnSpec c_bool{"b", qm::COL_BOOLEAN, std::move(bool_body)};
-    ColumnSpec c_byte{"by", qm::COL_BYTE,
-                      fixed_column_bytes(2, pack_le<int8_t>({-1, 42}))};
-    ColumnSpec c_short{"sh", qm::COL_SHORT,
-                       fixed_column_bytes(2, pack_le<int16_t>({-1234, 31000}))};
-    ColumnSpec c_char{"ch", qm::COL_CHAR,
-                      fixed_column_bytes(2, pack_le<uint16_t>({'A', 0x4E2D}))};
-    ColumnSpec c_int{"i", qm::COL_INT,
-                     fixed_column_bytes(2, pack_le<int32_t>({-7, 2147483647}))};
-    ColumnSpec c_ipv4{"ip", qm::COL_IPV4,
-                      fixed_column_bytes(2, pack_le<uint32_t>({0x7F000001u, 0xC0A80101u}))};
-    ColumnSpec c_long{"l", qm::COL_LONG,
-                      fixed_column_bytes(2, pack_le<int64_t>({-1, 9223372036854775807LL}))};
-    ColumnSpec c_f32{"f", qm::COL_FLOAT,
-                     fixed_column_bytes(2, pack_le<float>({1.25f, -0.5f}))};
-    ColumnSpec c_f64{"d", qm::COL_DOUBLE,
-                     fixed_column_bytes(2, pack_le<double>({1.5, -3.14}))};
-    ColumnSpec c_ts{"ts", qm::COL_TIMESTAMP,
-                    fixed_column_bytes(2, pack_le<int64_t>({1700000000000000LL, 1800000000000000LL}))};
-    ColumnSpec c_date{"dt", qm::COL_DATE,
-                      fixed_column_bytes(2, pack_le<int64_t>({0, 86400000LL}))};
-    ColumnSpec c_tsn{"tn", qm::COL_TIMESTAMP_NANOS,
-                     fixed_column_bytes(2, pack_le<int64_t>({1, 999999999LL}))};
+    ColumnSpec c_byte{
+        "by", qm::COL_BYTE, fixed_column_bytes(2, pack_le<int8_t>({-1, 42}))};
+    ColumnSpec c_short{
+        "sh",
+        qm::COL_SHORT,
+        fixed_column_bytes(2, pack_le<int16_t>({-1234, 31000}))};
+    ColumnSpec c_char{
+        "ch",
+        qm::COL_CHAR,
+        fixed_column_bytes(2, pack_le<uint16_t>({'A', 0x4E2D}))};
+    ColumnSpec c_int{
+        "i",
+        qm::COL_INT,
+        fixed_column_bytes(2, pack_le<int32_t>({-7, 2147483647}))};
+    ColumnSpec c_ipv4{
+        "ip",
+        qm::COL_IPV4,
+        fixed_column_bytes(2, pack_le<uint32_t>({0x7F000001u, 0xC0A80101u}))};
+    ColumnSpec c_long{
+        "l",
+        qm::COL_LONG,
+        fixed_column_bytes(2, pack_le<int64_t>({-1, 9223372036854775807LL}))};
+    ColumnSpec c_f32{
+        "f",
+        qm::COL_FLOAT,
+        fixed_column_bytes(2, pack_le<float>({1.25f, -0.5f}))};
+    ColumnSpec c_f64{
+        "d",
+        qm::COL_DOUBLE,
+        fixed_column_bytes(2, pack_le<double>({1.5, -3.14}))};
+    ColumnSpec c_ts{
+        "ts",
+        qm::COL_TIMESTAMP,
+        fixed_column_bytes(
+            2, pack_le<int64_t>({1700000000000000LL, 1800000000000000LL}))};
+    ColumnSpec c_date{
+        "dt",
+        qm::COL_DATE,
+        fixed_column_bytes(2, pack_le<int64_t>({0, 86400000LL}))};
+    ColumnSpec c_tsn{
+        "tn",
+        qm::COL_TIMESTAMP_NANOS,
+        fixed_column_bytes(2, pack_le<int64_t>({1, 999999999LL}))};
     ColumnSpec c_uuid{"u", qm::COL_UUID, fixed_column_bytes(2, uuid_bytes)};
-    ColumnSpec c_l256{"l256", qm::COL_LONG256,
-                      fixed_column_bytes(2, long256_bytes)};
+    ColumnSpec c_l256{
+        "l256", qm::COL_LONG256, fixed_column_bytes(2, long256_bytes)};
 
-    std::vector<ColumnSpec> cols{c_bool, c_byte, c_short, c_char, c_int,
-                                  c_ipv4, c_long, c_f32, c_f64, c_ts,
-                                  c_date, c_tsn, c_uuid, c_l256};
+    std::vector<ColumnSpec> cols{
+        c_bool,
+        c_byte,
+        c_short,
+        c_char,
+        c_int,
+        c_ipv4,
+        c_long,
+        c_f32,
+        c_f64,
+        c_ts,
+        c_date,
+        c_tsn,
+        c_uuid,
+        c_l256};
 
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[cols](int64_t rid)
-                            {
-                                return qm::result_batch_frame(
-                                    rid, 0, 2, cols);
-                            }},
+        qm::ActionSendBuilt{[cols](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 2, cols);
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -4153,35 +4434,46 @@ TEST_CASE("mock: batch::column — every fixed-width scalar kind round-trip")
     }
 }
 
-TEST_CASE("mock: batch::column — binary + decimal64/128/256 + geohash bulk vs per-cell")
+TEST_CASE(
+    "mock: batch::column — binary + decimal64/128/256 + geohash bulk vs "
+    "per-cell")
 {
     qm::ColumnSpec c_bin{
-        "bin", qm::COL_BINARY,
-        qm::varlen_column_bytes({{0xDE, 0xAD, 0xBE, 0xEF}, {0x00, 0x01, 0x02}})};
+        "bin",
+        qm::COL_BINARY,
+        qm::varlen_column_bytes(
+            {{0xDE, 0xAD, 0xBE, 0xEF}, {0x00, 0x01, 0x02}})};
 
     qm::ColumnSpec c_dec64{
-        "d64", qm::COL_DECIMAL64,
+        "d64",
+        qm::COL_DECIMAL64,
         qm::decimal64_column_bytes({12345, -67890}, /*scale=*/3)};
 
     // DECIMAL128 is the 16-byte two's-complement little-endian mantissa.
     std::array<uint8_t, 16> dec128_a{};
-    dec128_a[0] = 0x39; dec128_a[1] = 0x30; // 12345 LE
+    dec128_a[0] = 0x39;
+    dec128_a[1] = 0x30; // 12345 LE
     std::array<uint8_t, 16> dec128_b{};
-    for (auto& b : dec128_b) b = 0xFF; // -1 LE
+    for (auto& b : dec128_b)
+        b = 0xFF; // -1 LE
     qm::ColumnSpec c_dec128{
-        "d128", qm::COL_DECIMAL128,
+        "d128",
+        qm::COL_DECIMAL128,
         qm::decimal128_column_bytes({dec128_a, dec128_b}, /*scale=*/0)};
 
     std::array<uint8_t, 32> dec256_a{};
-    dec256_a[0] = 0x39; dec256_a[1] = 0x30;
+    dec256_a[0] = 0x39;
+    dec256_a[1] = 0x30;
     std::array<uint8_t, 32> dec256_b{};
     dec256_b[0] = 0x01;
     qm::ColumnSpec c_dec256{
-        "d256", qm::COL_DECIMAL256,
+        "d256",
+        qm::COL_DECIMAL256,
         qm::decimal256_column_bytes({dec256_a, dec256_b}, /*scale=*/2)};
 
     qm::ColumnSpec c_geo{
-        "g", qm::COL_GEOHASH,
+        "g",
+        qm::COL_GEOHASH,
         qm::geohash_column_bytes(
             std::vector<bool>{false, false},
             std::vector<uint8_t>{0xAB, 0xCD},
@@ -4191,11 +4483,9 @@ TEST_CASE("mock: batch::column — binary + decimal64/128/256 + geohash bulk vs 
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
         qm::ActionSendBuilt{
-            [c_bin, c_dec64, c_dec128, c_dec256, c_geo](int64_t rid)
-            {
+            [c_bin, c_dec64, c_dec128, c_dec256, c_geo](int64_t rid) {
                 return qm::result_batch_frame(
-                    rid, 0, 2,
-                    {c_bin, c_dec64, c_dec128, c_dec256, c_geo});
+                    rid, 0, 2, {c_bin, c_dec64, c_dec128, c_dec256, c_geo});
             }},
         qm::ActionSendResultEnd{},
     };
@@ -4276,11 +4566,9 @@ TEST_CASE("mock: batch::column — DOUBLE_ARRAY round-trip")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{
-            [c_da](int64_t rid)
-            {
-                return qm::result_batch_frame(rid, 0, 3, {c_da});
-            }},
+        qm::ActionSendBuilt{[c_da](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 3, {c_da});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -4326,20 +4614,20 @@ TEST_CASE("mock: batch::column — DOUBLE_ARRAY round-trip")
 TEST_CASE("mock: batch::symbol — column codes + dictionary bulk round-trip")
 {
     qm::ColumnSpec c_sym{
-        "s", qm::COL_SYMBOL,
-        qm::symbol_column_bytes({0u, 1u, 2u, 1u})};
+        "s", qm::COL_SYMBOL, qm::symbol_column_bytes({0u, 1u, 2u, 1u})};
 
     qm::Script script = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{
-            [c_sym](int64_t rid)
-            {
-                return qm::result_batch_frame_with_dict(
-                    rid, 0, 4, {c_sym},
-                    /*delta_start=*/0,
-                    {"alpha", "beta", "gamma"});
-            }},
+        qm::ActionSendBuilt{[c_sym](int64_t rid) {
+            return qm::result_batch_frame_with_dict(
+                rid,
+                0,
+                4,
+                {c_sym},
+                /*delta_start=*/0,
+                {"alpha", "beta", "gamma"});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({script});
@@ -4397,8 +4685,9 @@ TEST_CASE("mock: array accessors on a scalar column raise")
     qm::Script s = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{[c](int64_t rid)
-                            { return qm::result_batch_frame(rid, 0, 1, {c}); }},
+        qm::ActionSendBuilt{[c](int64_t rid) {
+            return qm::result_batch_frame(rid, 0, 1, {c});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({s});
@@ -4436,8 +4725,7 @@ TEST_CASE("decimal_view: mantissa_bytes is width-agnostic and null-safe")
         for (size_t i = 0; i < 2 * c.stride; ++i)
             values[i] = static_cast<uint8_t>(i + 1);
         const uint8_t validity = 0x02; // row 1 is NULL
-        const eg::decimal_view view{
-            c.kind, values, c.stride, 2, 3, &validity};
+        const eg::decimal_view view{c.kind, values, c.stride, 2, 3, &validity};
 
         const auto first = view.mantissa_bytes(0);
         REQUIRE(first.has_value());
@@ -4449,8 +4737,7 @@ TEST_CASE("decimal_view: mantissa_bytes is width-agnostic and null-safe")
     }
 }
 
-TEST_CASE(
-    "mock: column::visit dispatches to the matching typed view per kind")
+TEST_CASE("mock: column::visit dispatches to the matching typed view per kind")
 {
     // One batch covering one representative column per view family. visit
     // returns a stable discriminator string identifying which view branch
@@ -4471,32 +4758,41 @@ TEST_CASE(
     ColumnSpec c_double{
         "d", qm::COL_DOUBLE, fixed_column_bytes(1, pack_le<double>({3.5}))};
     ColumnSpec c_dec64{
-        "d64", qm::COL_DECIMAL64,
+        "d64",
+        qm::COL_DECIMAL64,
         qm::decimal64_column_bytes({12345}, /*scale=*/3)};
     ColumnSpec c_uuid{"u", qm::COL_UUID, fixed_column_bytes(1, uuid_bytes)};
     ColumnSpec c_geo{
-        "g", qm::COL_GEOHASH,
+        "g",
+        qm::COL_GEOHASH,
         qm::geohash_column_bytes(
             std::vector<bool>{false},
             std::vector<uint8_t>{0xAB},
             /*precision_bits=*/8)};
     ColumnSpec c_varchar{
         "s", qm::COL_VARCHAR, qm::varlen_column_bytes({{'h', 'i'}})};
-    ColumnSpec c_sym{
-        "sym", qm::COL_SYMBOL, qm::symbol_column_bytes({0u})};
+    ColumnSpec c_sym{"sym", qm::COL_SYMBOL, qm::symbol_column_bytes({0u})};
 
     qm::Script script = {
         qm::ActionSendServerInfo{},
         qm::ActionAwaitQueryRequest{},
-        qm::ActionSendBuilt{
-            [=](int64_t rid) {
-                return qm::result_batch_frame_with_dict(
-                    rid, 0, 1,
-                    {c_bool, c_int, c_long, c_double, c_dec64, c_uuid, c_geo,
-                     c_varchar, c_sym},
-                    /*delta_start=*/0,
-                    {"alpha"});
-            }},
+        qm::ActionSendBuilt{[=](int64_t rid) {
+            return qm::result_batch_frame_with_dict(
+                rid,
+                0,
+                1,
+                {c_bool,
+                 c_int,
+                 c_long,
+                 c_double,
+                 c_dec64,
+                 c_uuid,
+                 c_geo,
+                 c_varchar,
+                 c_sym},
+                /*delta_start=*/0,
+                {"alpha"});
+        }},
         qm::ActionSendResultEnd{},
     };
     qm::MockServer srv({script});
@@ -4508,23 +4804,24 @@ TEST_CASE(
     REQUIRE(batch.column_count() == 9);
 
     auto tag_of = [](const eg::column& col) -> std::string {
-        return col.visit(eg::overload{
-            [](eg::fixed_view<uint8_t>)  { return std::string{"bool"}; },
-            [](eg::fixed_view<int8_t>)   { return std::string{"byte"}; },
-            [](eg::fixed_view<int16_t>)  { return std::string{"short"}; },
-            [](eg::fixed_view<uint16_t>) { return std::string{"char"}; },
-            [](eg::fixed_view<int32_t>)  { return std::string{"i32"}; },
-            [](eg::fixed_view<uint32_t>) { return std::string{"ipv4"}; },
-            [](eg::fixed_view<int64_t>)  { return std::string{"i64"}; },
-            [](eg::fixed_view<float>)    { return std::string{"f32"}; },
-            [](eg::fixed_view<double>)   { return std::string{"f64"}; },
-            [](eg::decimal_view)         { return std::string{"decimal"}; },
-            [](eg::bytes_view)           { return std::string{"bytes"}; },
-            [](eg::geohash_view)         { return std::string{"geohash"}; },
-            [](eg::varlen_view)          { return std::string{"varlen"}; },
-            [](eg::symbol_view)          { return std::string{"symbol"}; },
-            [](eg::array_view<double>)   { return std::string{"darray"}; },
-        });
+        return col.visit(
+            eg::overload{
+                [](eg::fixed_view<uint8_t>) { return std::string{"bool"}; },
+                [](eg::fixed_view<int8_t>) { return std::string{"byte"}; },
+                [](eg::fixed_view<int16_t>) { return std::string{"short"}; },
+                [](eg::fixed_view<uint16_t>) { return std::string{"char"}; },
+                [](eg::fixed_view<int32_t>) { return std::string{"i32"}; },
+                [](eg::fixed_view<uint32_t>) { return std::string{"ipv4"}; },
+                [](eg::fixed_view<int64_t>) { return std::string{"i64"}; },
+                [](eg::fixed_view<float>) { return std::string{"f32"}; },
+                [](eg::fixed_view<double>) { return std::string{"f64"}; },
+                [](eg::decimal_view) { return std::string{"decimal"}; },
+                [](eg::bytes_view) { return std::string{"bytes"}; },
+                [](eg::geohash_view) { return std::string{"geohash"}; },
+                [](eg::varlen_view) { return std::string{"varlen"}; },
+                [](eg::symbol_view) { return std::string{"symbol"}; },
+                [](eg::array_view<double>) { return std::string{"darray"}; },
+            });
     };
 
     CHECK(tag_of(batch.column(0)) == "bool");
@@ -4538,41 +4835,46 @@ TEST_CASE(
     CHECK(tag_of(batch.column(8)) == "symbol");
 
     // Sanity: the dispatched view actually yields the right value.
-    batch.column(1).visit(eg::overload{
-        [](eg::fixed_view<int32_t> v) {
-            REQUIRE(v.row_count == 1);
-            REQUIRE_FALSE(v.is_null(0));
-            CHECK(load_le(v.values + 0) == 42);
-        },
-        [](auto&&) {
-            FAIL("INT column did not dispatch to fixed_view<int32_t>");
-        },
-    });
-    batch.column(4).visit(eg::overload{
-        [](eg::decimal_view v) {
-            CHECK(v.kind == eg::column_kind::decimal64);
-            CHECK(v.value_stride == 8);
-            CHECK(v.scale == 3);
-        },
-        [](auto&&) {
-            FAIL("DECIMAL64 column did not dispatch to decimal_view");
-        },
-    });
-    batch.column(8).visit(eg::overload{
-        [](eg::symbol_view v) {
-            const auto x = v.resolve(0);
-            REQUIRE(x);
-            CHECK(*x == "alpha");
-        },
-        [](auto&&) { FAIL("SYMBOL column did not dispatch to symbol_view"); },
-    });
+    batch.column(1).visit(
+        eg::overload{
+            [](eg::fixed_view<int32_t> v) {
+                REQUIRE(v.row_count == 1);
+                REQUIRE_FALSE(v.is_null(0));
+                CHECK(load_le(v.values + 0) == 42);
+            },
+            [](auto&&) {
+                FAIL("INT column did not dispatch to fixed_view<int32_t>");
+            },
+        });
+    batch.column(4).visit(
+        eg::overload{
+            [](eg::decimal_view v) {
+                CHECK(v.kind == eg::column_kind::decimal64);
+                CHECK(v.value_stride == 8);
+                CHECK(v.scale == 3);
+            },
+            [](auto&&) {
+                FAIL("DECIMAL64 column did not dispatch to decimal_view");
+            },
+        });
+    batch.column(8).visit(
+        eg::overload{
+            [](eg::symbol_view v) {
+                const auto x = v.resolve(0);
+                REQUIRE(x);
+                CHECK(*x == "alpha");
+            },
+            [](auto&&) {
+                FAIL("SYMBOL column did not dispatch to symbol_view");
+            },
+        });
 }
 
 TEST_CASE("mock: column::visit dispatches DOUBLE_ARRAY to array_view<double>")
 {
     qm::ArrayRow row0{{3}, pack_le<double>({1.5, 2.5, 3.5})};
-    auto body = qm::array_column_bytes(
-        {std::optional<qm::ArrayRow>{std::move(row0)}});
+    auto body =
+        qm::array_column_bytes({std::optional<qm::ArrayRow>{std::move(row0)}});
     qm::ColumnSpec c_da{"da", qm::COL_DOUBLE_ARRAY, std::move(body)};
     qm::Script s = {
         qm::ActionSendServerInfo{},
@@ -4588,24 +4890,25 @@ TEST_CASE("mock: column::visit dispatches DOUBLE_ARRAY to array_view<double>")
     auto batch_opt = cur.next_batch();
     REQUIRE(batch_opt);
 
-    batch_opt->column(0).visit(eg::overload{
-        [](eg::array_view<double> v) {
-            REQUIRE(v.row_count == 1);
-            const auto e = v.elements(0);
-            REQUIRE(e);
-            REQUIRE(e->second == 3);
-            CHECK(load_le(e->first + 0) == doctest::Approx(1.5));
-            CHECK(load_le(e->first + 1) == doctest::Approx(2.5));
-            CHECK(load_le(e->first + 2) == doctest::Approx(3.5));
-            const auto sh = v.shape(0);
-            REQUIRE(sh);
-            REQUIRE(sh->second == 1);
-            CHECK(load_le(sh->first + 0) == 3u);
-        },
-        [](auto&&) {
-            FAIL("DOUBLE_ARRAY did not dispatch to array_view<double>");
-        },
-    });
+    batch_opt->column(0).visit(
+        eg::overload{
+            [](eg::array_view<double> v) {
+                REQUIRE(v.row_count == 1);
+                const auto e = v.elements(0);
+                REQUIRE(e);
+                REQUIRE(e->second == 3);
+                CHECK(load_le(e->first + 0) == doctest::Approx(1.5));
+                CHECK(load_le(e->first + 1) == doctest::Approx(2.5));
+                CHECK(load_le(e->first + 2) == doctest::Approx(3.5));
+                const auto sh = v.shape(0);
+                REQUIRE(sh);
+                REQUIRE(sh->second == 1);
+                CHECK(load_le(sh->first + 0) == 3u);
+            },
+            [](auto&&) {
+                FAIL("DOUBLE_ARRAY did not dispatch to array_view<double>");
+            },
+        });
 }
 
 // ---------------------------------------------------------------------------

--- a/cpp_test/test_reader_offline.cpp
+++ b/cpp_test/test_reader_offline.cpp
@@ -39,7 +39,8 @@
 // would tautologically pass.
 // The expected numbers here are themselves cross-checked against the Rust enum
 // + C header by `c_header_line_sender_enum_matches_rust` in questdb-rs-ffi.
-static_assert(questdb_error_could_not_resolve_addr == 0, "client error alias drift");
+static_assert(
+    questdb_error_could_not_resolve_addr == 0, "client error alias drift");
 static_assert(questdb_error_invalid_api_call == 1, "client error alias drift");
 static_assert(questdb_error_socket_error == 2, "client error alias drift");
 static_assert(questdb_error_invalid_utf8 == 3, "client error alias drift");
@@ -49,17 +50,24 @@ static_assert(questdb_error_config_error == 10, "client error alias drift");
 static_assert(questdb_error_role_mismatch == 18, "client error alias drift");
 static_assert(questdb_error_connect_timeout == 19, "client error alias drift");
 static_assert(questdb_error_handshake_error == 20, "client error alias drift");
-static_assert(questdb_error_unsupported_server == 21, "client error alias drift");
+static_assert(
+    questdb_error_unsupported_server == 21, "client error alias drift");
 static_assert(questdb_error_protocol_error == 22, "client error alias drift");
 static_assert(questdb_error_invalid_bind == 23, "client error alias drift");
-static_assert(questdb_error_server_schema_mismatch == 24, "client error alias drift");
-static_assert(questdb_error_server_parse_error == 25, "client error alias drift");
-static_assert(questdb_error_server_internal_error == 26, "client error alias drift");
-static_assert(questdb_error_server_security_error == 27, "client error alias drift");
+static_assert(
+    questdb_error_server_schema_mismatch == 24, "client error alias drift");
+static_assert(
+    questdb_error_server_parse_error == 25, "client error alias drift");
+static_assert(
+    questdb_error_server_internal_error == 26, "client error alias drift");
+static_assert(
+    questdb_error_server_security_error == 27, "client error alias drift");
 static_assert(questdb_error_limit_exceeded == 28, "client error alias drift");
-static_assert(questdb_error_server_limit_exceeded == 29, "client error alias drift");
+static_assert(
+    questdb_error_server_limit_exceeded == 29, "client error alias drift");
 static_assert(questdb_error_cancelled == 30, "client error alias drift");
-static_assert(questdb_error_failover_would_duplicate == 31, "client error alias drift");
+static_assert(
+    questdb_error_failover_would_duplicate == 31, "client error alias drift");
 static_assert(questdb_error_schema_drift == 32, "client error alias drift");
 static_assert(questdb_error_no_schema == 33, "client error alias drift");
 static_assert(questdb_error_arrow_export == 34, "client error alias drift");
@@ -69,19 +77,25 @@ static_assert(questdb_error_arrow_export == 34, "client error alias drift");
 #include <string>
 
 #ifdef _WIN32
-#include <stdlib.h>
+#    include <stdlib.h>
 static int set_env(const char* name, const char* value)
 {
     return _putenv_s(name, value);
 }
-static int unset_env(const char* name) { return _putenv_s(name, ""); }
+static int unset_env(const char* name)
+{
+    return _putenv_s(name, "");
+}
 #else
-#include <stdlib.h>
+#    include <stdlib.h>
 static int set_env(const char* name, const char* value)
 {
     return setenv(name, value, 1);
 }
-static int unset_env(const char* name) { return unsetenv(name); }
+static int unset_env(const char* name)
+{
+    return unsetenv(name);
+}
 #endif
 
 using namespace questdb::ingress::literals;
@@ -168,8 +182,7 @@ TEST_CASE("reader stat / accessor getters return documented sentinels on NULL")
         bool ok = qwp_reader_server_version(nullptr, &version, &err);
         CHECK_FALSE(ok);
         REQUIRE(err != nullptr);
-        CHECK(questdb_error_get_code(err) ==
-              questdb_error_invalid_api_call);
+        CHECK(questdb_error_get_code(err) == questdb_error_invalid_api_call);
         questdb_error_free(err);
     }
     {
@@ -195,8 +208,7 @@ TEST_CASE("reader stat / accessor getters return documented sentinels on NULL")
 
 TEST_CASE("server_info accessors return documented sentinels on NULL")
 {
-    CHECK(qwp_reader_server_info_role(nullptr) ==
-          qwp_reader_server_role_other);
+    CHECK(qwp_reader_server_info_role(nullptr) == qwp_reader_server_role_other);
     CHECK(qwp_reader_server_info_role_byte(nullptr) == 0xFF);
     CHECK(qwp_reader_server_info_epoch(nullptr) == 0);
     CHECK(qwp_reader_server_info_capabilities(nullptr) == 0);
@@ -264,8 +276,9 @@ TEST_CASE("failover_event accessors return documented sentinels on NULL")
     CHECK(qwp_reader_failover_reset_event_elapsed_ns(nullptr) == 0);
 
     // _trigger_code mirrors `_error_get_code(NULL)`: same sentinel.
-    CHECK(qwp_reader_failover_reset_event_trigger_code(nullptr) ==
-          questdb_error_invalid_api_call);
+    CHECK(
+        qwp_reader_failover_reset_event_trigger_code(nullptr) ==
+        questdb_error_invalid_api_call);
 
     {
         const char* buf = reinterpret_cast<const char*>(0x1);
@@ -309,8 +322,7 @@ TEST_CASE("from_conf rejects malformed config strings as ConfigError")
         qwp_reader* r = qwp_reader_from_conf(conf, &err);
         REQUIRE(r == nullptr);
         REQUIRE(err != nullptr);
-        CHECK(questdb_error_get_code(err) ==
-              questdb_error_config_error);
+        CHECK(questdb_error_get_code(err) == questdb_error_config_error);
         size_t msg_len = 0;
         const char* msg = questdb_error_msg(err, &msg_len);
         CHECK(msg != nullptr);
@@ -361,8 +373,7 @@ TEST_CASE("from_env returns ConfigError when QDB_CLIENT_CONF is unset")
     qwp_reader* r = qwp_reader_from_env(&err);
     REQUIRE(r == nullptr);
     REQUIRE(err != nullptr);
-    CHECK(questdb_error_get_code(err) ==
-          questdb_error_config_error);
+    CHECK(questdb_error_get_code(err) == questdb_error_config_error);
 
     size_t msg_len = 0;
     const char* msg = questdb_error_msg(err, &msg_len);
@@ -379,8 +390,7 @@ TEST_CASE("from_env propagates parser errors when QDB_CLIENT_CONF is malformed")
     qwp_reader* r = qwp_reader_from_env(&err);
     REQUIRE(r == nullptr);
     REQUIRE(err != nullptr);
-    CHECK(questdb_error_get_code(err) ==
-          questdb_error_config_error);
+    CHECK(questdb_error_get_code(err) == questdb_error_config_error);
     questdb_error_free(err);
 
     REQUIRE(unset_env("QDB_CLIENT_CONF") == 0);
@@ -402,8 +412,7 @@ TEST_CASE("from_env distinguishes invalid-UTF-8 env value from unset")
     REQUIRE(err != nullptr);
     // Previously this collapsed to "not set" (ConfigError); the M-10 fix
     // surfaces the actual cause as InvalidUtf8.
-    CHECK(questdb_error_get_code(err) ==
-          questdb_error_invalid_utf8);
+    CHECK(questdb_error_get_code(err) == questdb_error_invalid_utf8);
     questdb_error_free(err);
 
     REQUIRE(unset_env("QDB_CLIENT_CONF") == 0);
@@ -420,8 +429,7 @@ TEST_CASE("from_env reaches the connect path when QDB_CLIENT_CONF is parseable")
     REQUIRE(err != nullptr);
     // We don't pin the code — connect-failure shape varies — but it must
     // NOT be ConfigError, since the config parsed successfully.
-    CHECK(questdb_error_get_code(err) !=
-          questdb_error_config_error);
+    CHECK(questdb_error_get_code(err) != questdb_error_config_error);
     questdb_error_free(err);
 
     REQUIRE(unset_env("QDB_CLIENT_CONF") == 0);

--- a/examples/bench_http_c.c
+++ b/examples/bench_http_c.c
@@ -1,7 +1,7 @@
 /* glibc hides XSI names (usleep) under strict -std=c11 (CMAKE_C_EXTENSIONS
  * OFF); macOS headers expose them unconditionally. */
 #if defined(__linux__)
-#define _XOPEN_SOURCE 600
+#    define _XOPEN_SOURCE 600
 #endif
 
 #include "bench_http_c.h"
@@ -12,7 +12,11 @@
 #include <time.h>
 #include <unistd.h>
 
-typedef struct { char* buf; size_t len; } body;
+typedef struct
+{
+    char* buf;
+    size_t len;
+} body;
 
 static size_t on_body(char* data, size_t sz, size_t nm, void* ud)
 {
@@ -30,7 +34,8 @@ static size_t on_body(char* data, size_t sz, size_t nm, void* ud)
 static long exec_get(const char* base, const char* sql, char** out)
 {
     CURL* c = curl_easy_init();
-    if (!c) return 0;
+    if (!c)
+        return 0;
     char* esc = curl_easy_escape(c, sql, 0);
     size_t ulen = strlen(base) + strlen(esc) + 32;
     char* url = malloc(ulen);
@@ -46,7 +51,10 @@ static long exec_get(const char* base, const char* sql, char** out)
     curl_free(esc);
     free(url);
     curl_easy_cleanup(c);
-    if (out) *out = b.buf; else free(b.buf);
+    if (out)
+        *out = b.buf;
+    else
+        free(b.buf);
     return status;
 }
 
@@ -54,9 +62,14 @@ int http_exec_sql(const char* base, const char* sql)
 {
     char* bdy = NULL;
     long status = exec_get(base, sql, &bdy);
-    if (status != 200) {
-        fprintf(stderr, "[bench_http] HTTP %ld for: %s\n%s\n",
-                status, sql, bdy ? bdy : "");
+    if (status != 200)
+    {
+        fprintf(
+            stderr,
+            "[bench_http] HTTP %ld for: %s\n%s\n",
+            status,
+            sql,
+            bdy ? bdy : "");
         free(bdy);
         return 1;
     }
@@ -72,24 +85,30 @@ static long long parse_count(const char* bdy)
     const char* p = NULL;
     for (const char* q = strstr(bdy, key); q; q = strstr(q + 1, key))
         p = q;
-    if (!p) return -1;
+    if (!p)
+        return -1;
     return atoll(p + strlen(key));
 }
 
-long long wait_for_count(const char* base, const char* table, long long expected)
+long long wait_for_count(
+    const char* base, const char* table, long long expected)
 {
     char sql[256];
     snprintf(sql, sizeof(sql), "SELECT count() FROM %s", table);
     time_t deadline = time(NULL) + 300;
     long long n = -1;
-    while (time(NULL) < deadline) {
+    while (time(NULL) < deadline)
+    {
         char* bdy = NULL;
-        if (exec_get(base, sql, &bdy) == 200 && bdy) {
+        if (exec_get(base, sql, &bdy) == 200 && bdy)
+        {
             long long c = parse_count(bdy);
-            if (c >= 0) n = c;
+            if (c >= 0)
+                n = c;
         }
         free(bdy);
-        if (n >= expected) return n;
+        if (n >= expected)
+            return n;
         usleep(500 * 1000);
     }
     return n;

--- a/examples/bench_http_c.h
+++ b/examples/bench_http_c.h
@@ -8,4 +8,5 @@ int http_exec_sql(const char* base, const char* sql);
 
 /* Poll `SELECT count() FROM {table}` every 500 ms until count >= expected or
  * 300 s elapse. Returns the last observed count (-1 if never parsed). */
-long long wait_for_count(const char* base, const char* table, long long expected);
+long long wait_for_count(
+    const char* base, const char* table, long long expected);

--- a/examples/bench_ingest_c.c
+++ b/examples/bench_ingest_c.c
@@ -7,7 +7,8 @@
 size_t env_zu(const char* name, size_t dflt)
 {
     const char* v = getenv(name);
-    if (!v || !*v) return dflt;
+    if (!v || !*v)
+        return dflt;
     char* end = NULL;
     unsigned long long n = strtoull(v, &end, 10);
     return (end && *end == 0) ? (size_t)n : dflt;
@@ -24,7 +25,8 @@ void bench_die(const char* prog, const char* what, line_sender_error* err)
     size_t len = 0;
     const char* msg = err ? line_sender_error_msg(err, &len) : "";
     fprintf(stderr, "[%s] %s failed: %.*s\n", prog, what, (int)len, msg);
-    if (err) line_sender_error_free(err);
+    if (err)
+        line_sender_error_free(err);
     exit(1);
 }
 
@@ -36,42 +38,85 @@ void sender_range(size_t rows, size_t n, size_t k, size_t* lo, size_t* hi)
 
 /* Append rows [start, start+n) of every column + the designated ts.
  * Chunk appends are zero-copy: the bench_data buffers outlive the flush. */
-void stage_batch(qwp_chunk* chunk, const bench_data* d,
-                 schema_kind kind, size_t start, size_t n,
-                 stage_scratch* scratch, const char* prog)
+void stage_batch(
+    qwp_chunk* chunk,
+    const bench_data* d,
+    schema_kind kind,
+    size_t start,
+    size_t n,
+    stage_scratch* scratch,
+    const char* prog)
 {
     line_sender_error* err = NULL;
     const qwp_validity* NOV = NULL;
     if (!qwp_chunk_column_i64(chunk, "id", 2, d->id + start, n, NOV, &err))
         bench_die(prog, "append id", err);
-    if (!qwp_chunk_column_f64(chunk, "price", 5, d->price + start, n, NOV, &err))
+    if (!qwp_chunk_column_f64(
+            chunk, "price", 5, d->price + start, n, NOV, &err))
         bench_die(prog, "append price", err);
-    if (!qwp_chunk_symbol_i32(chunk, "sym", 3, d->sym.codes + start, n,
-            d->sym.offsets, d->sym.card + 1, d->sym.bytes, d->sym.bytes_len, NOV, &err))
+    if (!qwp_chunk_symbol_i32(
+            chunk,
+            "sym",
+            3,
+            d->sym.codes + start,
+            n,
+            d->sym.offsets,
+            d->sym.card + 1,
+            d->sym.bytes,
+            d->sym.bytes_len,
+            NOV,
+            &err))
         bench_die(prog, "append sym", err);
     /* notes are fixed-length: rebased offsets are just i*varchar_len */
-    if (scratch->cap < n + 1) {
-        scratch->note_off = realloc(scratch->note_off, (n + 1) * sizeof(int32_t));
+    if (scratch->cap < n + 1)
+    {
+        scratch->note_off =
+            realloc(scratch->note_off, (n + 1) * sizeof(int32_t));
         scratch->cap = n + 1;
         for (size_t i = 0; i <= n; i++)
             scratch->note_off[i] = (int32_t)(i * d->varchar_len);
     }
-    if (!qwp_chunk_column_str(chunk, "note", 4, scratch->note_off,
-            d->note_bytes + start * d->varchar_len, n * d->varchar_len, n, NOV, &err))
+    if (!qwp_chunk_column_str(
+            chunk,
+            "note",
+            4,
+            scratch->note_off,
+            d->note_bytes + start * d->varchar_len,
+            n * d->varchar_len,
+            n,
+            NOV,
+            &err))
         bench_die(prog, "append note", err);
-    if (kind == SCHEMA_S2_WIDE) {
+    if (kind == SCHEMA_S2_WIDE)
+    {
         char name[4] = "d1";
-        for (size_t j = 0; j < N_WIDE_DOUBLES; j++) {
-            name[0] = 'd'; name[1] = (char)('1' + j); name[2] = 0;
-            if (!qwp_chunk_column_f64(chunk, name, 2,
-                    d->doubles[j] + start, n, NOV, &err))
+        for (size_t j = 0; j < N_WIDE_DOUBLES; j++)
+        {
+            name[0] = 'd';
+            name[1] = (char)('1' + j);
+            name[2] = 0;
+            if (!qwp_chunk_column_f64(
+                    chunk, name, 2, d->doubles[j] + start, n, NOV, &err))
                 bench_die(prog, "append dN", err);
         }
-        for (size_t j = 0; j < N_WIDE_SYMS; j++) {
-            name[0] = 's'; name[1] = (char)('1' + j); name[2] = 0;
+        for (size_t j = 0; j < N_WIDE_SYMS; j++)
+        {
+            name[0] = 's';
+            name[1] = (char)('1' + j);
+            name[2] = 0;
             const sym_col* c = &d->hi_syms[j];
-            if (!qwp_chunk_symbol_i32(chunk, name, 2, c->codes + start, n,
-                    c->offsets, c->card + 1, c->bytes, c->bytes_len, NOV, &err))
+            if (!qwp_chunk_symbol_i32(
+                    chunk,
+                    name,
+                    2,
+                    c->codes + start,
+                    n,
+                    c->offsets,
+                    c->card + 1,
+                    c->bytes,
+                    c->bytes_len,
+                    NOV,
+                    &err))
                 bench_die(prog, "append sN", err);
         }
     }
@@ -85,28 +130,38 @@ void stage_batch(qwp_chunk* chunk, const bench_data* d,
  * commit(ok) after the loop (mirrors flush_polars_dataframe's checkpoint
  * pipeline; the commit's no-progress wait is bounded by the pool's
  * request_timeout). */
-void ingest_pass(qwp_direct_sender* sender, qwp_chunk* chunk,
-                 const bench_data* d, schema_kind kind, size_t lo, size_t hi,
-                 size_t max_batch_rows, stage_scratch* scratch,
-                 const char* prog)
+void ingest_pass(
+    qwp_direct_sender* sender,
+    qwp_chunk* chunk,
+    const bench_data* d,
+    schema_kind kind,
+    size_t lo,
+    size_t hi,
+    size_t max_batch_rows,
+    stage_scratch* scratch,
+    const char* prog)
 {
     line_sender_error* err = NULL;
     size_t batch_no = 0;
-    for (size_t start = lo; start < hi; start += max_batch_rows) {
+    for (size_t start = lo; start < hi; start += max_batch_rows)
+    {
         size_t n = hi - start < max_batch_rows ? hi - start : max_batch_rows;
         stage_batch(chunk, d, kind, start, n, scratch, prog);
-        if (sender) {
-            if (!qwp_direct_sender_flush(sender, chunk, &err)) /* clears chunk */
+        if (sender)
+        {
+            if (!qwp_direct_sender_flush(
+                    sender, chunk, &err)) /* clears chunk */
                 bench_die(prog, "flush", err);
-            if (++batch_no % CHECKPOINT_BATCHES == 0
-                && !qwp_direct_sender_commit(sender, qwpws_ack_level_ok, &err))
+            if (++batch_no % CHECKPOINT_BATCHES == 0 &&
+                !qwp_direct_sender_commit(sender, qwpws_ack_level_ok, &err))
                 bench_die(prog, "checkpoint commit", err);
-        } else {
+        }
+        else
+        {
             if (!qwp_chunk_clear(chunk, &err))
                 bench_die(prog, "chunk clear", err);
         }
     }
-    if (sender
-        && !qwp_direct_sender_commit(sender, qwpws_ack_level_ok, &err))
+    if (sender && !qwp_direct_sender_commit(sender, qwpws_ack_level_ok, &err))
         bench_die(prog, "final commit", err);
 }

--- a/examples/bench_ingest_c.h
+++ b/examples/bench_ingest_c.h
@@ -14,7 +14,8 @@ void bench_die(const char* prog, const char* what, line_sender_error* err);
 /* Per-thread scratch for stage_batch's rebased note offsets (was a
  * function-level static — not thread-safe). Zero-init; caller frees
  * .note_off. */
-typedef struct {
+typedef struct
+{
     int32_t* note_off;
     size_t cap;
 } stage_scratch;
@@ -23,14 +24,25 @@ typedef struct {
 void sender_range(size_t rows, size_t n, size_t k, size_t* lo, size_t* hi);
 
 /* append rows [start, start+n) of every column + designated ts (zero-copy) */
-void stage_batch(qwp_chunk* chunk, const bench_data* d,
-                 schema_kind kind, size_t start, size_t n,
-                 stage_scratch* scratch, const char* prog);
+void stage_batch(
+    qwp_chunk* chunk,
+    const bench_data* d,
+    schema_kind kind,
+    size_t start,
+    size_t n,
+    stage_scratch* scratch,
+    const char* prog);
 /* one full pass over d: sender NULL = floor (stage+clear); else pipelined
  * direct flush per batch, commit(ok) checkpoint every CHECKPOINT_BATCHES
  * batches and once after the loop (the commit's no-progress wait is bounded
  * by the pool's request_timeout) */
-void ingest_pass(qwp_direct_sender* sender, qwp_chunk* chunk,
-                 const bench_data* d, schema_kind kind, size_t lo, size_t hi,
-                 size_t max_batch_rows, stage_scratch* scratch,
-                 const char* prog);
+void ingest_pass(
+    qwp_direct_sender* sender,
+    qwp_chunk* chunk,
+    const bench_data* d,
+    schema_kind kind,
+    size_t lo,
+    size_t hi,
+    size_t max_batch_rows,
+    stage_scratch* scratch,
+    const char* prog);

--- a/examples/bench_json_c.c
+++ b/examples/bench_json_c.c
@@ -1,7 +1,7 @@
 /* glibc hides XSI names (strdup, getrusage) under strict -std=c11
  * (CMAKE_C_EXTENSIONS OFF); macOS headers expose them unconditionally. */
 #if defined(__linux__)
-#define _XOPEN_SOURCE 600
+#    define _XOPEN_SOURCE 600
 #endif
 
 #include "bench_json_c.h"
@@ -22,18 +22,27 @@ uint64_t now_ns(void)
 uint64_t process_cpu_ns(void)
 {
     struct rusage u;
-    if (getrusage(RUSAGE_SELF, &u) != 0) return 0;
-    uint64_t ns = (uint64_t)u.ru_utime.tv_sec * 1000000000ULL
-                + (uint64_t)u.ru_utime.tv_usec * 1000ULL
-                + (uint64_t)u.ru_stime.tv_sec * 1000000000ULL
-                + (uint64_t)u.ru_stime.tv_usec * 1000ULL;
+    if (getrusage(RUSAGE_SELF, &u) != 0)
+        return 0;
+    uint64_t ns = (uint64_t)u.ru_utime.tv_sec * 1000000000ULL +
+                  (uint64_t)u.ru_utime.tv_usec * 1000ULL +
+                  (uint64_t)u.ru_stime.tv_sec * 1000000000ULL +
+                  (uint64_t)u.ru_stime.tv_usec * 1000ULL;
     return ns;
 }
 
 /* -------- sorted-key object builder (mirrors bench_json Obj) -------- */
 
-typedef struct { char* key; char* val; } json_entry;
-struct json_obj { json_entry* e; size_t n, cap; };
+typedef struct
+{
+    char* key;
+    char* val;
+} json_entry;
+struct json_obj
+{
+    json_entry* e;
+    size_t n, cap;
+};
 
 json_obj* json_obj_new(void)
 {
@@ -43,7 +52,8 @@ json_obj* json_obj_new(void)
 
 static void put(json_obj* o, const char* k, char* rendered /* owned */)
 {
-    if (o->n == o->cap) {
+    if (o->n == o->cap)
+    {
         o->cap = o->cap ? o->cap * 2 : 16;
         o->e = realloc(o->e, o->cap * sizeof(json_entry));
     }
@@ -59,14 +69,31 @@ static char* json_escape(const char* s)
     size_t n = strlen(s), j = 0;
     char* out = malloc(n * 6 + 3); /* worst case: every byte -> \u00xx */
     out[j++] = '"';
-    for (size_t i = 0; i < n; i++) {
+    for (size_t i = 0; i < n; i++)
+    {
         unsigned char c = (unsigned char)s[i];
-        switch (c) {
-        case '"':  out[j++] = '\\'; out[j++] = '"';  break;
-        case '\\': out[j++] = '\\'; out[j++] = '\\'; break;
-        case '\n': out[j++] = '\\'; out[j++] = 'n';  break;
-        case '\r': out[j++] = '\\'; out[j++] = 'r';  break;
-        case '\t': out[j++] = '\\'; out[j++] = 't';  break;
+        switch (c)
+        {
+        case '"':
+            out[j++] = '\\';
+            out[j++] = '"';
+            break;
+        case '\\':
+            out[j++] = '\\';
+            out[j++] = '\\';
+            break;
+        case '\n':
+            out[j++] = '\\';
+            out[j++] = 'n';
+            break;
+        case '\r':
+            out[j++] = '\\';
+            out[j++] = 'r';
+            break;
+        case '\t':
+            out[j++] = '\\';
+            out[j++] = 't';
+            break;
         default:
             if (c < 0x20)
                 j += (size_t)sprintf(out + j, "\\u%04x", (unsigned)c);
@@ -83,24 +110,48 @@ static char* json_escape(const char* s)
 static char* json_f64(double v)
 {
     char* out = malloc(64);
-    if (!isfinite(v)) { strcpy(out, "null"); return out; }
+    if (!isfinite(v))
+    {
+        strcpy(out, "null");
+        return out;
+    }
     snprintf(out, 64, "%.12f", v);
     char* dot = strchr(out, '.');
-    if (dot) {
+    if (dot)
+    {
         char* end = out + strlen(out) - 1;
-        while (end > dot && *end == '0') *end-- = 0;
-        if (end == dot) *end = 0;
+        while (end > dot && *end == '0')
+            *end-- = 0;
+        if (end == dot)
+            *end = 0;
     }
-    if (out[0] == 0 || strcmp(out, "-") == 0) strcpy(out, "0");
+    if (out[0] == 0 || strcmp(out, "-") == 0)
+        strcpy(out, "0");
     return out;
 }
 
-void json_obj_str(json_obj* o, const char* k, const char* v) { put(o, k, json_escape(v)); }
+void json_obj_str(json_obj* o, const char* k, const char* v)
+{
+    put(o, k, json_escape(v));
+}
 void json_obj_int(json_obj* o, const char* k, uint64_t v)
-{ char* b = malloc(32); snprintf(b, 32, "%llu", (unsigned long long)v); put(o, k, b); }
-void json_obj_float(json_obj* o, const char* k, double v) { put(o, k, json_f64(v)); }
-void json_obj_bool(json_obj* o, const char* k, int v) { put(o, k, strdup(v ? "true" : "false")); }
-void json_obj_null(json_obj* o, const char* k) { put(o, k, strdup("null")); }
+{
+    char* b = malloc(32);
+    snprintf(b, 32, "%llu", (unsigned long long)v);
+    put(o, k, b);
+}
+void json_obj_float(json_obj* o, const char* k, double v)
+{
+    put(o, k, json_f64(v));
+}
+void json_obj_bool(json_obj* o, const char* k, int v)
+{
+    put(o, k, strdup(v ? "true" : "false"));
+}
+void json_obj_null(json_obj* o, const char* k)
+{
+    put(o, k, strdup("null"));
+}
 
 void json_obj_obj(json_obj* o, const char* k, json_obj* child)
 {
@@ -109,7 +160,9 @@ void json_obj_obj(json_obj* o, const char* k, json_obj* child)
 }
 
 static int entry_cmp(const void* a, const void* b)
-{ return strcmp(((const json_entry*)a)->key, ((const json_entry*)b)->key); }
+{
+    return strcmp(((const json_entry*)a)->key, ((const json_entry*)b)->key);
+}
 
 char* json_obj_render(json_obj* o)
 {
@@ -120,8 +173,10 @@ char* json_obj_render(json_obj* o)
     char* out = malloc(need);
     size_t j = 0;
     out[j++] = '{';
-    for (size_t i = 0; i < o->n; i++) {
-        if (i) out[j++] = ',';
+    for (size_t i = 0; i < o->n; i++)
+    {
+        if (i)
+            out[j++] = ',';
         j += (size_t)sprintf(out + j, "\"%s\":%s", o->e[i].key, o->e[i].val);
     }
     out[j++] = '}';
@@ -131,8 +186,13 @@ char* json_obj_render(json_obj* o)
 
 void json_obj_free(json_obj* o)
 {
-    if (!o) return;
-    for (size_t i = 0; i < o->n; i++) { free(o->e[i].key); free(o->e[i].val); }
+    if (!o)
+        return;
+    for (size_t i = 0; i < o->n; i++)
+    {
+        free(o->e[i].key);
+        free(o->e[i].val);
+    }
     free(o->e);
     free(o);
 }
@@ -147,9 +207,11 @@ static int f64_cmp(const void* a, const void* b)
 
 double median_s_of(const uint64_t* samples_ns, size_t n)
 {
-    if (n == 0) return 0.0;
+    if (n == 0)
+        return 0.0;
     double* s = malloc(n * sizeof(double));
-    for (size_t i = 0; i < n; i++) s[i] = (double)samples_ns[i] / 1e9;
+    for (size_t i = 0; i < n; i++)
+        s[i] = (double)samples_ns[i] / 1e9;
     qsort(s, n, sizeof(double), f64_cmp);
     double m = (n % 2 == 1) ? s[n / 2] : (s[n / 2 - 1] + s[n / 2]) / 2.0;
     free(s);
@@ -158,29 +220,42 @@ double median_s_of(const uint64_t* samples_ns, size_t n)
 
 static double percentile(const double* sorted, size_t n, double p)
 {
-    if (n == 0) return 0.0;
+    if (n == 0)
+        return 0.0;
     size_t idx = (size_t)llround(((double)n - 1.0) * p);
-    if (idx > n - 1) idx = n - 1;
+    if (idx > n - 1)
+        idx = n - 1;
     return sorted[idx];
 }
 
-void summarize(json_obj* obj, const uint64_t* samples_ns, size_t n,
-               size_t rows, size_t columns, const uint64_t* wire_bytes)
+void summarize(
+    json_obj* obj,
+    const uint64_t* samples_ns,
+    size_t n,
+    size_t rows,
+    size_t columns,
+    const uint64_t* wire_bytes)
 {
     double* s = malloc((n ? n : 1) * sizeof(double));
     double sum = 0.0;
-    for (size_t i = 0; i < n; i++) { s[i] = (double)samples_ns[i] / 1e9; sum += s[i]; }
+    for (size_t i = 0; i < n; i++)
+    {
+        s[i] = (double)samples_ns[i] / 1e9;
+        sum += s[i];
+    }
     double mean = n ? sum / (double)n : 0.0;
     double* sorted = malloc((n ? n : 1) * sizeof(double));
     memcpy(sorted, s, n * sizeof(double));
     qsort(sorted, n, sizeof(double), f64_cmp);
-    double median = (n == 0) ? 0.0
-                  : (n % 2 == 1) ? sorted[n / 2]
-                  : (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0;
+    double median = (n == 0)       ? 0.0
+                    : (n % 2 == 1) ? sorted[n / 2]
+                                   : (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0;
     double stdev = 0.0;
-    if (n > 1) {
+    if (n > 1)
+    {
         double var = 0.0;
-        for (size_t i = 0; i < n; i++) var += (s[i] - mean) * (s[i] - mean);
+        for (size_t i = 0; i < n; i++)
+            var += (s[i] - mean) * (s[i] - mean);
         stdev = sqrt(var / ((double)n - 1.0));
     }
     json_obj_int(obj, "iterations", (uint64_t)n);
@@ -191,24 +266,37 @@ void summarize(json_obj* obj, const uint64_t* samples_ns, size_t n,
     json_obj_float(obj, "p95_s", percentile(sorted, n, 0.95));
     json_obj_float(obj, "stdev_s", stdev);
     json_obj_float(obj, "cov", mean != 0.0 ? stdev / mean : 0.0);
-    if (median != 0.0) {
+    if (median != 0.0)
+    {
         json_obj_float(obj, "rows_per_s_median", (double)rows / median);
-        json_obj_float(obj, "cells_per_s_median", (double)(rows * columns) / median);
-    } else {
+        json_obj_float(
+            obj, "cells_per_s_median", (double)(rows * columns) / median);
+    }
+    else
+    {
         json_obj_null(obj, "rows_per_s_median");
         json_obj_null(obj, "cells_per_s_median");
     }
     if (wire_bytes && median != 0.0)
-        json_obj_float(obj, "mib_per_s", ((double)*wire_bytes / (1024.0 * 1024.0)) / median);
+        json_obj_float(
+            obj,
+            "mib_per_s",
+            ((double)*wire_bytes / (1024.0 * 1024.0)) / median);
     else
         json_obj_null(obj, "mib_per_s");
     free(s);
     free(sorted);
 }
 
-json_obj* path_summary(const uint64_t* wall_ns, const uint64_t* cpu_ns,
-                       size_t n, size_t rows, size_t columns,
-                       uint64_t wire_bytes, const char* phase, int warm)
+json_obj* path_summary(
+    const uint64_t* wall_ns,
+    const uint64_t* cpu_ns,
+    size_t n,
+    size_t rows,
+    size_t columns,
+    uint64_t wire_bytes,
+    const char* phase,
+    int warm)
 {
     int e2e = strcmp(phase, "e2e") == 0;
     const uint64_t* rate_wb = e2e ? &wire_bytes : NULL;

--- a/examples/bench_json_c.h
+++ b/examples/bench_json_c.h
@@ -15,20 +15,32 @@ void json_obj_int(json_obj* o, const char* k, uint64_t v);
 void json_obj_float(json_obj* o, const char* k, double v);
 void json_obj_bool(json_obj* o, const char* k, int v);
 void json_obj_null(json_obj* o, const char* k);
-void json_obj_obj(json_obj* o, const char* k, json_obj* child); /* takes ownership */
+void json_obj_obj(
+    json_obj* o, const char* k, json_obj* child); /* takes ownership */
 char* json_obj_render(json_obj* o); /* compact, keys sorted; caller frees */
 void json_obj_free(json_obj* o);
 
 /* iterations/median_s/mean_s/min_s/max_s/p95_s/stdev_s/cov +
  * rows_per_s_median/cells_per_s_median/mib_per_s (null unless wire_bytes). */
-void summarize(json_obj* obj, const uint64_t* samples_ns, size_t n,
-               size_t rows, size_t columns, const uint64_t* wire_bytes);
+void summarize(
+    json_obj* obj,
+    const uint64_t* samples_ns,
+    size_t n,
+    size_t rows,
+    size_t columns,
+    const uint64_t* wire_bytes);
 
 /* Full per-path object: wall stats + process_cpu sub-object + phase/warm/
  * wire_bytes. mib_per_s only when phase == "e2e" (rate_wire_bytes gating). */
-json_obj* path_summary(const uint64_t* wall_ns, const uint64_t* cpu_ns,
-                       size_t n, size_t rows, size_t columns,
-                       uint64_t wire_bytes, const char* phase, int warm);
+json_obj* path_summary(
+    const uint64_t* wall_ns,
+    const uint64_t* cpu_ns,
+    size_t n,
+    size_t rows,
+    size_t columns,
+    uint64_t wire_bytes,
+    const char* phase,
+    int warm);
 
 /* median of samples_ns in seconds (helper for headline blocks) */
 double median_s_of(const uint64_t* samples_ns, size_t n);

--- a/examples/bench_schema_c.c
+++ b/examples/bench_schema_c.c
@@ -5,19 +5,33 @@
 
 int schema_parse(const char* s, schema_kind* out)
 {
-    if (strcmp(s, "s1-narrow") == 0) { *out = SCHEMA_S1_NARROW; return 0; }
-    if (strcmp(s, "s2-wide") == 0)   { *out = SCHEMA_S2_WIDE;   return 0; }
+    if (strcmp(s, "s1-narrow") == 0)
+    {
+        *out = SCHEMA_S1_NARROW;
+        return 0;
+    }
+    if (strcmp(s, "s2-wide") == 0)
+    {
+        *out = SCHEMA_S2_WIDE;
+        return 0;
+    }
     return 1;
 }
 
 const char* schema_name(schema_kind k)
-{ return k == SCHEMA_S1_NARROW ? "s1-narrow" : "s2-wide"; }
+{
+    return k == SCHEMA_S1_NARROW ? "s1-narrow" : "s2-wide";
+}
 
 const char* schema_table(schema_kind k)
-{ return k == SCHEMA_S1_NARROW ? "bench_s1_narrow" : "bench_s2_wide"; }
+{
+    return k == SCHEMA_S1_NARROW ? "bench_s1_narrow" : "bench_s2_wide";
+}
 
 size_t schema_columns(schema_kind k)
-{ return k == SCHEMA_S1_NARROW ? 5 : 5 + N_WIDE_DOUBLES + N_WIDE_SYMS; }
+{
+    return k == SCHEMA_S1_NARROW ? 5 : 5 + N_WIDE_DOUBLES + N_WIDE_SYMS;
+}
 
 const char* schema_create_sql(schema_kind k)
 {
@@ -44,7 +58,8 @@ const char* schema_select_sql(schema_kind k)
 
 size_t note_template_count(size_t rows)
 {
-    if (rows < 1) return 1;
+    if (rows < 1)
+        return 1;
     return rows > 1024 ? 1024 : rows;
 }
 
@@ -56,16 +71,28 @@ void note_template(size_t idx, size_t varchar_len, char* out)
         out[i] = pat[i % (size_t)plen];
 }
 
-void sym_label(size_t v, char* out) { sprintf(out, "sym_%04zu", v); }
+void sym_label(size_t v, char* out)
+{
+    sprintf(out, "sym_%04zu", v);
+}
 
 void hi_sym_label(size_t col, size_t v, char* out)
-{ sprintf(out, "s%zu_%06zu", col - 1, v); }
+{
+    sprintf(out, "s%zu_%06zu", col - 1, v);
+}
 
-double wide_double(size_t i, size_t k) { return (double)i * (0.5 + (double)k); }
+double wide_double(size_t i, size_t k)
+{
+    return (double)i * (0.5 + (double)k);
+}
 
 /* Dict entries label(0)..label(card-1); codes cycle i % card. */
-static int build_sym(sym_col* c, size_t rows, size_t card,
-                     void (*label)(size_t, char*), size_t label_max)
+static int build_sym(
+    sym_col* c,
+    size_t rows,
+    size_t card,
+    void (*label)(size_t, char*),
+    size_t label_max)
 {
     char buf[32];
     (void)label_max;
@@ -74,10 +101,12 @@ static int build_sym(sym_col* c, size_t rows, size_t card,
     c->offsets = malloc((card + 1) * sizeof(int32_t));
     /* every label here is < 16 bytes; over-allocate then record real len */
     c->bytes = malloc(card * 16);
-    if (!c->codes || !c->offsets || !c->bytes) return 1;
+    if (!c->codes || !c->offsets || !c->bytes)
+        return 1;
     size_t pos = 0;
     c->offsets[0] = 0;
-    for (size_t v = 0; v < card; v++) {
+    for (size_t v = 0; v < card; v++)
+    {
         label(v, buf);
         size_t n = strlen(buf);
         memcpy(c->bytes + pos, buf, n);
@@ -92,10 +121,18 @@ static int build_sym(sym_col* c, size_t rows, size_t card,
 
 /* hi_sym_label needs the column number too — wrap per column. */
 static size_t g_hi_col;
-static void hi_label_bound(size_t v, char* out) { hi_sym_label(g_hi_col, v, out); }
+static void hi_label_bound(size_t v, char* out)
+{
+    hi_sym_label(g_hi_col, v, out);
+}
 
-int bench_data_build(bench_data* d, schema_kind k, size_t rows,
-                     size_t sym_card, size_t varchar_len, size_t hi_sym_card)
+int bench_data_build(
+    bench_data* d,
+    schema_kind k,
+    size_t rows,
+    size_t sym_card,
+    size_t varchar_len,
+    size_t hi_sym_card)
 {
     memset(d, 0, sizeof(*d));
     d->rows = rows;
@@ -105,39 +142,50 @@ int bench_data_build(bench_data* d, schema_kind k, size_t rows,
     d->price = malloc(rows * sizeof(double));
     d->note_offsets = malloc((rows + 1) * sizeof(int32_t));
     d->note_bytes = malloc(rows * varchar_len);
-    if (!d->ts_nanos || !d->id || !d->price || !d->note_offsets || !d->note_bytes)
+    if (!d->ts_nanos || !d->id || !d->price || !d->note_offsets ||
+        !d->note_bytes)
         return 1;
 
     size_t tcount = note_template_count(rows);
     char* templates = malloc(tcount * varchar_len);
-    if (!templates) return 1;
+    if (!templates)
+        return 1;
     for (size_t t = 0; t < tcount; t++)
         note_template(t, varchar_len, templates + t * varchar_len);
 
     d->note_offsets[0] = 0;
-    for (size_t i = 0; i < rows; i++) {
+    for (size_t i = 0; i < rows; i++)
+    {
         d->ts_nanos[i] = TS_BASE_NANOS + (int64_t)i * TS_STEP_NANOS;
         d->id[i] = (int64_t)i;
         d->price[i] = (double)i * 0.25;
-        memcpy(d->note_bytes + i * varchar_len,
-               templates + (i % tcount) * varchar_len, varchar_len);
+        memcpy(
+            d->note_bytes + i * varchar_len,
+            templates + (i % tcount) * varchar_len,
+            varchar_len);
         d->note_offsets[i + 1] = (int32_t)((i + 1) * varchar_len);
     }
     d->note_bytes_len = rows * varchar_len;
     free(templates);
 
-    if (build_sym(&d->sym, rows, sym_card, sym_label, 16)) return 1;
+    if (build_sym(&d->sym, rows, sym_card, sym_label, 16))
+        return 1;
 
-    if (k == SCHEMA_S2_WIDE) {
-        for (size_t j = 0; j < N_WIDE_DOUBLES; j++) {
+    if (k == SCHEMA_S2_WIDE)
+    {
+        for (size_t j = 0; j < N_WIDE_DOUBLES; j++)
+        {
             d->doubles[j] = malloc(rows * sizeof(double));
-            if (!d->doubles[j]) return 1;
+            if (!d->doubles[j])
+                return 1;
             for (size_t i = 0; i < rows; i++)
                 d->doubles[j][i] = wide_double(i, j + 1); /* d1 → k=1 */
         }
-        for (size_t j = 0; j < N_WIDE_SYMS; j++) {
+        for (size_t j = 0; j < N_WIDE_SYMS; j++)
+        {
             g_hi_col = j + 1; /* column s1 → labels s0_… */
-            if (build_sym(&d->hi_syms[j], rows, hi_sym_card, hi_label_bound, 16))
+            if (build_sym(
+                    &d->hi_syms[j], rows, hi_sym_card, hi_label_bound, 16))
                 return 1;
         }
     }
@@ -146,12 +194,20 @@ int bench_data_build(bench_data* d, schema_kind k, size_t rows,
 
 void bench_data_free(bench_data* d)
 {
-    free(d->ts_nanos); free(d->id); free(d->price);
-    free(d->note_offsets); free(d->note_bytes);
-    free(d->sym.codes); free(d->sym.offsets); free(d->sym.bytes);
-    for (size_t j = 0; j < N_WIDE_DOUBLES; j++) free(d->doubles[j]);
-    for (size_t j = 0; j < N_WIDE_SYMS; j++) {
-        free(d->hi_syms[j].codes); free(d->hi_syms[j].offsets);
+    free(d->ts_nanos);
+    free(d->id);
+    free(d->price);
+    free(d->note_offsets);
+    free(d->note_bytes);
+    free(d->sym.codes);
+    free(d->sym.offsets);
+    free(d->sym.bytes);
+    for (size_t j = 0; j < N_WIDE_DOUBLES; j++)
+        free(d->doubles[j]);
+    for (size_t j = 0; j < N_WIDE_SYMS; j++)
+    {
+        free(d->hi_syms[j].codes);
+        free(d->hi_syms[j].offsets);
         free(d->hi_syms[j].bytes);
     }
     memset(d, 0, sizeof(*d));

--- a/examples/bench_schema_c.h
+++ b/examples/bench_schema_c.h
@@ -5,7 +5,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
-typedef enum { SCHEMA_S1_NARROW, SCHEMA_S2_WIDE } schema_kind;
+typedef enum
+{
+    SCHEMA_S1_NARROW,
+    SCHEMA_S2_WIDE
+} schema_kind;
 
 #define N_WIDE_DOUBLES 5
 #define N_WIDE_SYMS 5
@@ -19,11 +23,15 @@ size_t schema_columns(schema_kind k);
 const char* schema_create_sql(schema_kind k);
 const char* schema_select_sql(schema_kind k);
 
-size_t note_template_count(size_t rows);           /* clamp(rows, 1, 1024) */
-void note_template(size_t idx, size_t varchar_len, char* out); /* exactly varchar_len bytes, no NUL */
-void sym_label(size_t v, char* out);               /* "sym_%04zu", NUL-terminated */
-void hi_sym_label(size_t col, size_t v, char* out);/* "s%zu_%06zu" with col-1  */
-double wide_double(size_t i, size_t k);            /* i * (0.5 + k)           */
+size_t note_template_count(size_t rows); /* clamp(rows, 1, 1024) */
+void note_template(
+    size_t idx,
+    size_t varchar_len,
+    char* out);                      /* exactly varchar_len bytes, no NUL */
+void sym_label(size_t v, char* out); /* "sym_%04zu", NUL-terminated */
+void hi_sym_label(
+    size_t col, size_t v, char* out);   /* "s%zu_%06zu" with col-1  */
+double wide_double(size_t i, size_t k); /* i * (0.5 + k)           */
 
 /* One SYMBOL column: per-row dict codes + dict as Arrow-Utf8 offsets/bytes. */
 typedef struct
@@ -41,15 +49,20 @@ typedef struct
     int64_t* ts_nanos;
     int64_t* id;
     double* price;
-    sym_col sym;                      /* low-card `sym`                 */
-    int32_t* note_offsets;            /* rows + 1; uniform varchar_len  */
+    sym_col sym;           /* low-card `sym`                 */
+    int32_t* note_offsets; /* rows + 1; uniform varchar_len  */
     uint8_t* note_bytes;
     size_t note_bytes_len;
     size_t varchar_len;
-    double* doubles[N_WIDE_DOUBLES];  /* NULL for S1                    */
-    sym_col hi_syms[N_WIDE_SYMS];     /* zeroed for S1                  */
+    double* doubles[N_WIDE_DOUBLES]; /* NULL for S1                    */
+    sym_col hi_syms[N_WIDE_SYMS];    /* zeroed for S1                  */
 } bench_data;
 
-int bench_data_build(bench_data* d, schema_kind k, size_t rows,
-                     size_t sym_card, size_t varchar_len, size_t hi_sym_card);
+int bench_data_build(
+    bench_data* d,
+    schema_kind k,
+    size_t rows,
+    size_t sym_card,
+    size_t varchar_len,
+    size_t hi_sym_card);
 void bench_data_free(bench_data* d);

--- a/examples/line_sender_c_example.c
+++ b/examples/line_sender_c_example.c
@@ -52,7 +52,8 @@ static bool example(const char* host, const char* port)
     if (!line_sender_buffer_symbol(buffer, side_name, side_value, &err))
         goto on_error;
 
-    // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
+    // The table must be created beforehand with the appropriate DECIMAL(N,M)
+    // type for the column.
     if (!line_sender_buffer_column_dec_str(
             buffer, price_name, "2615.54", strlen("2615.54"), &err))
         goto on_error;

--- a/examples/line_sender_c_example_auth.c
+++ b/examples/line_sender_c_example_auth.c
@@ -61,7 +61,8 @@ static bool example(const char* host, const char* port)
     if (!line_sender_buffer_symbol(buffer, side_name, side_value, &err))
         goto on_error;
 
-    // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
+    // The table must be created beforehand with the appropriate DECIMAL(N,M)
+    // type for the column.
     if (!line_sender_buffer_column_dec_str(
             buffer, price_name, "2615.54", strlen("2615.54"), &err))
         goto on_error;

--- a/examples/line_sender_c_example_auth_tls.c
+++ b/examples/line_sender_c_example_auth_tls.c
@@ -62,7 +62,8 @@ static bool example(const char* host, const char* port)
     if (!line_sender_buffer_symbol(buffer, side_name, side_value, &err))
         goto on_error;
 
-    // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
+    // The table must be created beforehand with the appropriate DECIMAL(N,M)
+    // type for the column.
     if (!line_sender_buffer_column_dec_str(
             buffer, price_name, "2615.54", strlen("2615.54"), &err))
         goto on_error;

--- a/examples/line_sender_c_example_decimal_binary.c
+++ b/examples/line_sender_c_example_decimal_binary.c
@@ -52,8 +52,8 @@ static bool example(const char* host, const char* port)
     if (!line_sender_buffer_symbol(buffer, side_name, side_value, &err))
         goto on_error;
 
-    // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
-    // 123 with a scale of 1 gives a decimal of 12.3
+    // The table must be created beforehand with the appropriate DECIMAL(N,M)
+    // type for the column. 123 with a scale of 1 gives a decimal of 12.3
     const uint8_t price_unscaled_value[] = {123};
     if (!line_sender_buffer_column_dec(
             buffer, price_name, 1, price_unscaled_value, 1, &err))

--- a/examples/line_sender_c_example_from_conf.c
+++ b/examples/line_sender_c_example_from_conf.c
@@ -39,7 +39,8 @@ int main(int argc, const char* argv[])
     if (!line_sender_buffer_symbol(buffer, side_name, side_value, &err))
         goto on_error;
 
-    // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
+    // The table must be created beforehand with the appropriate DECIMAL(N,M)
+    // type for the column.
     if (!line_sender_buffer_column_dec_str(
             buffer, price_name, "2615.54", strlen("2615.54"), &err))
         goto on_error;

--- a/examples/line_sender_c_example_from_env.c
+++ b/examples/line_sender_c_example_from_env.c
@@ -38,7 +38,8 @@ int main(int argc, const char* argv[])
     if (!line_sender_buffer_symbol(buffer, side_name, side_value, &err))
         goto on_error;
 
-    // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
+    // The table must be created beforehand with the appropriate DECIMAL(N,M)
+    // type for the column.
     if (!line_sender_buffer_column_dec_str(
             buffer, price_name, "2615.54", strlen("2615.54"), &err))
         goto on_error;

--- a/examples/line_sender_c_example_http.c
+++ b/examples/line_sender_c_example_http.c
@@ -50,7 +50,8 @@ static bool example(const char* host, const char* port)
     if (!line_sender_buffer_symbol(buffer, side_name, side_value, &err))
         goto on_error;
 
-    // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
+    // The table must be created beforehand with the appropriate DECIMAL(N,M)
+    // type for the column.
     if (!line_sender_buffer_column_dec_str(
             buffer, price_name, "2615.54", strlen("2615.54"), &err))
         goto on_error;

--- a/examples/line_sender_c_example_tls_ca.c
+++ b/examples/line_sender_c_example_tls_ca.c
@@ -65,7 +65,8 @@ static bool example(const char* ca_path, const char* host, const char* port)
     if (!line_sender_buffer_symbol(buffer, side_name, side_value, &err))
         goto on_error;
 
-    // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
+    // The table must be created beforehand with the appropriate DECIMAL(N,M)
+    // type for the column.
     if (!line_sender_buffer_column_dec_str(
             buffer, price_name, "2615.54", strlen("2615.54"), &err))
         goto on_error;

--- a/examples/line_sender_c_example_udp.c
+++ b/examples/line_sender_c_example_udp.c
@@ -125,14 +125,11 @@ static bool displayed_help(int argc, const char* argv[])
         {
             fprintf(stderr, "Usage:\n");
             fprintf(
-                stderr,
-                "line_sender_c_example_udp: [HOST [PORT [TABLE]]]\n");
+                stderr, "line_sender_c_example_udp: [HOST [PORT [TABLE]]]\n");
             fprintf(
                 stderr,
                 "    HOST: QWP/UDP host (defaults to \"localhost\").\n");
-            fprintf(
-                stderr,
-                "    PORT: QWP/UDP port (defaults to \"9007\").\n");
+            fprintf(stderr, "    PORT: QWP/UDP port (defaults to \"9007\").\n");
             fprintf(
                 stderr,
                 "    TABLE: Target table (defaults to \"c_udp_example\").\n");

--- a/examples/line_sender_c_example_udp_batch.c
+++ b/examples/line_sender_c_example_udp_batch.c
@@ -113,12 +113,11 @@ static bool displayed_help(int argc, const char* argv[])
             fprintf(
                 stderr,
                 "    HOST: QWP/UDP host (defaults to \"localhost\").\n");
+            fprintf(stderr, "    PORT: QWP/UDP port (defaults to \"9007\").\n");
             fprintf(
                 stderr,
-                "    PORT: QWP/UDP port (defaults to \"9007\").\n");
-            fprintf(
-                stderr,
-                "    TABLE: Target table (defaults to \"c_udp_batch_example\").\n");
+                "    TABLE: Target table (defaults to "
+                "\"c_udp_batch_example\").\n");
             return true;
         }
     }

--- a/examples/line_sender_cpp_example.cpp
+++ b/examples/line_sender_cpp_example.cpp
@@ -26,7 +26,8 @@ static bool example(std::string_view host, std::string_view port)
         buffer.table(table_name)
             .symbol(symbol_name, "ETH-USD"_utf8)
             .symbol(side_name, "sell"_utf8)
-        // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
+            // The table must be created beforehand with the appropriate
+            // DECIMAL(N,M) type for the column.
             .column(price_name, "2615.54"_decimal)
             .column(amount_name, 0.00044)
             .at(questdb::ingress::timestamp_nanos::now());

--- a/examples/line_sender_cpp_example_arrow.cpp
+++ b/examples/line_sender_cpp_example_arrow.cpp
@@ -13,7 +13,8 @@
 #include <memory>
 #include <string>
 
-namespace {
+namespace
+{
 
 namespace qdb = questdb::ingress;
 using namespace questdb::ingress::literals;
@@ -36,7 +37,8 @@ std::shared_ptr<arrow::RecordBatch> build_batch()
     auto schema = arrow::schema(
         {arrow::field("ts", ts_arr->type()),
          arrow::field("price", arrow::float64())});
-    return arrow::RecordBatch::Make(schema, ts_arr->length(), {ts_arr, price_arr});
+    return arrow::RecordBatch::Make(
+        schema, ts_arr->length(), {ts_arr, price_arr});
 }
 
 bool example(const std::string& host, const std::string& port)
@@ -50,8 +52,10 @@ bool example(const std::string& host, const std::string& port)
         size_t err_len = 0;
         const char* err_msg = ::line_sender_error_msg(err, &err_len);
         std::fprintf(
-            stderr, "questdb_db_connect: %.*s\n",
-            static_cast<int>(err_len), err_msg);
+            stderr,
+            "questdb_db_connect: %.*s\n",
+            static_cast<int>(err_len),
+            err_msg);
         ::line_sender_error_free(err);
         return false;
     }
@@ -61,8 +65,10 @@ bool example(const std::string& host, const std::string& port)
         size_t err_len = 0;
         const char* err_msg = ::line_sender_error_msg(err, &err_len);
         std::fprintf(
-            stderr, "questdb_db_borrow_sender: %.*s\n",
-            static_cast<int>(err_len), err_msg);
+            stderr,
+            "questdb_db_borrow_sender: %.*s\n",
+            static_cast<int>(err_len),
+            err_msg);
         ::line_sender_error_free(err);
         ::questdb_db_close(db);
         return false;
@@ -90,21 +96,24 @@ bool example(const std::string& host, const std::string& port)
         auto st = arrow::ExportRecordBatch(*batch, &c_arr, &c_sch);
         if (!st.ok())
         {
-            std::fprintf(stderr, "ExportRecordBatch: %s\n", st.ToString().c_str());
+            std::fprintf(
+                stderr, "ExportRecordBatch: %s\n", st.ToString().c_str());
         }
         else
         {
             arrow_c_guard guard{c_arr, c_sch};
             qdb::sender_view sender_view{raw_sender};
-            sender_view.flush_arrow_batch("cpp_arrow_trades"_tn, c_arr, c_sch, "ts"_cn);
-            if (!::qwp_sender_wait(
-                    raw_sender, ::qwpws_ack_level_ok, 0, &err))
+            sender_view.flush_arrow_batch(
+                "cpp_arrow_trades"_tn, c_arr, c_sch, "ts"_cn);
+            if (!::qwp_sender_wait(raw_sender, ::qwpws_ack_level_ok, 0, &err))
             {
                 size_t err_len = 0;
                 const char* err_msg = ::line_sender_error_msg(err, &err_len);
                 std::fprintf(
-                    stderr, "qwp_sender_wait: %.*s\n",
-                    static_cast<int>(err_len), err_msg);
+                    stderr,
+                    "qwp_sender_wait: %.*s\n",
+                    static_cast<int>(err_len),
+                    err_msg);
                 ::line_sender_error_free(err);
             }
             else

--- a/examples/line_sender_cpp_example_auth.cpp
+++ b/examples/line_sender_cpp_example_auth.cpp
@@ -30,7 +30,8 @@ static bool example(std::string_view host, std::string_view port)
         buffer.table(table_name)
             .symbol(symbol_name, "ETH-USD"_utf8)
             .symbol(side_name, "sell"_utf8)
-        // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
+            // The table must be created beforehand with the appropriate
+            // DECIMAL(N,M) type for the column.
             .column(price_name, "2615.54"_decimal)
             .column(amount_name, 0.00044)
             .at(questdb::ingress::timestamp_nanos::now());

--- a/examples/line_sender_cpp_example_decimal_binary.cpp
+++ b/examples/line_sender_cpp_example_decimal_binary.cpp
@@ -20,8 +20,9 @@ static bool example(std::string_view host, std::string_view port)
         const auto price_name = "price"_cn;
         const auto amount_name = "amount"_cn;
         const uint8_t price_unscaled_value[] = {123};
-        // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
-        // 123 with a scale of 1 gives a decimal of 12.3
+        // The table must be created beforehand with the appropriate
+        // DECIMAL(N,M) type for the column. 123 with a scale of 1 gives a
+        // decimal of 12.3
         const auto price_value =
             questdb::ingress::decimal::decimal_view(1, price_unscaled_value);
 

--- a/examples/line_sender_cpp_example_decimal_custom.cpp
+++ b/examples/line_sender_cpp_example_decimal_custom.cpp
@@ -75,8 +75,9 @@ static bool example(std::string_view host, std::string_view port)
         const auto price_name = "price"_cn;
         const auto amount_name = "amount"_cn;
 
-        // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
-        // 123 with a scale of 1 gives a decimal of 12.3
+        // The table must be created beforehand with the appropriate
+        // DECIMAL(N,M) type for the column. 123 with a scale of 1 gives a
+        // decimal of 12.3
         const auto price_value = custom_decimal::Decimal32(1, 123);
 
         questdb::ingress::line_sender_buffer buffer = sender.new_buffer();

--- a/examples/line_sender_cpp_example_from_conf.cpp
+++ b/examples/line_sender_cpp_example_from_conf.cpp
@@ -25,7 +25,8 @@ int main(int argc, const char* argv[])
         buffer.table(table_name)
             .symbol(symbol_name, "ETH-USD"_utf8)
             .symbol(side_name, "sell"_utf8)
-        // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
+            // The table must be created beforehand with the appropriate
+            // DECIMAL(N,M) type for the column.
             .column(price_name, "2615.54"_decimal)
             .column(amount_name, 0.00044)
             .at(questdb::ingress::timestamp_nanos::now());

--- a/examples/line_sender_cpp_example_from_env.cpp
+++ b/examples/line_sender_cpp_example_from_env.cpp
@@ -24,7 +24,8 @@ int main(int argc, const char* argv[])
         buffer.table(table_name)
             .symbol(symbol_name, "ETH-USD"_utf8)
             .symbol(side_name, "sell"_utf8)
-        // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
+            // The table must be created beforehand with the appropriate
+            // DECIMAL(N,M) type for the column.
             .column(price_name, "2615.54"_decimal)
             .column(amount_name, 0.00044)
             .at(questdb::ingress::timestamp_nanos::now());

--- a/examples/line_sender_cpp_example_http.cpp
+++ b/examples/line_sender_cpp_example_http.cpp
@@ -25,7 +25,8 @@ static bool example(std::string_view host, std::string_view port)
         buffer.table(table_name)
             .symbol(symbol_name, "ETH-USD"_utf8)
             .symbol(side_name, "sell"_utf8)
-        // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
+            // The table must be created beforehand with the appropriate
+            // DECIMAL(N,M) type for the column.
             .column(price_name, "2615.54"_decimal)
             .column(amount_name, 0.00044)
             .at(questdb::ingress::timestamp_nanos::now());

--- a/examples/line_sender_cpp_example_tls_ca.cpp
+++ b/examples/line_sender_cpp_example_tls_ca.cpp
@@ -33,7 +33,8 @@ static bool example(
         buffer.table(table_name)
             .symbol(symbol_name, "ETH-USD"_utf8)
             .symbol(side_name, "sell"_utf8)
-        // The table must be created beforehand with the appropriate DECIMAL(N,M) type for the column.
+            // The table must be created beforehand with the appropriate
+            // DECIMAL(N,M) type for the column.
             .column(price_name, "2615.54"_decimal)
             .column(amount_name, 0.00044)
             .at(questdb::ingress::timestamp_nanos::now());

--- a/examples/line_sender_cpp_example_udp.cpp
+++ b/examples/line_sender_cpp_example_udp.cpp
@@ -5,9 +5,7 @@ using namespace std::literals::string_view_literals;
 using namespace questdb::ingress::literals;
 
 static bool example(
-    std::string_view host,
-    std::string_view port,
-    std::string_view table_name)
+    std::string_view host, std::string_view port, std::string_view table_name)
 {
     try
     {
@@ -25,7 +23,8 @@ static bool example(
             .column_i32("region"_cn, int32_t{42})
             .column_f32("temp_f"_cn, 21.5f)
             .column("temp"_cn, 21.5)
-            .column_uuid("trace_id"_cn, 0x0102030405060708ULL, 0x090A0B0C0D0E0F10ULL)
+            .column_uuid(
+                "trace_id"_cn, 0x0102030405060708ULL, 0x090A0B0C0D0E0F10ULL)
             .column_date("first_seen"_cn, int64_t{1700000000000})
             .column_dec64("price"_cn, "1.25"sv)
             .column_geohash("loc"_cn, uint64_t{0x012EA85B}, uint8_t{25})

--- a/examples/line_sender_cpp_example_udp_batch.cpp
+++ b/examples/line_sender_cpp_example_udp_batch.cpp
@@ -5,9 +5,7 @@ using namespace std::literals::string_view_literals;
 using namespace questdb::ingress::literals;
 
 static bool example(
-    std::string_view host,
-    std::string_view port,
-    std::string_view table_name)
+    std::string_view host, std::string_view port, std::string_view table_name)
 {
     try
     {
@@ -55,7 +53,8 @@ static bool displayed_help(int argc, const char* argv[])
                 << "line_sender_cpp_example_udp_batch: [HOST [PORT [TABLE]]]\n"
                 << "    HOST: QWP/UDP host (defaults to \"localhost\").\n"
                 << "    PORT: QWP/UDP port (defaults to \"9007\").\n"
-                << "    TABLE: Target table (defaults to \"cpp_udp_batch_example\")."
+                << "    TABLE: Target table (defaults to "
+                   "\"cpp_udp_batch_example\")."
                 << std::endl;
             return true;
         }

--- a/examples/qwp_bench_selftest.c
+++ b/examples/qwp_bench_selftest.c
@@ -1,7 +1,8 @@
 /* Golden-value self-test for the C QWP bench modules. Values cross-checked
  * against questdb-rs/examples/bench_schema/mod.rs and bench_json/mod.rs —
  * if these drift, cross-client parity is broken. No server, no curl. */
-#undef NDEBUG /* asserts are the test; keep them in Release (-DNDEBUG) builds */
+#undef NDEBUG /* asserts are the test; keep them in Release (-DNDEBUG) builds  \
+               */
 #include <assert.h>
 #include <math.h>
 #include <stdio.h>
@@ -21,12 +22,18 @@ static void test_schema(void)
     assert(strcmp(schema_table(SCHEMA_S2_WIDE), "bench_s2_wide") == 0);
     assert(schema_columns(SCHEMA_S1_NARROW) == 5);
     assert(schema_columns(SCHEMA_S2_WIDE) == 15);
-    assert(strstr(schema_create_sql(SCHEMA_S2_WIDE),
-                  "s5 SYMBOL CAPACITY 200000") != NULL);
-    assert(strstr(schema_create_sql(SCHEMA_S1_NARROW),
-                  "DEDUP UPSERT KEYS(ts)") != NULL);
-    assert(strncmp(schema_select_sql(SCHEMA_S1_NARROW),
-                   "SELECT ts, id, price, sym, note FROM bench_s1_narrow", 53) == 0);
+    assert(
+        strstr(
+            schema_create_sql(SCHEMA_S2_WIDE), "s5 SYMBOL CAPACITY 200000") !=
+        NULL);
+    assert(
+        strstr(schema_create_sql(SCHEMA_S1_NARROW), "DEDUP UPSERT KEYS(ts)") !=
+        NULL);
+    assert(
+        strncmp(
+            schema_select_sql(SCHEMA_S1_NARROW),
+            "SELECT ts, id, price, sym, note FROM bench_s1_narrow",
+            53) == 0);
 }
 
 static void test_generators(void)
@@ -62,10 +69,10 @@ static void test_data_build(void)
     assert(d.ts_nanos[1] - d.ts_nanos[0] == 1000);
     assert(d.id[1999] == 1999);
     assert(d.price[4] == 1.0);
-    assert(d.sym.card == 8 && d.sym.codes[9] == 1);          /* 9 % 8 */
-    assert(d.note_offsets[2000] == 2000 * 16);               /* fixed-len notes */
+    assert(d.sym.card == 8 && d.sym.codes[9] == 1); /* 9 % 8 */
+    assert(d.note_offsets[2000] == 2000 * 16);      /* fixed-len notes */
     assert(memcmp(d.note_bytes + 16, "note_001_note_00", 16) == 0);
-    assert(d.doubles[2][5] == 5.0 * 3.5);                    /* d3: k=3 */
+    assert(d.doubles[2][5] == 5.0 * 3.5); /* d3: k=3 */
     assert(d.hi_syms[0].card == 1000);
     assert(memcmp(d.hi_syms[4].bytes, "s4_000000", 9) == 0); /* dict entry 0 */
     bench_data_free(&d);
@@ -77,28 +84,34 @@ static void test_data_build(void)
 
 static void test_stats(void)
 {
-    /* samples 1..4 s in ns: median=(2+3)/2=2.5, stdev=sqrt(5/3), p95=idx round(2.85)=3 → 4.0 */
-    uint64_t s[4] = {1000000000ULL, 2000000000ULL, 3000000000ULL, 4000000000ULL};
+    /* samples 1..4 s in ns: median=(2+3)/2=2.5, stdev=sqrt(5/3), p95=idx
+     * round(2.85)=3 → 4.0 */
+    uint64_t s[4] = {
+        1000000000ULL, 2000000000ULL, 3000000000ULL, 4000000000ULL};
     json_obj* o = json_obj_new();
     summarize(o, s, 4, 10, 5, NULL);
     char* j = json_obj_render(o);
     assert(strstr(j, "\"iterations\":4") != NULL);
     assert(strstr(j, "\"median_s\":2.5") != NULL);
     assert(strstr(j, "\"p95_s\":4") != NULL);
-    assert(strstr(j, "\"cov\":0.516397779494") != NULL);  /* stdev/mean, %.12f trimmed */
+    assert(
+        strstr(j, "\"cov\":0.516397779494") !=
+        NULL); /* stdev/mean, %.12f trimmed */
     assert(strstr(j, "\"rows_per_s_median\":4") != NULL); /* 10 / 2.5 */
     assert(strstr(j, "\"cells_per_s_median\":20") != NULL);
-    assert(strstr(j, "\"mib_per_s\":null") != NULL);      /* no wire_bytes */
-    free(j); json_obj_free(o);
+    assert(strstr(j, "\"mib_per_s\":null") != NULL); /* no wire_bytes */
+    free(j);
+    json_obj_free(o);
 
     uint64_t one[1] = {2000000000ULL};
     uint64_t wb = 2097152; /* 2 MiB over 2 s → 1 MiB/s */
     o = json_obj_new();
     summarize(o, one, 1, 10, 5, &wb);
     j = json_obj_render(o);
-    assert(strstr(j, "\"stdev_s\":0") != NULL);           /* n==1 → 0 */
+    assert(strstr(j, "\"stdev_s\":0") != NULL); /* n==1 → 0 */
     assert(strstr(j, "\"mib_per_s\":1") != NULL);
-    free(j); json_obj_free(o);
+    free(j);
+    json_obj_free(o);
 }
 
 static void test_json(void)
@@ -109,14 +122,17 @@ static void test_json(void)
     json_obj_float(o, "c", 2.5);
     json_obj_float(o, "d", 1.0 / 3.0);
     char* j = json_obj_render(o);
-    assert(strcmp(j, "{\"a\":\"x\",\"b\":1,\"c\":2.5,\"d\":0.333333333333}") == 0);
-    free(j); json_obj_free(o);
+    assert(
+        strcmp(j, "{\"a\":\"x\",\"b\":1,\"c\":2.5,\"d\":0.333333333333}") == 0);
+    free(j);
+    json_obj_free(o);
 
     o = json_obj_new();
     json_obj_str(o, "s", "a\tb\nc\x01");
     j = json_obj_render(o);
     assert(strcmp(j, "{\"s\":\"a\\tb\\nc\\u0001\"}") == 0);
-    free(j); json_obj_free(o);
+    free(j);
+    json_obj_free(o);
 
     assert(now_ns() > 0);
     (void)process_cpu_ns();
@@ -125,13 +141,18 @@ static void test_json(void)
 static void test_sender_range(void)
 {
     size_t lo, hi;
-    sender_range(10, 1, 0, &lo, &hi); assert(lo == 0 && hi == 10);
-    sender_range(10, 3, 0, &lo, &hi); assert(lo == 0 && hi == 3);
-    sender_range(10, 3, 1, &lo, &hi); assert(lo == 3 && hi == 6);
-    sender_range(10, 3, 2, &lo, &hi); assert(lo == 6 && hi == 10);
+    sender_range(10, 1, 0, &lo, &hi);
+    assert(lo == 0 && hi == 10);
+    sender_range(10, 3, 0, &lo, &hi);
+    assert(lo == 0 && hi == 3);
+    sender_range(10, 3, 1, &lo, &hi);
+    assert(lo == 3 && hi == 6);
+    sender_range(10, 3, 2, &lo, &hi);
+    assert(lo == 6 && hi == 10);
     /* exact tiling on an awkward split */
     size_t prev = 0;
-    for (size_t k = 0; k < 7; k++) {
+    for (size_t k = 0; k < 7; k++)
+    {
         sender_range(1000003, 7, k, &lo, &hi);
         assert(lo == prev && hi >= lo);
         prev = hi;
@@ -141,7 +162,8 @@ static void test_sender_range(void)
      * sender) always ends at hi==rows and can never be empty for rows>=1
      * (lo=rows*(n-1)/n < rows strictly); the empty ranges live at the
      * interior tail indices before that, e.g. k=6 here (k=7 is (1,2)). */
-    sender_range(2, 8, 6, &lo, &hi); assert(lo == 1 && hi == 1);
+    sender_range(2, 8, 6, &lo, &hi);
+    assert(lo == 1 && hi == 1);
 }
 
 int main(void)

--- a/examples/qwp_egress_c.c
+++ b/examples/qwp_egress_c.c
@@ -26,42 +26,64 @@
 #define PROG "qwp_egress_c"
 #define POPULATE_BATCH_ROWS 10000 /* Rust egress hardcodes max_rows(10_000) */
 
-static void populate(const char* host, size_t port, const char* base,
-                     schema_kind kind, size_t rows, size_t sym_card,
-                     size_t varchar_len, size_t hi_sym_card)
+static void populate(
+    const char* host,
+    size_t port,
+    const char* base,
+    schema_kind kind,
+    size_t rows,
+    size_t sym_card,
+    size_t varchar_len,
+    size_t hi_sym_card)
 {
     const char* table = schema_table(kind);
     char drop[256];
     snprintf(drop, sizeof(drop), "DROP TABLE IF EXISTS %s", table);
-    if (http_exec_sql(base, drop) != 0
-        || http_exec_sql(base, schema_create_sql(kind)) != 0)
+    if (http_exec_sql(base, drop) != 0 ||
+        http_exec_sql(base, schema_create_sql(kind)) != 0)
         exit(1);
 
     bench_data d;
-    if (bench_data_build(&d, kind, rows, sym_card, varchar_len, hi_sym_card) != 0) {
+    if (bench_data_build(&d, kind, rows, sym_card, varchar_len, hi_sym_card) !=
+        0)
+    {
         fprintf(stderr, "[" PROG "] data build OOM\n");
         exit(1);
     }
     char conf[256];
-    snprintf(conf, sizeof(conf),
-             "ws::addr=%s:%zu;sender_pool_min=1;sender_pool_max=1;pool_reap=manual;",
-             host, port);
+    snprintf(
+        conf,
+        sizeof(conf),
+        "ws::addr=%s:%zu;sender_pool_min=1;sender_pool_max=1;pool_reap=manual;",
+        host,
+        port);
     line_sender_error* err = NULL;
     questdb_db* db = questdb_db_connect(conf, strlen(conf), &err);
-    if (!db) bench_die(PROG, "connect", err);
+    if (!db)
+        bench_die(PROG, "connect", err);
     /* Direct sender = the pipelined backend flush_polars_dataframe uses
      * (parity with the Rust bench). Unlike the store-and-forward sender it
      * never re-states the connection-lifetime symbol dict in replay frames,
      * and it has no internal failover — errors are fatal for the bench
      * (bench_die), which is the intended behavior. */
-    qwp_direct_sender* sender =
-        questdb_db_borrow_direct_sender(db, &err);
-    if (!sender) bench_die(PROG, "borrow sender", err);
+    qwp_direct_sender* sender = questdb_db_borrow_direct_sender(db, &err);
+    if (!sender)
+        bench_die(PROG, "borrow sender", err);
     qwp_chunk* chunk = qwp_chunk_new(table, strlen(table), &err);
-    if (!chunk) bench_die(PROG, "chunk_new", err);
+    if (!chunk)
+        bench_die(PROG, "chunk_new", err);
 
     stage_scratch scratch = {0};
-    ingest_pass(sender, chunk, &d, kind, 0, d.rows, POPULATE_BATCH_ROWS, &scratch, PROG);
+    ingest_pass(
+        sender,
+        chunk,
+        &d,
+        kind,
+        0,
+        d.rows,
+        POPULATE_BATCH_ROWS,
+        &scratch,
+        PROG);
     free(scratch.note_off);
 
     qwp_chunk_free(chunk);
@@ -71,7 +93,8 @@ static void populate(const char* host, size_t port, const char* base,
 
     fprintf(stderr, "[" PROG "] waiting for WAL apply (count == %zu)\n", rows);
     long long count = wait_for_count(base, table, (long long)rows);
-    if (count != (long long)rows) {
+    if (count != (long long)rows)
+    {
         fprintf(stderr, "[" PROG "] populate count %lld != %zu\n", count, rows);
         exit(2);
     }
@@ -80,8 +103,11 @@ static void populate(const char* host, size_t port, const char* base,
 /* One read pass. materialize=0: decode-only (row counting).
  * materialize=1: touch every cell through the typed getters, fold into a
  * checksum so the reads cannot be optimized away. Returns rows seen. */
-static size_t read_pass(const char* rconf, const char* select, int materialize,
-                        double* checksum_out)
+static size_t read_pass(
+    const char* rconf,
+    const char* select,
+    int materialize,
+    double* checksum_out)
 {
     questdb_error* err = NULL;
     line_sender_utf8 conf_u, sql_u;
@@ -90,44 +116,57 @@ static size_t read_pass(const char* rconf, const char* select, int materialize,
     if (!line_sender_utf8_init(&sql_u, strlen(select), select, &err))
         bench_die(PROG, "sql utf8", err);
     qwp_reader* r = qwp_reader_from_conf(conf_u, &err);
-    if (!r) bench_die(PROG, "qwp_reader_from_conf", err);
+    if (!r)
+        bench_die(PROG, "qwp_reader_from_conf", err);
     qwp_reader_cursor* cur = qwp_reader_execute(r, sql_u, &err);
-    if (!cur) bench_die(PROG, "qwp_reader_execute", err);
+    if (!cur)
+        bench_die(PROG, "qwp_reader_execute", err);
 
     size_t seen = 0;
     double checksum = 0.0;
     const qwp_reader_batch* batch;
-    while ((batch = qwp_reader_cursor_next_batch(cur, &err)) != NULL) {
+    while ((batch = qwp_reader_cursor_next_batch(cur, &err)) != NULL)
+    {
         size_t nrows = qwp_reader_batch_row_count(batch);
-        if (materialize) {
+        if (materialize)
+        {
             size_t ncols = qwp_reader_batch_column_count(batch);
             qwp_reader_symbol_dict dict = {0};
             if (!qwp_reader_batch_symbol_dict(batch, &dict, &err))
                 bench_die(PROG, "symbol_dict", err);
-            for (size_t c = 0; c < ncols; c++) {
+            for (size_t c = 0; c < ncols; c++)
+            {
                 qwp_reader_column_data col = {0};
                 if (!qwp_reader_batch_column_data(batch, c, &col, &err))
                     bench_die(PROG, "column_data", err);
-                for (size_t i = 0; i < nrows; i++) {
+                for (size_t i = 0; i < nrows; i++)
+                {
                     bool is_null = false;
-                    switch (col.kind) {
+                    switch (col.kind)
+                    {
                     case qwp_reader_column_kind_long:
                     case qwp_reader_column_kind_timestamp:
                     case qwp_reader_column_kind_timestamp_nanos:
-                        checksum += (double)qwp_reader_column_data_get_i64(&col, i, &is_null);
+                        checksum += (double)qwp_reader_column_data_get_i64(
+                            &col, i, &is_null);
                         break;
                     case qwp_reader_column_kind_double:
-                        checksum += qwp_reader_column_data_get_f64(&col, i, &is_null);
+                        checksum +=
+                            qwp_reader_column_data_get_f64(&col, i, &is_null);
                         break;
                     case qwp_reader_column_kind_symbol: {
-                        const char* s = NULL; size_t sl = 0;
-                        qwp_reader_column_data_get_symbol(&col, &dict, i, &s, &sl, &is_null);
+                        const char* s = NULL;
+                        size_t sl = 0;
+                        qwp_reader_column_data_get_symbol(
+                            &col, &dict, i, &s, &sl, &is_null);
                         checksum += (double)sl;
                         break;
                     }
                     case qwp_reader_column_kind_varchar: {
-                        const uint8_t* v = NULL; size_t vl = 0;
-                        qwp_reader_column_data_get_varlen(&col, i, &v, &vl, &is_null);
+                        const uint8_t* v = NULL;
+                        size_t vl = 0;
+                        qwp_reader_column_data_get_varlen(
+                            &col, i, &v, &vl, &is_null);
                         checksum += (double)vl;
                         break;
                     }
@@ -139,17 +178,20 @@ static size_t read_pass(const char* rconf, const char* select, int materialize,
         }
         seen += nrows;
     }
-    if (err) bench_die(PROG, "next_batch", err);
+    if (err)
+        bench_die(PROG, "next_batch", err);
     qwp_reader_cursor_free(cur);
     qwp_reader_close(r);
-    if (checksum_out) *checksum_out = checksum;
+    if (checksum_out)
+        *checksum_out = checksum;
     return seen;
 }
 
 int main(void)
 {
     schema_kind kind;
-    if (schema_parse(env_str("SCHEMA", "s1-narrow"), &kind) != 0) {
+    if (schema_parse(env_str("SCHEMA", "s1-narrow"), &kind) != 0)
+    {
         fprintf(stderr, "[" PROG "] unknown SCHEMA\n");
         return 1;
     }
@@ -168,16 +210,27 @@ int main(void)
 
     char base[256], rconf[256];
     snprintf(base, sizeof(base), "http://%s:%zu", host, port);
-    snprintf(rconf, sizeof(rconf), "ws::addr=%s:%zu;compression=raw;", host, port);
+    snprintf(
+        rconf, sizeof(rconf), "ws::addr=%s:%zu;compression=raw;", host, port);
 
-    fprintf(stderr, "[" PROG "] schema=%s rows=%zu it=%zu wu=%zu host=%s:%zu\n",
-            schema_name(kind), rows, iterations, warmups, host, port);
+    fprintf(
+        stderr,
+        "[" PROG "] schema=%s rows=%zu it=%zu wu=%zu host=%s:%zu\n",
+        schema_name(kind),
+        rows,
+        iterations,
+        warmups,
+        host,
+        port);
 
     if (!skip_populate)
-        populate(host, port, base, kind, rows, sym_card, varchar_len, hi_sym_card);
+        populate(
+            host, port, base, kind, rows, sym_card, varchar_len, hi_sym_card);
     else
-        fprintf(stderr, "[" PROG "] SKIP_POPULATE: reading existing %s\n",
-                schema_table(kind));
+        fprintf(
+            stderr,
+            "[" PROG "] SKIP_POPULATE: reading existing %s\n",
+            schema_table(kind));
 
     uint64_t* wall = malloc(iterations * sizeof(uint64_t));
     uint64_t* cpu = malloc(iterations * sizeof(uint64_t));
@@ -185,38 +238,56 @@ int main(void)
 
     /* decode-only floor */
     for (size_t w = 0; w < warmups; w++)
-        if (read_pass(rconf, select, 0, NULL) != rows) {
+        if (read_pass(rconf, select, 0, NULL) != rows)
+        {
             fprintf(stderr, "[" PROG "] warmup row mismatch\n");
             return 2;
         }
-    for (size_t i = 0; i < iterations; i++) {
+    for (size_t i = 0; i < iterations; i++)
+    {
         uint64_t c0 = process_cpu_ns(), t0 = now_ns();
         size_t seen = read_pass(rconf, select, 0, NULL);
         wall[i] = now_ns() - t0;
         cpu[i] = process_cpu_ns() - c0;
-        if (seen != rows) { fprintf(stderr, "[" PROG "] rows %zu != %zu\n", seen, rows); return 2; }
+        if (seen != rows)
+        {
+            fprintf(stderr, "[" PROG "] rows %zu != %zu\n", seen, rows);
+            return 2;
+        }
     }
     double floor_median = median_s_of(wall, iterations);
-    json_obj_obj(paths, "decode-only",
-        path_summary(wall, cpu, iterations, rows, columns, 0, "floor", warmups > 0));
+    json_obj_obj(
+        paths,
+        "decode-only",
+        path_summary(
+            wall, cpu, iterations, rows, columns, 0, "floor", warmups > 0));
 
     /* materialize e2e */
     double checksum = 0.0;
     for (size_t w = 0; w < warmups; w++)
-        if (read_pass(rconf, select, 1, &checksum) != rows) {
+        if (read_pass(rconf, select, 1, &checksum) != rows)
+        {
             fprintf(stderr, "[" PROG "] warmup row mismatch\n");
             return 2;
         }
-    for (size_t i = 0; i < iterations; i++) {
+    for (size_t i = 0; i < iterations; i++)
+    {
         uint64_t c0 = process_cpu_ns(), t0 = now_ns();
         size_t seen = read_pass(rconf, select, 1, &checksum);
         wall[i] = now_ns() - t0;
         cpu[i] = process_cpu_ns() - c0;
-        if (seen != rows) { fprintf(stderr, "[" PROG "] rows %zu != %zu\n", seen, rows); return 2; }
+        if (seen != rows)
+        {
+            fprintf(stderr, "[" PROG "] rows %zu != %zu\n", seen, rows);
+            return 2;
+        }
     }
     double e2e_median = median_s_of(wall, iterations);
-    json_obj_obj(paths, "materialize",
-        path_summary(wall, cpu, iterations, rows, columns, 0, "e2e", warmups > 0));
+    json_obj_obj(
+        paths,
+        "materialize",
+        path_summary(
+            wall, cpu, iterations, rows, columns, 0, "e2e", warmups > 0));
     fprintf(stderr, "[" PROG "] checksum=%f\n", checksum);
 
     json_obj* report = json_obj_new();
@@ -246,10 +317,14 @@ int main(void)
     json_obj* commits = json_obj_new();
     const char* cc = getenv("C_QUESTDB_CLIENT_COMMIT");
     const char* py = getenv("PY_QUESTDB_CLIENT_COMMIT");
-    if (cc) json_obj_str(commits, "c_questdb_client", cc);
-    else json_obj_null(commits, "c_questdb_client");
-    if (py) json_obj_str(commits, "py_questdb_client", py);
-    else json_obj_null(commits, "py_questdb_client");
+    if (cc)
+        json_obj_str(commits, "c_questdb_client", cc);
+    else
+        json_obj_null(commits, "c_questdb_client");
+    if (py)
+        json_obj_str(commits, "py_questdb_client", py);
+    else
+        json_obj_null(commits, "py_questdb_client");
     json_obj_obj(report, "commits", commits);
 
     json_obj* rcc = json_obj_new();
@@ -263,7 +338,8 @@ int main(void)
     json_obj_float(headline, "decode_floor_s", floor_median);
     json_obj_float(headline, "materialize_s", e2e_median);
     if (e2e_median != 0.0)
-        json_obj_float(headline, "materialize_rows_per_s", (double)rows / e2e_median);
+        json_obj_float(
+            headline, "materialize_rows_per_s", (double)rows / e2e_median);
     json_obj_obj(report, "headline", headline);
 
     json_obj_str(report, "real_conf", rconf);

--- a/examples/qwp_ingress_c.c
+++ b/examples/qwp_ingress_c.c
@@ -26,7 +26,8 @@
 
 /* One parallel sender: its own connection, chunk, scratch and row range.
  * bench_die() exits the whole process on error — acceptable for a bench. */
-typedef struct {
+typedef struct
+{
     qwp_direct_sender* sender;
     qwp_chunk* chunk;
     const bench_data* d;
@@ -38,20 +39,30 @@ typedef struct {
 static void* sender_thread(void* arg)
 {
     sender_job* j = arg;
-    ingest_pass(j->sender, j->chunk, j->d, j->kind, j->lo, j->hi,
-                j->max_batch_rows, &j->scratch, PROG);
+    ingest_pass(
+        j->sender,
+        j->chunk,
+        j->d,
+        j->kind,
+        j->lo,
+        j->hi,
+        j->max_batch_rows,
+        &j->scratch,
+        PROG);
     return NULL;
 }
 
 static void run_multi_pass(sender_job* jobs, size_t n)
 {
-    if (n == 1) { /* classic path: no thread overhead in the timed region */
+    if (n == 1)
+    { /* classic path: no thread overhead in the timed region */
         sender_thread(&jobs[0]);
         return;
     }
     pthread_t* tids = malloc(n * sizeof(pthread_t));
     for (size_t k = 0; k < n; k++)
-        if (pthread_create(&tids[k], NULL, sender_thread, &jobs[k]) != 0) {
+        if (pthread_create(&tids[k], NULL, sender_thread, &jobs[k]) != 0)
+        {
             fprintf(stderr, "[" PROG "] pthread_create failed\n");
             exit(1);
         }
@@ -63,7 +74,8 @@ static void run_multi_pass(sender_job* jobs, size_t n)
 int main(void)
 {
     schema_kind kind;
-    if (schema_parse(env_str("SCHEMA", "s1-narrow"), &kind) != 0) {
+    if (schema_parse(env_str("SCHEMA", "s1-narrow"), &kind) != 0)
+    {
         fprintf(stderr, "[" PROG "] unknown SCHEMA\n");
         return 1;
     }
@@ -75,7 +87,8 @@ int main(void)
     size_t warmups = env_zu("WARMUPS", 2);
     size_t max_batch_rows = env_zu("MAX_BATCH_ROWS", 10000);
     size_t n_senders = env_zu("SENDERS", 1);
-    if (n_senders < 1) n_senders = 1;
+    if (n_senders < 1)
+        n_senders = 1;
     const char* run_mode = env_str("RUN_MODE", "full");
     const char* host = env_str("QDB_HOST", "127.0.0.1");
     size_t port = env_zu("QDB_PORT", 9000);
@@ -83,12 +96,24 @@ int main(void)
     size_t columns = schema_columns(kind);
     const char* table = schema_table(kind);
 
-    fprintf(stderr,
-        "[" PROG "] schema=%s rows=%zu it=%zu wu=%zu batch=%zu senders=%zu host=%s:%zu\n",
-        schema_name(kind), rows, iterations, warmups, max_batch_rows, n_senders, host, port);
+    fprintf(
+        stderr,
+        "[" PROG
+        "] schema=%s rows=%zu it=%zu wu=%zu batch=%zu senders=%zu "
+        "host=%s:%zu\n",
+        schema_name(kind),
+        rows,
+        iterations,
+        warmups,
+        max_batch_rows,
+        n_senders,
+        host,
+        port);
 
     bench_data d;
-    if (bench_data_build(&d, kind, rows, sym_card, varchar_len, hi_sym_card) != 0) {
+    if (bench_data_build(&d, kind, rows, sym_card, varchar_len, hi_sym_card) !=
+        0)
+    {
         fprintf(stderr, "[" PROG "] data build OOM\n");
         return 1;
     }
@@ -101,36 +126,63 @@ int main(void)
 
     /* ---- floor: chunk-build (no server) ---- */
     qwp_chunk* chunk = qwp_chunk_new(table, strlen(table), &err);
-    if (!chunk) bench_die(PROG, "chunk_new", err);
+    if (!chunk)
+        bench_die(PROG, "chunk_new", err);
     stage_scratch floor_scratch = {0};
     for (size_t w = 0; w < warmups; w++)
-        ingest_pass(NULL, chunk, &d, kind, 0, rows, max_batch_rows, &floor_scratch, PROG);
-    for (size_t i = 0; i < iterations; i++) {
+        ingest_pass(
+            NULL,
+            chunk,
+            &d,
+            kind,
+            0,
+            rows,
+            max_batch_rows,
+            &floor_scratch,
+            PROG);
+    for (size_t i = 0; i < iterations; i++)
+    {
         uint64_t c0 = process_cpu_ns(), t0 = now_ns();
-        ingest_pass(NULL, chunk, &d, kind, 0, rows, max_batch_rows, &floor_scratch, PROG);
+        ingest_pass(
+            NULL,
+            chunk,
+            &d,
+            kind,
+            0,
+            rows,
+            max_batch_rows,
+            &floor_scratch,
+            PROG);
         wall[i] = now_ns() - t0;
         cpu[i] = process_cpu_ns() - c0;
     }
     free(floor_scratch.note_off);
     double floor_median = median_s_of(wall, iterations);
-    json_obj_obj(paths, "chunk-build",
-        path_summary(wall, cpu, iterations, rows, columns, 0, "floor", warmups > 0));
+    json_obj_obj(
+        paths,
+        "chunk-build",
+        path_summary(
+            wall, cpu, iterations, rows, columns, 0, "floor", warmups > 0));
 
     char base[256], conf[256];
     snprintf(base, sizeof(base), "http://%s:%zu", host, port);
-    snprintf(conf, sizeof(conf),
-             "ws::addr=%s:%zu;sender_pool_min=1;sender_pool_max=1;pool_reap=manual;"
-             /* ingestion-only: skip the eager reader pre-open */
-             "query_pool_min=0;",
-             host, port);
+    snprintf(
+        conf,
+        sizeof(conf),
+        "ws::addr=%s:%zu;sender_pool_min=1;sender_pool_max=1;pool_reap=manual;"
+        /* ingestion-only: skip the eager reader pre-open */
+        "query_pool_min=0;",
+        host,
+        port);
 
     long long count = -1;
     double e2e_median = 0.0;
-    if (!skip_e2e) {
+    if (!skip_e2e)
+    {
         char drop[256];
         snprintf(drop, sizeof(drop), "DROP TABLE IF EXISTS %s", table);
-        if (http_exec_sql(base, drop) != 0
-            || http_exec_sql(base, schema_create_sql(kind)) != 0)
+        if (http_exec_sql(base, drop) != 0 ||
+            http_exec_sql(base, schema_create_sql(kind)) != 0)
             return 1;
 
         /* Direct sender = the pipelined backend flush_polars_dataframe uses
@@ -140,13 +192,17 @@ int main(void)
          * bench (bench_die), which is the intended behavior. */
         questdb_db** dbs = malloc(n_senders * sizeof(questdb_db*));
         sender_job* jobs = calloc(n_senders, sizeof(sender_job));
-        for (size_t k = 0; k < n_senders; k++) {
+        for (size_t k = 0; k < n_senders; k++)
+        {
             dbs[k] = questdb_db_connect(conf, strlen(conf), &err);
-            if (!dbs[k]) bench_die(PROG, "connect", err);
+            if (!dbs[k])
+                bench_die(PROG, "connect", err);
             jobs[k].sender = questdb_db_borrow_direct_sender(dbs[k], &err);
-            if (!jobs[k].sender) bench_die(PROG, "borrow sender", err);
+            if (!jobs[k].sender)
+                bench_die(PROG, "borrow sender", err);
             jobs[k].chunk = qwp_chunk_new(table, strlen(table), &err);
-            if (!jobs[k].chunk) bench_die(PROG, "chunk_new", err);
+            if (!jobs[k].chunk)
+                bench_die(PROG, "chunk_new", err);
             jobs[k].d = &d;
             jobs[k].kind = kind;
             sender_range(rows, n_senders, k, &jobs[k].lo, &jobs[k].hi);
@@ -155,17 +211,22 @@ int main(void)
 
         for (size_t w = 0; w < warmups; w++)
             run_multi_pass(jobs, n_senders);
-        for (size_t i = 0; i < iterations; i++) {
+        for (size_t i = 0; i < iterations; i++)
+        {
             uint64_t c0 = process_cpu_ns(), t0 = now_ns();
             run_multi_pass(jobs, n_senders);
             wall[i] = now_ns() - t0;
             cpu[i] = process_cpu_ns() - c0;
         }
         e2e_median = median_s_of(wall, iterations);
-        json_obj_obj(paths, "flush-chunks",
-            path_summary(wall, cpu, iterations, rows, columns, 0, "e2e", warmups > 0));
+        json_obj_obj(
+            paths,
+            "flush-chunks",
+            path_summary(
+                wall, cpu, iterations, rows, columns, 0, "e2e", warmups > 0));
 
-        for (size_t k = 0; k < n_senders; k++) {
+        for (size_t k = 0; k < n_senders; k++)
+        {
             questdb_db_return_direct_sender(dbs[k], jobs[k].sender);
             questdb_db_close(dbs[k]);
             qwp_chunk_free(jobs[k].chunk);
@@ -174,9 +235,12 @@ int main(void)
         free(jobs);
         free(dbs);
 
-        fprintf(stderr, "[" PROG "] waiting for WAL apply (count == %zu)\n", rows);
+        fprintf(
+            stderr, "[" PROG "] waiting for WAL apply (count == %zu)\n", rows);
         count = wait_for_count(base, table, (long long)rows);
-    } else {
+    }
+    else
+    {
         fprintf(stderr, "[" PROG "] SKIP_E2E: floor only\n");
     }
     qwp_chunk_free(chunk);
@@ -210,21 +274,28 @@ int main(void)
     json_obj* commits = json_obj_new();
     const char* cc = getenv("C_QUESTDB_CLIENT_COMMIT");
     const char* py = getenv("PY_QUESTDB_CLIENT_COMMIT");
-    if (cc) json_obj_str(commits, "c_questdb_client", cc);
-    else json_obj_null(commits, "c_questdb_client");
-    if (py) json_obj_str(commits, "py_questdb_client", py);
-    else json_obj_null(commits, "py_questdb_client");
+    if (cc)
+        json_obj_str(commits, "c_questdb_client", cc);
+    else
+        json_obj_null(commits, "c_questdb_client");
+    if (py)
+        json_obj_str(commits, "py_questdb_client", py);
+    else
+        json_obj_null(commits, "py_questdb_client");
     json_obj_obj(report, "commits", commits);
 
     json_obj_float(headline, "chunk_build_s", floor_median);
     if (floor_median != 0.0)
-        json_obj_float(headline, "chunk_build_rows_per_s", (double)rows / floor_median);
-    if (!skip_e2e) {
+        json_obj_float(
+            headline, "chunk_build_rows_per_s", (double)rows / floor_median);
+    if (!skip_e2e)
+    {
         json_obj_float(headline, "flush_chunks_s", e2e_median);
         double ovh = e2e_median - floor_median;
         json_obj_float(headline, "staging_overhead_s", ovh < 0.0 ? 0.0 : ovh);
         if (e2e_median != 0.0)
-            json_obj_float(headline, "flush_chunks_rows_per_s", (double)rows / e2e_median);
+            json_obj_float(
+                headline, "flush_chunks_rows_per_s", (double)rows / e2e_median);
         json_obj* rcc = json_obj_new();
         json_obj_int(rcc, "expected", (uint64_t)rows);
         json_obj_int(rcc, "actual", (uint64_t)(count < 0 ? 0 : count));

--- a/examples/reader_c_example_arrow.c
+++ b/examples/reader_c_example_arrow.c
@@ -3,7 +3,8 @@
 #include <stdio.h>
 #include <string.h>
 
-static void print_batch(const struct ArrowArray* arr, const struct ArrowSchema* sch)
+static void print_batch(
+    const struct ArrowArray* arr, const struct ArrowSchema* sch)
 {
     for (int64_t c = 0; c < sch->n_children; ++c)
     {
@@ -63,8 +64,8 @@ int main(int argc, const char* argv[])
     if (!reader)
         goto on_error;
 
-    line_sender_utf8 sql = QDB_UTF8_LITERAL(
-        "SELECT x AS n, x * 1.5 AS d FROM long_sequence(5)");
+    line_sender_utf8 sql =
+        QDB_UTF8_LITERAL("SELECT x AS n, x * 1.5 AS d FROM long_sequence(5)");
     cursor = qwp_reader_execute(reader, sql, &err);
     if (!cursor)
         goto on_error;

--- a/examples/reader_c_example_columns.c
+++ b/examples/reader_c_example_columns.c
@@ -40,20 +40,22 @@
 
 static void print_hex(const uint8_t* p, size_t n)
 {
-    for (size_t i = 0; i < n; ++i) printf("%02x", p[i]);
+    for (size_t i = 0; i < n; ++i)
+        printf("%02x", p[i]);
 }
 
 static int print_scalar_column(
     const qwp_reader_batch* batch, size_t col_idx, questdb_error** err)
 {
     qwp_reader_column_data d = {0};
-    if (!qwp_reader_batch_column_data(batch, col_idx, &d, err)) return -1;
+    if (!qwp_reader_batch_column_data(batch, col_idx, &d, err))
+        return -1;
 
     /* For SYMBOL columns we resolve dict codes per row; fetch the dict
      * snapshot once outside the row loop. */
     qwp_reader_symbol_dict dict = {0};
-    if (d.kind == qwp_reader_column_kind_symbol
-        && !qwp_reader_batch_symbol_dict(batch, &dict, err))
+    if (d.kind == qwp_reader_column_kind_symbol &&
+        !qwp_reader_batch_symbol_dict(batch, &dict, err))
         return -1;
 
     for (size_t r = 0; r < d.row_count; ++r)
@@ -67,9 +69,10 @@ static int print_scalar_column(
         switch (d.kind)
         {
         case qwp_reader_column_kind_boolean:
-            printf("%s\t",
-                   qwp_reader_column_data_get_bool(&d, r, &is_null)
-                       ? "true" : "false");
+            printf(
+                "%s\t",
+                qwp_reader_column_data_get_bool(&d, r, &is_null) ? "true"
+                                                                 : "false");
             break;
         case qwp_reader_column_kind_byte:
             printf("%d\t", qwp_reader_column_data_get_i8(&d, r, &is_null));
@@ -78,25 +81,28 @@ static int print_scalar_column(
             printf("%d\t", qwp_reader_column_data_get_i16(&d, r, &is_null));
             break;
         case qwp_reader_column_kind_char:
-            printf("U+%04X\t",
-                   qwp_reader_column_data_get_char(&d, r, &is_null));
+            printf(
+                "U+%04X\t", qwp_reader_column_data_get_char(&d, r, &is_null));
             break;
         case qwp_reader_column_kind_int:
-            printf("%" PRId32 "\t",
-                   qwp_reader_column_data_get_i32(&d, r, &is_null));
+            printf(
+                "%" PRId32 "\t",
+                qwp_reader_column_data_get_i32(&d, r, &is_null));
             break;
-        case qwp_reader_column_kind_ipv4:
-        {
-            const uint32_t v =
-                qwp_reader_column_data_get_ipv4(&d, r, &is_null);
-            printf("%u.%u.%u.%u\t",
-                   (v >> 24) & 0xFF, (v >> 16) & 0xFF,
-                   (v >> 8) & 0xFF, v & 0xFF);
+        case qwp_reader_column_kind_ipv4: {
+            const uint32_t v = qwp_reader_column_data_get_ipv4(&d, r, &is_null);
+            printf(
+                "%u.%u.%u.%u\t",
+                (v >> 24) & 0xFF,
+                (v >> 16) & 0xFF,
+                (v >> 8) & 0xFF,
+                v & 0xFF);
             break;
         }
         case qwp_reader_column_kind_float:
-            printf("%g\t", (double)qwp_reader_column_data_get_f32(
-                                &d, r, &is_null));
+            printf(
+                "%g\t",
+                (double)qwp_reader_column_data_get_f32(&d, r, &is_null));
             break;
         case qwp_reader_column_kind_double:
             printf("%g\t", qwp_reader_column_data_get_f64(&d, r, &is_null));
@@ -105,41 +111,40 @@ static int print_scalar_column(
         case qwp_reader_column_kind_timestamp:
         case qwp_reader_column_kind_date:
         case qwp_reader_column_kind_timestamp_nanos:
-            printf("%" PRId64 "\t",
-                   qwp_reader_column_data_get_i64(&d, r, &is_null));
+            printf(
+                "%" PRId64 "\t",
+                qwp_reader_column_data_get_i64(&d, r, &is_null));
             break;
         case qwp_reader_column_kind_decimal64:
-            printf("%" PRId64 "e%d\t",
-                   qwp_reader_column_data_get_decimal64_mantissa(
-                       &d, r, &is_null),
-                   -(int)d.decimal_scale);
+            printf(
+                "%" PRId64 "e%d\t",
+                qwp_reader_column_data_get_decimal64_mantissa(&d, r, &is_null),
+                -(int)d.decimal_scale);
             break;
         case qwp_reader_column_kind_decimal128:
         case qwp_reader_column_kind_decimal256:
         case qwp_reader_column_kind_uuid:
-        case qwp_reader_column_kind_long256:
-        {
+        case qwp_reader_column_kind_long256: {
             uint8_t bytes[32];
             qwp_reader_column_data_get_bytes(&d, r, bytes, &is_null);
             print_hex(bytes, d.value_stride);
-            if (d.kind == qwp_reader_column_kind_decimal128
-                || d.kind == qwp_reader_column_kind_decimal256)
+            if (d.kind == qwp_reader_column_kind_decimal128 ||
+                d.kind == qwp_reader_column_kind_decimal256)
                 printf("e%d", -(int)d.decimal_scale);
             printf("\t");
             break;
         }
         case qwp_reader_column_kind_geohash:
-            printf("%" PRIx64 "/%u\t",
-                   qwp_reader_column_data_get_geohash(&d, r, &is_null),
-                   (unsigned)d.geohash_precision_bits);
+            printf(
+                "%" PRIx64 "/%u\t",
+                qwp_reader_column_data_get_geohash(&d, r, &is_null),
+                (unsigned)d.geohash_precision_bits);
             break;
         case qwp_reader_column_kind_varchar:
-        case qwp_reader_column_kind_binary:
-        {
+        case qwp_reader_column_kind_binary: {
             const uint8_t* buf = NULL;
             size_t len = 0;
-            qwp_reader_column_data_get_varlen(
-                &d, r, &buf, &len, &is_null);
+            qwp_reader_column_data_get_varlen(&d, r, &buf, &len, &is_null);
             if (d.kind == qwp_reader_column_kind_varchar)
                 printf("%.*s\t", (int)len, (const char*)buf);
             else
@@ -149,8 +154,7 @@ static int print_scalar_column(
             }
             break;
         }
-        case qwp_reader_column_kind_symbol:
-        {
+        case qwp_reader_column_kind_symbol: {
             const char* sym_buf = NULL;
             size_t sym_len = 0;
             if (!qwp_reader_column_data_get_symbol(
@@ -179,8 +183,7 @@ static int print_double_array_column(
 
     for (size_t r = 0; r < d.row_count; ++r)
     {
-        if (d.validity != NULL
-            && ((d.validity[r >> 3] >> (r & 7)) & 1))
+        if (d.validity != NULL && ((d.validity[r >> 3] >> (r & 7)) & 1))
         {
             printf("NULL\t");
             continue;
@@ -213,12 +216,14 @@ int main(int argc, const char* argv[])
 
     line_sender_utf8 conf = QDB_UTF8_LITERAL("ws::addr=localhost:9000;");
     reader = qwp_reader_from_conf(conf, &err);
-    if (!reader) goto on_error;
+    if (!reader)
+        goto on_error;
 
-    line_sender_utf8 sql = QDB_UTF8_LITERAL(
-        "SELECT x AS n, x * 1.5 AS d FROM long_sequence(5)");
+    line_sender_utf8 sql =
+        QDB_UTF8_LITERAL("SELECT x AS n, x * 1.5 AS d FROM long_sequence(5)");
     cursor = qwp_reader_execute(reader, sql, &err);
-    if (!cursor) goto on_error;
+    if (!cursor)
+        goto on_error;
 
     const qwp_reader_batch* batch;
     while ((batch = qwp_reader_cursor_next_batch(cursor, &err)) != NULL)
@@ -242,7 +247,8 @@ int main(int argc, const char* argv[])
             const int prc = (k == qwp_reader_column_kind_double_array)
                                 ? print_double_array_column(batch, c, &err)
                                 : print_scalar_column(batch, c, &err);
-            if (prc != 0) goto on_error;
+            if (prc != 0)
+                goto on_error;
         }
         printf("\n");
     }

--- a/examples/reader_c_example_from_conf.c
+++ b/examples/reader_c_example_from_conf.c
@@ -18,8 +18,8 @@ int main(int argc, const char* argv[])
     if (!reader)
         goto on_error;
 
-    line_sender_utf8 sql = QDB_UTF8_LITERAL(
-        "SELECT x AS n, x * 1.5 AS d FROM long_sequence(5)");
+    line_sender_utf8 sql =
+        QDB_UTF8_LITERAL("SELECT x AS n, x * 1.5 AS d FROM long_sequence(5)");
     query = qwp_reader_prepare(reader, sql, &err);
     if (!query)
         goto on_error;
@@ -52,8 +52,7 @@ int main(int argc, const char* argv[])
                 bool is_null = false;
                 switch (d[c].kind)
                 {
-                case qwp_reader_column_kind_long:
-                {
+                case qwp_reader_column_kind_long: {
                     int64_t v =
                         qwp_reader_column_data_get_i64(&d[c], r, &is_null);
                     if (is_null)
@@ -62,8 +61,7 @@ int main(int argc, const char* argv[])
                         printf("%lld ", (long long)v);
                     break;
                 }
-                case qwp_reader_column_kind_double:
-                {
+                case qwp_reader_column_kind_double: {
                     double v =
                         qwp_reader_column_data_get_f64(&d[c], r, &is_null);
                     if (is_null)

--- a/examples/reader_cpp_example_arrow.cpp
+++ b/examples/reader_cpp_example_arrow.cpp
@@ -11,7 +11,8 @@
 #include <iostream>
 #include <string>
 
-namespace {
+namespace
+{
 
 namespace egress = questdb::egress;
 namespace ingress = questdb::ingress;
@@ -21,8 +22,9 @@ bool example()
     try
     {
         egress::reader reader{ingress::utf8_view{"ws::addr=localhost:9000;"}};
-        auto cursor = reader.execute(ingress::utf8_view{
-            "SELECT x AS n, x * 1.5 AS d FROM long_sequence(5)"});
+        auto cursor = reader.execute(
+            ingress::utf8_view{
+                "SELECT x AS n, x * 1.5 AS d FROM long_sequence(5)"});
 
         while (auto batch = cursor.next_arrow_batch())
         {
@@ -34,7 +36,8 @@ bool example()
             if (!rb_res.ok())
             {
                 std::fprintf(
-                    stderr, "ImportRecordBatch: %s\n",
+                    stderr,
+                    "ImportRecordBatch: %s\n",
                     rb_res.status().ToString().c_str());
                 if (batch->array.release)
                     batch->array.release(&batch->array);

--- a/examples/reader_cpp_example_from_conf.cpp
+++ b/examples/reader_cpp_example_from_conf.cpp
@@ -25,14 +25,18 @@ int main()
                     if (k == questdb::egress::column_kind::long_)
                     {
                         auto v = col.get<int64_t>(r);
-                        if (v) std::cout << *v << " ";
-                        else std::cout << "NULL ";
+                        if (v)
+                            std::cout << *v << " ";
+                        else
+                            std::cout << "NULL ";
                     }
                     else if (k == questdb::egress::column_kind::double_)
                     {
                         auto v = col.get<double>(r);
-                        if (v) std::cout << *v << " ";
-                        else std::cout << "NULL ";
+                        if (v)
+                            std::cout << *v << " ";
+                        else
+                            std::cout << "NULL ";
                     }
                     else
                     {

--- a/examples/reader_cpp_example_with_binds.cpp
+++ b/examples/reader_cpp_example_with_binds.cpp
@@ -32,9 +32,15 @@ int main()
                 auto scaled = col_scaled.get<int64_t>(r);
                 auto label = col_label.varchar(r);
                 std::cout << "scaled=";
-                if (scaled) std::cout << *scaled; else std::cout << "NULL";
+                if (scaled)
+                    std::cout << *scaled;
+                else
+                    std::cout << "NULL";
                 std::cout << " label=";
-                if (label) std::cout << *label; else std::cout << "NULL";
+                if (label)
+                    std::cout << *label;
+                else
+                    std::cout << "NULL";
                 std::cout << "\n";
             }
         }

--- a/include/questdb/client.h
+++ b/include/questdb/client.h
@@ -30,7 +30,8 @@
  * borrowed from it through the direction-specific headers:
  *
  *   - `questdb/ingress/qwp_sender.h` — borrow senders to write rows.
- *   - `questdb/egress/qwp_reader.h`         — borrow readers to run SQL queries.
+ *   - `questdb/egress/qwp_reader.h`         — borrow readers to run SQL
+ * queries.
  *
  * Either of those includes this header, so a consumer that needs only one
  * direction includes only that header. Include this one directly to hold or
@@ -120,9 +121,7 @@ typedef struct questdb_db questdb_db;
  */
 QUESTDB_CLIENT_API
 questdb_db* questdb_db_connect(
-    const char* conf,
-    size_t conf_len,
-    questdb_error** err_out);
+    const char* conf, size_t conf_len, questdb_error** err_out);
 
 /**
  * Close the pool. Accepts NULL and no-ops.

--- a/include/questdb/client.hpp
+++ b/include/questdb/client.hpp
@@ -68,8 +68,8 @@ namespace questdb
  * `query_pool_max`, `acquire_timeout_ms`, `idle_timeout_ms`, `pool_reap`).
  * With `sf_dir`, `sender_id` is the
  * slot base; pooled senders mint `<sender_id>-ingest-<index>` disk slots.
- * Those `<sender_id>-ingest-*` directories under `sf_dir` belong to the pool namespace;
- * use a unique `sender_id` for each pool sharing an `sf_dir`.
+ * Those `<sender_id>-ingest-*` directories under `sf_dir` belong to the pool
+ * namespace; use a unique `sender_id` for each pool sharing an `sf_dir`.
  *
  * Construction connects eagerly by default: it pre-opens the warm minimums
  * (`sender_pool_min` senders, `query_pool_min` readers), honoring
@@ -118,10 +118,19 @@ public:
         return *this;
     }
 
-    ~pool() noexcept { close(); }
+    ~pool() noexcept
+    {
+        close();
+    }
 
-    ::questdb_db* c_ptr() noexcept { return _raw; }
-    const ::questdb_db* c_ptr() const noexcept { return _raw; }
+    ::questdb_db* c_ptr() noexcept
+    {
+        return _raw;
+    }
+    const ::questdb_db* c_ptr() const noexcept
+    {
+        return _raw;
+    }
 
     /** Borrow a store-and-forward sender. At cap, disk-backed slots can wait
      * up to `close_flush_timeout` (default 5s) while an in-flight close
@@ -133,11 +142,11 @@ public:
     ingress::borrowed_sender borrow_sender();
 
     /**
-     * Borrow a store-and-forward sender, retrying the connect within `budget_ms`
-     * using the pool's reconnect backoff. On a transient `failover_retry`,
-     * drop the dead sender then call this with `reconnect_max_duration_ms()` (or
-     * your tracked remaining budget). Throws on a terminal error or budget
-     * exhaustion.
+     * Borrow a store-and-forward sender, retrying the connect within
+     * `budget_ms` using the pool's reconnect backoff. On a transient
+     * `failover_retry`, drop the dead sender then call this with
+     * `reconnect_max_duration_ms()` (or your tracked remaining budget). Throws
+     * on a terminal error or budget exhaustion.
      *
      * DEFINED in `questdb/ingress/qwp_sender.hpp`, alongside the
      * `borrowed_sender` type it returns. Include that header to call this.
@@ -157,12 +166,13 @@ public:
      * reader is destroyed, it is closed instead of recycled. Throws
      * `questdb::error` on cap exhaustion or transport failure.
      *
-     * DEFINED in `questdb/egress/qwp_reader.hpp`, alongside the `reader` type it
-     * returns. Include that header to call this.
+     * DEFINED in `questdb/egress/qwp_reader.hpp`, alongside the `reader` type
+     * it returns. Include that header to call this.
      */
     ::questdb::egress::reader borrow_reader();
 
-    /** The pool's failover budget (`reconnect_max_duration`) in milliseconds. */
+    /** The pool's failover budget (`reconnect_max_duration`) in milliseconds.
+     */
     uint64_t reconnect_max_duration_ms() const noexcept
     {
         return ::questdb_db_reconnect_max_duration_ms(_raw);

--- a/include/questdb/egress/qwp_reader.h
+++ b/include/questdb/egress/qwp_reader.h
@@ -116,35 +116,35 @@ extern "C" {
  */
 typedef enum qwp_reader_column_kind
 {
-    qwp_reader_column_kind_boolean         = 0x01,
-    qwp_reader_column_kind_byte            = 0x02,
-    qwp_reader_column_kind_short           = 0x03,
-    qwp_reader_column_kind_int             = 0x04,
-    qwp_reader_column_kind_long            = 0x05,
-    qwp_reader_column_kind_float           = 0x06,
-    qwp_reader_column_kind_double          = 0x07,
-    qwp_reader_column_kind_symbol          = 0x09,
-    qwp_reader_column_kind_timestamp       = 0x0A,
-    qwp_reader_column_kind_date            = 0x0B,
-    qwp_reader_column_kind_uuid            = 0x0C,
-    qwp_reader_column_kind_long256         = 0x0D,
-    qwp_reader_column_kind_geohash         = 0x0E,
-    qwp_reader_column_kind_varchar         = 0x0F,
+    qwp_reader_column_kind_boolean = 0x01,
+    qwp_reader_column_kind_byte = 0x02,
+    qwp_reader_column_kind_short = 0x03,
+    qwp_reader_column_kind_int = 0x04,
+    qwp_reader_column_kind_long = 0x05,
+    qwp_reader_column_kind_float = 0x06,
+    qwp_reader_column_kind_double = 0x07,
+    qwp_reader_column_kind_symbol = 0x09,
+    qwp_reader_column_kind_timestamp = 0x0A,
+    qwp_reader_column_kind_date = 0x0B,
+    qwp_reader_column_kind_uuid = 0x0C,
+    qwp_reader_column_kind_long256 = 0x0D,
+    qwp_reader_column_kind_geohash = 0x0E,
+    qwp_reader_column_kind_varchar = 0x0F,
     qwp_reader_column_kind_timestamp_nanos = 0x10,
-    qwp_reader_column_kind_double_array    = 0x11,
-    qwp_reader_column_kind_long_array      = 0x12,
-    qwp_reader_column_kind_decimal64       = 0x13,
-    qwp_reader_column_kind_decimal128      = 0x14,
-    qwp_reader_column_kind_decimal256      = 0x15,
-    qwp_reader_column_kind_char            = 0x16,
-    qwp_reader_column_kind_binary          = 0x17,
-    qwp_reader_column_kind_ipv4            = 0x18,
+    qwp_reader_column_kind_double_array = 0x11,
+    qwp_reader_column_kind_long_array = 0x12,
+    qwp_reader_column_kind_decimal64 = 0x13,
+    qwp_reader_column_kind_decimal128 = 0x14,
+    qwp_reader_column_kind_decimal256 = 0x15,
+    qwp_reader_column_kind_char = 0x16,
+    qwp_reader_column_kind_binary = 0x17,
+    qwp_reader_column_kind_ipv4 = 0x18,
     /** Sentinel for column kinds the running FFI build doesn't
      *  recognise. Emitted when the upstream Rust crate adds a new
      *  `ColumnKind` variant the C ABI hasn't been recompiled against
      *  yet. Treat as opaque: skip / log / surface to ops rather than
      *  route on it. */
-    qwp_reader_column_kind_unknown         = 0xFF,
+    qwp_reader_column_kind_unknown = 0xFF,
 } qwp_reader_column_kind;
 
 /////////// Reader.
@@ -168,10 +168,10 @@ typedef struct qwp_reader_query qwp_reader_query;
 /**
  * Construct a reader from a QuestDB config string.
  *
- * The config string follows the same format as the Rust `ReaderConfig::from_conf`
- * API (e.g. `"ws::addr=localhost:9000;"`). On success returns a non-NULL handle
- * that must be released with `qwp_reader_close`. On failure returns NULL and
- * sets `*err_out`.
+ * The config string follows the same format as the Rust
+ * `ReaderConfig::from_conf` API (e.g. `"ws::addr=localhost:9000;"`). On success
+ * returns a non-NULL handle that must be released with `qwp_reader_close`. On
+ * failure returns NULL and sets `*err_out`.
  *
  * The `config` payload is re-validated as UTF-8 on entry; a hand-rolled
  * `line_sender_utf8` carrying invalid bytes (i.e. one not built via
@@ -184,8 +184,7 @@ typedef struct qwp_reader_query qwp_reader_query;
  */
 QUESTDB_CLIENT_API
 qwp_reader* qwp_reader_from_conf(
-    line_sender_utf8 config,
-    questdb_error** err_out);
+    line_sender_utf8 config, questdb_error** err_out);
 
 /**
  * Construct a reader from the configuration stored in the
@@ -206,8 +205,7 @@ qwp_reader* qwp_reader_from_conf(
  * @return Reader handle or NULL.
  */
 QUESTDB_CLIENT_API
-qwp_reader* qwp_reader_from_env(
-    questdb_error** err_out);
+qwp_reader* qwp_reader_from_env(questdb_error** err_out);
 
 /**
  * Close the reader and release all associated resources. Idempotent on NULL.
@@ -261,9 +259,7 @@ void qwp_reader_drop_on_return(qwp_reader* reader);
  * was called first, or if the pool has been closed).
  */
 QUESTDB_CLIENT_API
-qwp_reader* questdb_db_borrow_reader(
-    questdb_db* db,
-    questdb_error** err_out);
+qwp_reader* questdb_db_borrow_reader(questdb_db* db, questdb_error** err_out);
 
 /** Snapshot of idle reader count. Diagnostics / test-only; not part of
  *  the supported API surface. */
@@ -296,8 +292,7 @@ uint8_t qwp_reader_has_active_query(const qwp_reader* reader);
 QUESTDB_CLIENT_API uint64_t qwp_reader_bytes_received(const qwp_reader*);
 
 /** Cumulative CREDIT bytes granted to the server across this reader. */
-QUESTDB_CLIENT_API uint64_t
-qwp_reader_credit_granted_total(const qwp_reader*);
+QUESTDB_CLIENT_API uint64_t qwp_reader_credit_granted_total(const qwp_reader*);
 
 /** Cumulative wall-clock nanoseconds spent in `read` calls (saturating). */
 QUESTDB_CLIENT_API uint64_t qwp_reader_read_ns(const qwp_reader*);
@@ -320,9 +315,7 @@ QUESTDB_CLIENT_API void qwp_reader_reset_timing(qwp_reader*);
  */
 QUESTDB_CLIENT_API
 bool qwp_reader_server_version(
-    const qwp_reader* reader,
-    uint8_t* out_version,
-    questdb_error** err_out);
+    const qwp_reader* reader, uint8_t* out_version, questdb_error** err_out);
 
 /**
  * Borrow the current endpoint host as a UTF-8 byte slice. The pointer is
@@ -334,9 +327,7 @@ bool qwp_reader_server_version(
  */
 QUESTDB_CLIENT_API
 void qwp_reader_current_addr_host(
-    const qwp_reader* reader,
-    const char** out_buf,
-    size_t* out_len);
+    const qwp_reader* reader, const char** out_buf, size_t* out_len);
 
 /**
  * Port of the endpoint the reader is currently connected to.
@@ -361,13 +352,13 @@ typedef struct qwp_reader_server_info qwp_reader_server_info;
 /** Cluster role advertised by `SERVER_INFO`. */
 typedef enum qwp_reader_server_role
 {
-    qwp_reader_server_role_standalone       = 0,
-    qwp_reader_server_role_primary          = 1,
-    qwp_reader_server_role_replica          = 2,
-    qwp_reader_server_role_primary_catchup  = 3,
+    qwp_reader_server_role_standalone = 0,
+    qwp_reader_server_role_primary = 1,
+    qwp_reader_server_role_replica = 2,
+    qwp_reader_server_role_primary_catchup = 3,
     /** Forward-compat: a server role this client doesn't recognise. The
      *  raw byte is available via `qwp_reader_server_info_role_byte`. */
-    qwp_reader_server_role_other            = 0xFF,
+    qwp_reader_server_role_other = 0xFF,
 } qwp_reader_server_role;
 
 /**
@@ -380,7 +371,8 @@ typedef enum qwp_reader_server_role
  * connection metadata).
  */
 QUESTDB_CLIENT_API
-const qwp_reader_server_info* qwp_reader_current_server_info(const qwp_reader* reader);
+const qwp_reader_server_info* qwp_reader_current_server_info(
+    const qwp_reader* reader);
 
 /** Cluster role advertised by `SERVER_INFO`. */
 QUESTDB_CLIENT_API qwp_reader_server_role
@@ -477,46 +469,53 @@ typedef struct qwp_reader_failover_reset_event qwp_reader_failover_reset_event;
  * that `user_data` remains valid and is safe to access there.
  */
 typedef void (*qwp_reader_failover_reset_callback)(
-    const qwp_reader_failover_reset_event* event,
-    void* user_data);
+    const qwp_reader_failover_reset_event* event, void* user_data);
 
 /** Host of the previously-connected endpoint that failed. UTF-8 byte slice
  *  borrowed for the duration of the callback. */
 QUESTDB_CLIENT_API void qwp_reader_failover_reset_event_failed_host(
-    const qwp_reader_failover_reset_event*, const char** out_buf, size_t* out_len);
+    const qwp_reader_failover_reset_event*,
+    const char** out_buf,
+    size_t* out_len);
 /** Port of the previously-connected endpoint that failed. */
-QUESTDB_CLIENT_API uint16_t
-qwp_reader_failover_reset_event_failed_port(const qwp_reader_failover_reset_event*);
+QUESTDB_CLIENT_API uint16_t qwp_reader_failover_reset_event_failed_port(
+    const qwp_reader_failover_reset_event*);
 /** Host of the new endpoint the cursor is reconnecting to. UTF-8 byte slice
  *  borrowed for the duration of the callback. */
 QUESTDB_CLIENT_API void qwp_reader_failover_reset_event_new_host(
-    const qwp_reader_failover_reset_event*, const char** out_buf, size_t* out_len);
+    const qwp_reader_failover_reset_event*,
+    const char** out_buf,
+    size_t* out_len);
 /** Port of the new endpoint the cursor is reconnecting to. */
-QUESTDB_CLIENT_API uint16_t
-qwp_reader_failover_reset_event_new_port(const qwp_reader_failover_reset_event*);
+QUESTDB_CLIENT_API uint16_t qwp_reader_failover_reset_event_new_port(
+    const qwp_reader_failover_reset_event*);
 /** Request_id reissued on the new connection (the original request_id is
  *  invalidated by the failover; the cursor's request_id is updated). */
-QUESTDB_CLIENT_API int64_t
-qwp_reader_failover_reset_event_new_request_id(const qwp_reader_failover_reset_event*);
+QUESTDB_CLIENT_API int64_t qwp_reader_failover_reset_event_new_request_id(
+    const qwp_reader_failover_reset_event*);
 /** Number of reconnect attempts that preceded this success (1 on the first
  *  retry, etc.). */
-QUESTDB_CLIENT_API uint32_t
-qwp_reader_failover_reset_event_attempts(const qwp_reader_failover_reset_event*);
+QUESTDB_CLIENT_API uint32_t qwp_reader_failover_reset_event_attempts(
+    const qwp_reader_failover_reset_event*);
 /** Wall-clock nanoseconds spent reconnecting — sleep + dial + handshake +
  *  `SERVER_INFO` read. Saturating. */
-QUESTDB_CLIENT_API uint64_t
-qwp_reader_failover_reset_event_elapsed_ns(const qwp_reader_failover_reset_event*);
+QUESTDB_CLIENT_API uint64_t qwp_reader_failover_reset_event_elapsed_ns(
+    const qwp_reader_failover_reset_event*);
 /** Error code that triggered the failover (cause-of-death of the previous
  *  connection). */
 QUESTDB_CLIENT_API questdb_error_code
-qwp_reader_failover_reset_event_trigger_code(const qwp_reader_failover_reset_event*);
+qwp_reader_failover_reset_event_trigger_code(
+    const qwp_reader_failover_reset_event*);
 /** Trigger error message (UTF-8). Borrowed for the duration of the call. */
 QUESTDB_CLIENT_API void qwp_reader_failover_reset_event_trigger_msg(
-    const qwp_reader_failover_reset_event*, const char** out_buf, size_t* out_len);
+    const qwp_reader_failover_reset_event*,
+    const char** out_buf,
+    size_t* out_len);
 /** `SERVER_INFO` for the new endpoint; NULL only if the server omitted
  *  it. */
 QUESTDB_CLIENT_API const qwp_reader_server_info*
-qwp_reader_failover_reset_event_server_info(const qwp_reader_failover_reset_event*);
+qwp_reader_failover_reset_event_server_info(
+    const qwp_reader_failover_reset_event*);
 
 /////////// Failover progress callback.
 
@@ -565,7 +564,8 @@ typedef enum qwp_reader_failover_phase
  * passed to your callback is valid only for the duration of that
  * callback invocation.
  */
-typedef struct qwp_reader_failover_progress_event qwp_reader_failover_progress_event;
+typedef struct qwp_reader_failover_progress_event
+    qwp_reader_failover_progress_event;
 
 /**
  * User callback fired at every phase of a mid-query failover
@@ -602,8 +602,7 @@ typedef struct qwp_reader_failover_progress_event qwp_reader_failover_progress_e
  * that `user_data` remains valid and is safe to access there.
  */
 typedef void (*qwp_reader_failover_progress_callback)(
-    const qwp_reader_failover_progress_event* event,
-    void* user_data);
+    const qwp_reader_failover_progress_event* event, void* user_data);
 
 /** Phase of this event. NULL-safe: returns
  *  `qwp_reader_failover_phase_disconnected` for a NULL handle. */
@@ -639,8 +638,7 @@ QUESTDB_CLIENT_API uint16_t qwp_reader_failover_progress_event_new_port(
  *  id to `*out_request_id` on Reset; returns `false` and writes `0` in
  *  every other phase. */
 QUESTDB_CLIENT_API bool qwp_reader_failover_progress_event_new_request_id(
-    const qwp_reader_failover_progress_event*,
-    int64_t* out_request_id);
+    const qwp_reader_failover_progress_event*, int64_t* out_request_id);
 
 /** 1-based attempt counter:
  *  - `0` on Disconnected (no attempt yet).
@@ -683,8 +681,7 @@ qwp_reader_failover_progress_event_server_info(
  *  code matches what the cursor's next `_next_batch` / `_add_credit`
  *  call will surface. */
 QUESTDB_CLIENT_API bool qwp_reader_failover_progress_event_final_error_code(
-    const qwp_reader_failover_progress_event*,
-    questdb_error_code* out_code);
+    const qwp_reader_failover_progress_event*, questdb_error_code* out_code);
 
 /** Final error message (GaveUp phase only). Returns `true` and writes
  *  the borrowed UTF-8 message on GaveUp; returns `false` and writes
@@ -722,9 +719,7 @@ QUESTDB_CLIENT_API bool qwp_reader_failover_progress_event_final_error_msg(
  */
 QUESTDB_CLIENT_API
 qwp_reader_query* qwp_reader_prepare(
-    qwp_reader* reader,
-    line_sender_utf8 sql,
-    questdb_error** err_out);
+    qwp_reader* reader, line_sender_utf8 sql, questdb_error** err_out);
 
 /**
  * Free a query without executing it. Idempotent on NULL.
@@ -752,8 +747,7 @@ void qwp_reader_query_free(qwp_reader_query* query);
  */
 QUESTDB_CLIENT_API
 qwp_reader_cursor* qwp_reader_query_execute(
-    qwp_reader_query** query_inout,
-    questdb_error** err_out);
+    qwp_reader_query** query_inout, questdb_error** err_out);
 
 /**
  * Convenience: prepare + execute in one call, for SQL with no binds.
@@ -769,9 +763,7 @@ qwp_reader_cursor* qwp_reader_query_execute(
  */
 QUESTDB_CLIENT_API
 qwp_reader_cursor* qwp_reader_execute(
-    qwp_reader* reader,
-    line_sender_utf8 sql,
-    questdb_error** err_out);
+    qwp_reader* reader, line_sender_utf8 sql, questdb_error** err_out);
 
 /* Bind parameters. All `qwp_reader_query_bind_*` functions append a bind
  * to the query in declaration order, matching the SQL placeholders
@@ -793,29 +785,27 @@ QUESTDB_CLIENT_API void qwp_reader_query_bind_bool(qwp_reader_query*, bool v);
 QUESTDB_CLIENT_API void qwp_reader_query_bind_i8(qwp_reader_query*, int8_t v);
 
 /** Bind a SHORT (signed 16-bit) positional parameter. */
-QUESTDB_CLIENT_API void qwp_reader_query_bind_i16(
-    qwp_reader_query*, int16_t v);
+QUESTDB_CLIENT_API void qwp_reader_query_bind_i16(qwp_reader_query*, int16_t v);
 
 /** Bind an INT (signed 32-bit) positional parameter. */
-QUESTDB_CLIENT_API void qwp_reader_query_bind_i32(
-    qwp_reader_query*, int32_t v);
+QUESTDB_CLIENT_API void qwp_reader_query_bind_i32(qwp_reader_query*, int32_t v);
 
 /** Bind a LONG (signed 64-bit) positional parameter. */
-QUESTDB_CLIENT_API void qwp_reader_query_bind_i64(
-    qwp_reader_query*, int64_t v);
+QUESTDB_CLIENT_API void qwp_reader_query_bind_i64(qwp_reader_query*, int64_t v);
 
 /** Bind a FLOAT (32-bit IEEE-754) positional parameter. */
 QUESTDB_CLIENT_API void qwp_reader_query_bind_f32(qwp_reader_query*, float v);
 
 /** Bind a DOUBLE (64-bit IEEE-754) positional parameter. */
-QUESTDB_CLIENT_API void qwp_reader_query_bind_f64(
-    qwp_reader_query*, double v);
+QUESTDB_CLIENT_API void qwp_reader_query_bind_f64(qwp_reader_query*, double v);
 
-/** Bind a TIMESTAMP positional parameter as microseconds since the Unix epoch. */
+/** Bind a TIMESTAMP positional parameter as microseconds since the Unix epoch.
+ */
 QUESTDB_CLIENT_API void qwp_reader_query_bind_timestamp_micros(
     qwp_reader_query*, int64_t v);
 
-/** Bind a TIMESTAMP_NANOS positional parameter as nanoseconds since the Unix epoch. */
+/** Bind a TIMESTAMP_NANOS positional parameter as nanoseconds since the Unix
+ * epoch. */
 QUESTDB_CLIENT_API void qwp_reader_query_bind_timestamp_nanos(
     qwp_reader_query*, int64_t v);
 
@@ -910,10 +900,7 @@ QUESTDB_CLIENT_API void qwp_reader_query_bind_ipv4(
  * and corrupts negative values.
  */
 QUESTDB_CLIENT_API void qwp_reader_query_bind_decimal128(
-    qwp_reader_query*,
-    uint64_t mantissa_lo,
-    int64_t mantissa_hi,
-    int8_t scale);
+    qwp_reader_query*, uint64_t mantissa_lo, int64_t mantissa_hi, int8_t scale);
 
 /** Bind a DECIMAL256 mantissa as 32 little-endian raw bytes plus column scale.
  *  `value` MUST be non-NULL and point to at least 32 readable bytes. A NULL
@@ -1097,8 +1084,7 @@ typedef struct qwp_reader_batch qwp_reader_batch;
  */
 QUESTDB_CLIENT_API
 const qwp_reader_batch* qwp_reader_cursor_next_batch(
-    qwp_reader_cursor* cursor,
-    questdb_error** err_out);
+    qwp_reader_cursor* cursor, questdb_error** err_out);
 
 /** Rows in the batch. Returns 0 on a NULL handle. */
 QUESTDB_CLIENT_API
@@ -1360,8 +1346,8 @@ qwp_reader_cursor_current_server_info(const qwp_reader_cursor* cursor);
 /** Discriminant of the cursor's terminal frame. */
 typedef enum qwp_reader_terminal_kind
 {
-    qwp_reader_terminal_kind_none      = 0,
-    qwp_reader_terminal_kind_end       = 1,
+    qwp_reader_terminal_kind_none = 0,
+    qwp_reader_terminal_kind_end = 1,
     qwp_reader_terminal_kind_exec_done = 2,
 } qwp_reader_terminal_kind;
 
@@ -1730,12 +1716,12 @@ static inline bool qwp_reader_column_data_get_symbol(
  * block in `qwp_sender.h`, with arrow.h, nanoarrow, polars-arrow,
  * and any other header that ships the same definitions.
  * https://arrow.apache.org/docs/format/CDataInterface.html */
-#ifndef ARROW_C_DATA_INTERFACE
-#    define ARROW_C_DATA_INTERFACE
+#    ifndef ARROW_C_DATA_INTERFACE
+#        define ARROW_C_DATA_INTERFACE
 
-#    define ARROW_FLAG_DICTIONARY_ORDERED 1
-#    define ARROW_FLAG_NULLABLE 2
-#    define ARROW_FLAG_MAP_KEYS_SORTED 4
+#        define ARROW_FLAG_DICTIONARY_ORDERED 1
+#        define ARROW_FLAG_NULLABLE 2
+#        define ARROW_FLAG_MAP_KEYS_SORTED 4
 
 struct ArrowSchema
 {
@@ -1764,8 +1750,7 @@ struct ArrowArray
     void* private_data;
 };
 
-#endif /* ARROW_C_DATA_INTERFACE */
-
+#    endif /* ARROW_C_DATA_INTERFACE */
 
 /**
  * Tri-state return for `qwp_reader_cursor_next_arrow_batch`.

--- a/include/questdb/egress/qwp_reader.hpp
+++ b/include/questdb/egress/qwp_reader.hpp
@@ -38,7 +38,7 @@
 #include <utility>
 
 #include "../ingress/line_sender_core.hpp" // utf8_view
-#include "../client.hpp" // questdb::pool (borrow_reader)
+#include "../client.hpp"                   // questdb::pool (borrow_reader)
 
 namespace questdb::egress
 {
@@ -72,29 +72,29 @@ namespace questdb::egress
  */
 enum class column_kind : int
 {
-    boolean         = ::qwp_reader_column_kind_boolean,
-    byte            = ::qwp_reader_column_kind_byte,
-    short_          = ::qwp_reader_column_kind_short,
-    int_            = ::qwp_reader_column_kind_int,
-    long_           = ::qwp_reader_column_kind_long,
-    float_          = ::qwp_reader_column_kind_float,
-    double_         = ::qwp_reader_column_kind_double,
-    symbol          = ::qwp_reader_column_kind_symbol,
-    timestamp       = ::qwp_reader_column_kind_timestamp,
-    date            = ::qwp_reader_column_kind_date,
-    uuid            = ::qwp_reader_column_kind_uuid,
-    long256         = ::qwp_reader_column_kind_long256,
-    geohash         = ::qwp_reader_column_kind_geohash,
-    varchar         = ::qwp_reader_column_kind_varchar,
+    boolean = ::qwp_reader_column_kind_boolean,
+    byte = ::qwp_reader_column_kind_byte,
+    short_ = ::qwp_reader_column_kind_short,
+    int_ = ::qwp_reader_column_kind_int,
+    long_ = ::qwp_reader_column_kind_long,
+    float_ = ::qwp_reader_column_kind_float,
+    double_ = ::qwp_reader_column_kind_double,
+    symbol = ::qwp_reader_column_kind_symbol,
+    timestamp = ::qwp_reader_column_kind_timestamp,
+    date = ::qwp_reader_column_kind_date,
+    uuid = ::qwp_reader_column_kind_uuid,
+    long256 = ::qwp_reader_column_kind_long256,
+    geohash = ::qwp_reader_column_kind_geohash,
+    varchar = ::qwp_reader_column_kind_varchar,
     timestamp_nanos = ::qwp_reader_column_kind_timestamp_nanos,
-    double_array    = ::qwp_reader_column_kind_double_array,
-    long_array      = ::qwp_reader_column_kind_long_array,
-    decimal64       = ::qwp_reader_column_kind_decimal64,
-    decimal128      = ::qwp_reader_column_kind_decimal128,
-    decimal256      = ::qwp_reader_column_kind_decimal256,
-    char_           = ::qwp_reader_column_kind_char,
-    binary          = ::qwp_reader_column_kind_binary,
-    ipv4            = ::qwp_reader_column_kind_ipv4,
+    double_array = ::qwp_reader_column_kind_double_array,
+    long_array = ::qwp_reader_column_kind_long_array,
+    decimal64 = ::qwp_reader_column_kind_decimal64,
+    decimal128 = ::qwp_reader_column_kind_decimal128,
+    decimal256 = ::qwp_reader_column_kind_decimal256,
+    char_ = ::qwp_reader_column_kind_char,
+    binary = ::qwp_reader_column_kind_binary,
+    ipv4 = ::qwp_reader_column_kind_ipv4,
 };
 
 /**
@@ -102,11 +102,11 @@ enum class column_kind : int
  */
 enum class server_role : int
 {
-    standalone       = ::qwp_reader_server_role_standalone,
-    primary          = ::qwp_reader_server_role_primary,
-    replica          = ::qwp_reader_server_role_replica,
-    primary_catchup  = ::qwp_reader_server_role_primary_catchup,
-    other            = ::qwp_reader_server_role_other,
+    standalone = ::qwp_reader_server_role_standalone,
+    primary = ::qwp_reader_server_role_primary,
+    replica = ::qwp_reader_server_role_replica,
+    primary_catchup = ::qwp_reader_server_role_primary_catchup,
+    other = ::qwp_reader_server_role_other,
 };
 
 /**
@@ -114,8 +114,8 @@ enum class server_role : int
  */
 enum class terminal_kind : int
 {
-    none      = ::qwp_reader_terminal_kind_none,
-    end       = ::qwp_reader_terminal_kind_end,
+    none = ::qwp_reader_terminal_kind_none,
+    end = ::qwp_reader_terminal_kind_end,
     exec_done = ::qwp_reader_terminal_kind_exec_done,
 };
 
@@ -128,31 +128,55 @@ enum class terminal_kind : int
 // alongside the unified `questdb::error_code`; see line_sender_core.hpp.)
 
 inline bool operator==(column_kind l, ::qwp_reader_column_kind r) noexcept
-{ return static_cast<int>(l) == static_cast<int>(r); }
+{
+    return static_cast<int>(l) == static_cast<int>(r);
+}
 inline bool operator==(::qwp_reader_column_kind l, column_kind r) noexcept
-{ return r == l; }
+{
+    return r == l;
+}
 inline bool operator!=(column_kind l, ::qwp_reader_column_kind r) noexcept
-{ return !(l == r); }
+{
+    return !(l == r);
+}
 inline bool operator!=(::qwp_reader_column_kind l, column_kind r) noexcept
-{ return !(l == r); }
+{
+    return !(l == r);
+}
 
 inline bool operator==(server_role l, ::qwp_reader_server_role r) noexcept
-{ return static_cast<int>(l) == static_cast<int>(r); }
+{
+    return static_cast<int>(l) == static_cast<int>(r);
+}
 inline bool operator==(::qwp_reader_server_role l, server_role r) noexcept
-{ return r == l; }
+{
+    return r == l;
+}
 inline bool operator!=(server_role l, ::qwp_reader_server_role r) noexcept
-{ return !(l == r); }
+{
+    return !(l == r);
+}
 inline bool operator!=(::qwp_reader_server_role l, server_role r) noexcept
-{ return !(l == r); }
+{
+    return !(l == r);
+}
 
 inline bool operator==(terminal_kind l, ::qwp_reader_terminal_kind r) noexcept
-{ return static_cast<int>(l) == static_cast<int>(r); }
+{
+    return static_cast<int>(l) == static_cast<int>(r);
+}
 inline bool operator==(::qwp_reader_terminal_kind l, terminal_kind r) noexcept
-{ return r == l; }
+{
+    return r == l;
+}
 inline bool operator!=(terminal_kind l, ::qwp_reader_terminal_kind r) noexcept
-{ return !(l == r); }
+{
+    return !(l == r);
+}
 inline bool operator!=(::qwp_reader_terminal_kind l, terminal_kind r) noexcept
-{ return !(l == r); }
+{
+    return !(l == r);
+}
 
 /**
  * Optional value for nullable cells. Returned by the typed getters on
@@ -250,28 +274,61 @@ struct terminal_exec_done_info
 /**
  * Owning snapshot of an endpoint's `SERVER_INFO` handshake metadata.
  *
- * Unlike the C ABI's borrowed `qwp_reader_server_info*`, every string is copied,
- * so this value may safely outlive the reader/cursor and may be retained
- * across query execution or failover. An unrecognised role remains
+ * Unlike the C ABI's borrowed `qwp_reader_server_info*`, every string is
+ * copied, so this value may safely outlive the reader/cursor and may be
+ * retained across query execution or failover. An unrecognised role remains
  * `server_role::other` while `role_byte()` preserves its original wire byte.
  */
 class server_info
 {
 public:
-    server_role role() const noexcept { return _role; }
-    uint8_t role_byte() const noexcept { return _role_byte; }
-    uint64_t epoch() const noexcept { return _epoch; }
-    uint32_t capabilities() const noexcept { return _capabilities; }
-    int64_t server_wall_ns() const noexcept { return _server_wall_ns; }
+    server_role role() const noexcept
+    {
+        return _role;
+    }
+    uint8_t role_byte() const noexcept
+    {
+        return _role_byte;
+    }
+    uint64_t epoch() const noexcept
+    {
+        return _epoch;
+    }
+    uint32_t capabilities() const noexcept
+    {
+        return _capabilities;
+    }
+    int64_t server_wall_ns() const noexcept
+    {
+        return _server_wall_ns;
+    }
 
     // Lvalue access is zero-copy; chained access on a temporary transfers an
     // owning value instead of returning a reference into a destroyed object.
-    const std::string& cluster_id() const & noexcept { return _cluster_id; }
-    std::string cluster_id() && noexcept { return std::move(_cluster_id); }
-    const std::string& node_id() const & noexcept { return _node_id; }
-    std::string node_id() && noexcept { return std::move(_node_id); }
-    const nullable<std::string>& zone_id() const & noexcept { return _zone_id; }
-    nullable<std::string> zone_id() && noexcept { return std::move(_zone_id); }
+    const std::string& cluster_id() const& noexcept
+    {
+        return _cluster_id;
+    }
+    std::string cluster_id() && noexcept
+    {
+        return std::move(_cluster_id);
+    }
+    const std::string& node_id() const& noexcept
+    {
+        return _node_id;
+    }
+    std::string node_id() && noexcept
+    {
+        return std::move(_node_id);
+    }
+    const nullable<std::string>& zone_id() const& noexcept
+    {
+        return _zone_id;
+    }
+    nullable<std::string> zone_id() && noexcept
+    {
+        return std::move(_zone_id);
+    }
 
 private:
     server_info(
@@ -317,10 +374,15 @@ class server_info_view
 {
 public:
     explicit server_info_view(const ::qwp_reader_server_info* impl) noexcept
-        : _impl{impl} {}
+        : _impl{impl}
+    {
+    }
 
     /** True if a `SERVER_INFO` is available. */
-    explicit operator bool() const noexcept { return _impl != nullptr; }
+    explicit operator bool() const noexcept
+    {
+        return _impl != nullptr;
+    }
 
     server_role role() const noexcept
     {
@@ -376,8 +438,7 @@ public:
         if (!_impl)
             return std::nullopt;
 
-        const auto copy = [](std::string_view value)
-        {
+        const auto copy = [](std::string_view value) {
             return value.empty() ? std::string{} : std::string{value};
         };
         nullable<std::string> zone;
@@ -405,12 +466,16 @@ private:
 class failover_reset_event_view
 {
 public:
-    explicit failover_reset_event_view(const ::qwp_reader_failover_reset_event* impl) noexcept
-        : _impl{impl} {}
+    explicit failover_reset_event_view(
+        const ::qwp_reader_failover_reset_event* impl) noexcept
+        : _impl{impl}
+    {
+    }
 
     // Non-copyable: `_impl` is borrowed, valid only during the callback.
     failover_reset_event_view(const failover_reset_event_view&) = delete;
-    failover_reset_event_view& operator=(const failover_reset_event_view&) = delete;
+    failover_reset_event_view& operator=(const failover_reset_event_view&) =
+        delete;
     failover_reset_event_view(failover_reset_event_view&&) = delete;
     failover_reset_event_view& operator=(failover_reset_event_view&&) = delete;
 
@@ -471,7 +536,8 @@ private:
 };
 
 /** User callback type for failover-reset notifications. */
-using failover_reset_callback = std::function<void(const failover_reset_event_view&)>;
+using failover_reset_callback =
+    std::function<void(const failover_reset_event_view&)>;
 
 /**
  * Lifecycle phase of a failover-progress event. Numeric values match
@@ -481,12 +547,9 @@ enum class failover_phase : int
 {
     disconnected =
         ::qwp_reader_failover_phase::qwp_reader_failover_phase_disconnected,
-    retrying =
-        ::qwp_reader_failover_phase::qwp_reader_failover_phase_retrying,
-    reset =
-        ::qwp_reader_failover_phase::qwp_reader_failover_phase_reset,
-    gave_up =
-        ::qwp_reader_failover_phase::qwp_reader_failover_phase_gave_up,
+    retrying = ::qwp_reader_failover_phase::qwp_reader_failover_phase_retrying,
+    reset = ::qwp_reader_failover_phase::qwp_reader_failover_phase_reset,
+    gave_up = ::qwp_reader_failover_phase::qwp_reader_failover_phase_gave_up,
 };
 
 /**
@@ -502,15 +565,17 @@ class failover_progress_event_view
 public:
     explicit failover_progress_event_view(
         const ::qwp_reader_failover_progress_event* impl) noexcept
-        : _impl{impl} {}
+        : _impl{impl}
+    {
+    }
 
     // Non-copyable: `_impl` is borrowed, valid only during the callback.
     failover_progress_event_view(const failover_progress_event_view&) = delete;
     failover_progress_event_view& operator=(
         const failover_progress_event_view&) = delete;
     failover_progress_event_view(failover_progress_event_view&&) = delete;
-    failover_progress_event_view& operator=(
-        failover_progress_event_view&&) = delete;
+    failover_progress_event_view& operator=(failover_progress_event_view&&) =
+        delete;
 
     failover_phase phase() const noexcept
     {
@@ -602,8 +667,7 @@ public:
     {
         const char* buf = nullptr;
         size_t len = 0;
-        ::qwp_reader_failover_progress_event_final_error_msg(
-            _impl, &buf, &len);
+        ::qwp_reader_failover_progress_event_final_error_msg(_impl, &buf, &len);
         return {buf, len};
     }
 
@@ -654,14 +718,14 @@ public:
      */
     static reader from_env()
     {
-        return reader{
-            ::questdb::error::wrapped_call(::qwp_reader_from_env)};
+        return reader{::questdb::error::wrapped_call(::qwp_reader_from_env)};
     }
 
     reader(const reader&) = delete;
     reader& operator=(const reader&) = delete;
 
-    reader(reader&& other) noexcept : _impl{other._impl}
+    reader(reader&& other) noexcept
+        : _impl{other._impl}
     {
         other._impl = nullptr;
     }
@@ -693,7 +757,10 @@ public:
         return *this;
     }
 
-    ~reader() noexcept { ::qwp_reader_close(_impl); }
+    ~reader() noexcept
+    {
+        ::qwp_reader_close(_impl);
+    }
 
     /**
      * Execute a SQL statement with no binds and return a streaming cursor.
@@ -769,8 +836,7 @@ public:
         ensure_impl();
         ensure_connection_metadata_access("server_version");
         uint8_t v = 0;
-        ::questdb::error::wrapped_call(
-            ::qwp_reader_server_version, _impl, &v);
+        ::questdb::error::wrapped_call(::qwp_reader_server_version, _impl, &v);
         return v;
     }
 
@@ -783,8 +849,8 @@ public:
     {
         ensure_impl();
         ensure_connection_metadata_access("server_info");
-        auto info = server_info_view{
-            ::qwp_reader_current_server_info(_impl)}.snapshot();
+        auto info = server_info_view{::qwp_reader_current_server_info(_impl)}
+                        .snapshot();
         if (!info)
             throw ::questdb::error{
                 error_code::invalid_api_call,
@@ -817,7 +883,10 @@ public:
     }
 
 private:
-    explicit reader(::qwp_reader* impl) noexcept : _impl{impl} {}
+    explicit reader(::qwp_reader* impl) noexcept
+        : _impl{impl}
+    {
+    }
 
     /// Borrow a pooled reader from a `questdb_db` pool. Backs
     /// `questdb::pool::borrow_reader`. The returned reader is
@@ -851,7 +920,8 @@ private:
                 error_code::invalid_api_call,
                 std::string{"reader::"} + accessor +
                     "() called while a query or cursor produced by this "
-                    "reader is still live; use cursor::" + accessor + "()"};
+                    "reader is still live; use cursor::" +
+                    accessor + "()"};
     }
 
     ::qwp_reader* _impl;
@@ -892,7 +962,10 @@ public:
         return *this;
     }
 
-    ~query() noexcept { ::qwp_reader_query_free(_impl); }
+    ~query() noexcept
+    {
+        ::qwp_reader_query_free(_impl);
+    }
 
     query& bind_bool(bool v)
     {
@@ -976,10 +1049,12 @@ public:
      * `(mantissa_lo = UINT64_MAX, mantissa_hi = -1)` — always cast the
      * high limb through `int64_t` so the sign extends correctly.
      */
-    query& bind_decimal128(uint64_t mantissa_lo, int64_t mantissa_hi, int8_t scale)
+    query& bind_decimal128(
+        uint64_t mantissa_lo, int64_t mantissa_hi, int8_t scale)
     {
         ensure_impl();
-        ::qwp_reader_query_bind_decimal128(_impl, mantissa_lo, mantissa_hi, scale);
+        ::qwp_reader_query_bind_decimal128(
+            _impl, mantissa_lo, mantissa_hi, scale);
         return *this;
     }
     query& bind_decimal256(const std::array<uint8_t, 32>& bytes, int8_t scale)
@@ -1058,8 +1133,7 @@ public:
     query& bind_null(column_kind kind)
     {
         ensure_impl();
-        ::qwp_reader_query_bind_null(
-            _impl, static_cast<uint32_t>(kind));
+        ::qwp_reader_query_bind_null(_impl, static_cast<uint32_t>(kind));
         return *this;
     }
     query& bind_null_varchar()
@@ -1157,9 +1231,7 @@ public:
         auto new_callback =
             std::make_unique<failover_reset_callback>(std::move(cb));
         ::qwp_reader_query_on_failover_reset(
-            _impl,
-            &query::trampoline,
-            new_callback.get());
+            _impl, &query::trampoline, new_callback.get());
         _callback = std::move(new_callback);
         return *this;
     }
@@ -1190,9 +1262,7 @@ public:
         auto new_callback =
             std::make_unique<failover_progress_callback>(std::move(cb));
         ::qwp_reader_query_on_failover_progress(
-            _impl,
-            &query::progress_trampoline,
-            new_callback.get());
+            _impl, &query::progress_trampoline, new_callback.get());
         _progress_callback = std::move(new_callback);
         return *this;
     }
@@ -1204,7 +1274,10 @@ public:
     cursor execute();
 
 private:
-    explicit query(::qwp_reader_query* impl) noexcept : _impl{impl} {}
+    explicit query(::qwp_reader_query* impl) noexcept
+        : _impl{impl}
+    {
+    }
 
     /// Throw `questdb::error{invalid_api_call}` if `_impl` is null.
     /// A null `_impl` means the query has been moved from or already
@@ -1374,9 +1447,7 @@ inline T load_unaligned(const void* base, size_t row) noexcept
 {
     T value;
     std::memcpy(
-        &value,
-        static_cast<const uint8_t*>(base) + row * sizeof(T),
-        sizeof(T));
+        &value, static_cast<const uint8_t*>(base) + row * sizeof(T), sizeof(T));
     return value;
 }
 } // namespace detail
@@ -2497,7 +2568,10 @@ public:
         return *this;
     }
 
-    ~cursor() noexcept { ::qwp_reader_cursor_free(_impl); }
+    ~cursor() noexcept
+    {
+        ::qwp_reader_cursor_free(_impl);
+    }
 
     /**
      * Advance to the next batch.
@@ -2544,12 +2618,17 @@ public:
         ::ArrowArray array;
         ::ArrowSchema schema;
 
-        arrow_batch() noexcept : array{}, schema{} {}
+        arrow_batch() noexcept
+            : array{}
+            , schema{}
+        {
+        }
         arrow_batch(const arrow_batch&) = delete;
         arrow_batch& operator=(const arrow_batch&) = delete;
 
         arrow_batch(arrow_batch&& other) noexcept
-            : array(other.array), schema(other.schema)
+            : array(other.array)
+            , schema(other.schema)
         {
             // Zero the source so its destructor skips release() and so
             // any post-move access (`other.array.length`, `.buffers[0]`,
@@ -2572,7 +2651,10 @@ public:
             return *this;
         }
 
-        ~arrow_batch() noexcept { release_in_place(); }
+        ~arrow_batch() noexcept
+        {
+            release_in_place();
+        }
 
     private:
         void release_in_place() noexcept
@@ -2615,13 +2697,13 @@ public:
             _impl, &out.array, &out.schema, &c_err);
         switch (rc)
         {
-            case ::qwp_reader_arrow_batch_ok:
-                return out;
-            case ::qwp_reader_arrow_batch_end:
-                return std::nullopt;
-            case ::qwp_reader_arrow_batch_error:
-            default:
-                throw ::questdb::error::from_c(c_err);
+        case ::qwp_reader_arrow_batch_ok:
+            return out;
+        case ::qwp_reader_arrow_batch_end:
+            return std::nullopt;
+        case ::qwp_reader_arrow_batch_error:
+        default:
+            throw ::questdb::error::from_c(c_err);
         }
     }
 #endif /* QUESTDB_CLIENT_ENABLE_ARROW */
@@ -2687,8 +2769,9 @@ public:
     egress::server_info server_info() const
     {
         ensure_impl();
-        auto info = server_info_view{
-            ::qwp_reader_cursor_current_server_info(_impl)}.snapshot();
+        auto info =
+            server_info_view{::qwp_reader_cursor_current_server_info(_impl)}
+                .snapshot();
         if (!info)
             throw ::questdb::error{
                 error_code::invalid_api_call,
@@ -2751,7 +2834,10 @@ public:
     }
 
 private:
-    explicit cursor(::qwp_reader_cursor* impl) noexcept : _impl{impl} {}
+    explicit cursor(::qwp_reader_cursor* impl) noexcept
+        : _impl{impl}
+    {
+    }
 
     /// Throw `questdb::error{invalid_api_call}` if `_impl` is null.
     /// A null `_impl` means the cursor has been moved from or already
@@ -2802,7 +2888,8 @@ inline cursor query::execute()
     // NULL on return — so a subsequent `~query()` calling `_query_free`
     // is a NULL no-op without us having to clear `_impl` explicitly here.
     auto* c = ::qwp_reader_query_execute(&_impl, &c_err);
-    if (!c) throw ::questdb::error::from_c(c_err);
+    if (!c)
+        throw ::questdb::error::from_c(c_err);
     cursor result{c};
     result._failover_callback = std::move(cb);
     result._failover_progress_callback = std::move(pcb);

--- a/include/questdb/ingress/line_sender.h
+++ b/include/questdb/ingress/line_sender.h
@@ -196,7 +196,8 @@ typedef enum line_sender_error_code
     /** Server-reported QWP `LIMIT_EXCEEDED` (status `0x0B`). */
     line_sender_error_server_limit_exceeded = 29,
 
-    /** Query was cancelled (locally or via server `CANCELLED` status `0x0A`). */
+    /** Query was cancelled (locally or via server `CANCELLED` status `0x0A`).
+     */
     line_sender_error_cancelled = 30,
 
     /** Mid-query failover was eligible but a batch had already been delivered
@@ -235,33 +236,36 @@ typedef enum line_sender_error_code
     /** The QWP/WebSocket connection-scoped symbol dictionary is full: interning
      *  another distinct symbol would exceed its entry-count cap (2,000,000,
      *  matching the server's ingress ceiling) or its cumulative UTF-8 heap cap
-     *  (256 MiB). The failing frame is rejected before any byte reaches the wire
-     *  and the buffer is rolled back, so *that flush* loses nothing and chunks
-     *  referencing only already-interned symbols keep flushing — but retrying a
-     *  *new* symbol on the same sender can never succeed. A full dictionary
-     *  RETIRES the connection on return: a pooled sender is dropped rather than
-     *  recycled (the next borrow gets a fresh, empty-dictionary connection, not the
-     *  same full one) and its earlier frames are drained / committed best-effort on
-     *  the way out. So the simplest recovery is to return the sender as usual and
-     *  borrow a fresh one. If those earlier frames must not be lost, drain or commit
-     *  them AND check first:
+     *  (256 MiB). The failing frame is rejected before any byte reaches the
+     * wire and the buffer is rolled back, so *that flush* loses nothing and
+     * chunks referencing only already-interned symbols keep flushing — but
+     * retrying a *new* symbol on the same sender can never succeed. A full
+     * dictionary RETIRES the connection on return: a pooled sender is dropped
+     * rather than recycled (the next borrow gets a fresh, empty-dictionary
+     * connection, not the same full one) and its earlier frames are drained /
+     * committed best-effort on the way out. So the simplest recovery is to
+     * return the sender as usual and borrow a fresh one. If those earlier
+     * frames must not be lost, drain or commit them AND check first:
      *
-     *    - Pooled row sender: a plain `questdb_db_return_sender` now retires (does
-     *      NOT recycle) a full-dictionary connection and drains its queue
-     *      best-effort within `close_flush_timeout`; the next borrow is fresh. Call
-     *      `qwp_sender_wait` first if the queued frames must not be lost. With
+     *    - Pooled row sender: a plain `questdb_db_return_sender` now retires
+     * (does NOT recycle) a full-dictionary connection and drains its queue
+     *      best-effort within `close_flush_timeout`; the next borrow is fresh.
+     * Call `qwp_sender_wait` first if the queued frames must not be lost. With
      *      `sf_dir` configured they persist in the slot, but so does the
-     *      dictionary, and the next borrower re-seeds from that slot's side-file at
-     *      the same size unless the slot drained first, so wait there too.
-     *    - Pooled direct sender: a plain `questdb_db_return_direct_sender` retires
-     *      the connection and commits the deferred tail best-effort. Its flushes are
-     *      deferred, so for a CHECKED guarantee call `qwp_direct_sender_commit` (or
-     *      a waited flush) and confirm it succeeded before the return. Do NOT use
-     *      `questdb_db_drop_direct_sender` on a full dictionary: it force-drops and
-     *      skips the best-effort commit, discarding the tail.
-     *    - Standalone direct sender: `qwp_direct_sender_free` commits the deferred
-     *      tail best-effort; call `qwp_direct_sender_commit` and CHECK IT SUCCEEDED
-     *      first for a guarantee, then `qwp_direct_sender_free`, then re-open.
+     *      dictionary, and the next borrower re-seeds from that slot's
+     * side-file at the same size unless the slot drained first, so wait there
+     * too.
+     *    - Pooled direct sender: a plain `questdb_db_return_direct_sender`
+     * retires the connection and commits the deferred tail best-effort. Its
+     * flushes are deferred, so for a CHECKED guarantee call
+     * `qwp_direct_sender_commit` (or a waited flush) and confirm it succeeded
+     * before the return. Do NOT use `questdb_db_drop_direct_sender` on a full
+     * dictionary: it force-drops and skips the best-effort commit, discarding
+     * the tail.
+     *    - Standalone direct sender: `qwp_direct_sender_free` commits the
+     * deferred tail best-effort; call `qwp_direct_sender_commit` and CHECK IT
+     * SUCCEEDED first for a guarantee, then `qwp_direct_sender_free`, then
+     * re-open.
      *    - Standalone row sender (`line_sender_from_conf` / `_from_env` /
      *      `line_sender_build` on a
      *      `ws://` or `wss://` address, flushed with `line_sender_flush*`):
@@ -276,11 +280,11 @@ typedef enum line_sender_error_code
      *  `line_sender_error_invalid_api_call` so callers can recognise it without
      *  matching on the message text.
      *
-     *  One exception to "that flush loses nothing", and it matters for resends: a chunk
-     *  too large for a single frame is split and each half published on its own,
-     *  so an earlier half can already be durably queued (store-and-forward is
-     *  at-least-once) when a later half hits the cap. The error is then
-     *  delivery-unknown rather than known-not-delivered - check
+     *  One exception to "that flush loses nothing", and it matters for resends:
+     * a chunk too large for a single frame is split and each half published on
+     * its own, so an earlier half can already be durably queued
+     * (store-and-forward is at-least-once) when a later half hits the cap. The
+     * error is then delivery-unknown rather than known-not-delivered - check
      *  `line_sender_error_in_doubt` before resending, or the rows the committed
      *  prefix already carried are duplicated. */
     line_sender_error_symbol_dict_full = 37,
@@ -299,7 +303,8 @@ typedef line_sender_error_code questdb_error_code;
 /* Neutral names for the unified error-code constants. The underlying
  * `line_sender_error_code` enum and its enumerators are retained because they
  * shipped before the client-wide error vocabulary was introduced. */
-#define questdb_error_could_not_resolve_addr line_sender_error_could_not_resolve_addr
+#define questdb_error_could_not_resolve_addr                                   \
+    line_sender_error_could_not_resolve_addr
 #define questdb_error_invalid_api_call line_sender_error_invalid_api_call
 #define questdb_error_socket_error line_sender_error_socket_error
 #define questdb_error_invalid_utf8 line_sender_error_invalid_utf8
@@ -311,10 +316,12 @@ typedef line_sender_error_code questdb_error_code;
 #define questdb_error_server_flush_error line_sender_error_server_flush_error
 #define questdb_error_config_error line_sender_error_config_error
 #define questdb_error_array_error line_sender_error_array_error
-#define questdb_error_protocol_version_error line_sender_error_protocol_version_error
+#define questdb_error_protocol_version_error                                   \
+    line_sender_error_protocol_version_error
 #define questdb_error_invalid_decimal line_sender_error_invalid_decimal
 #define questdb_error_server_rejection line_sender_error_server_rejection
-#define questdb_error_arrow_unsupported_column_kind line_sender_error_arrow_unsupported_column_kind
+#define questdb_error_arrow_unsupported_column_kind                            \
+    line_sender_error_arrow_unsupported_column_kind
 #define questdb_error_arrow_ingest line_sender_error_arrow_ingest
 #define questdb_error_failover_retry line_sender_error_failover_retry
 #define questdb_error_role_mismatch line_sender_error_role_mismatch
@@ -323,19 +330,25 @@ typedef line_sender_error_code questdb_error_code;
 #define questdb_error_unsupported_server line_sender_error_unsupported_server
 #define questdb_error_protocol_error line_sender_error_protocol_error
 #define questdb_error_invalid_bind line_sender_error_invalid_bind
-#define questdb_error_server_schema_mismatch line_sender_error_server_schema_mismatch
+#define questdb_error_server_schema_mismatch                                   \
+    line_sender_error_server_schema_mismatch
 #define questdb_error_server_parse_error line_sender_error_server_parse_error
-#define questdb_error_server_internal_error line_sender_error_server_internal_error
-#define questdb_error_server_security_error line_sender_error_server_security_error
+#define questdb_error_server_internal_error                                    \
+    line_sender_error_server_internal_error
+#define questdb_error_server_security_error                                    \
+    line_sender_error_server_security_error
 #define questdb_error_limit_exceeded line_sender_error_limit_exceeded
-#define questdb_error_server_limit_exceeded line_sender_error_server_limit_exceeded
+#define questdb_error_server_limit_exceeded                                    \
+    line_sender_error_server_limit_exceeded
 #define questdb_error_cancelled line_sender_error_cancelled
-#define questdb_error_failover_would_duplicate line_sender_error_failover_would_duplicate
+#define questdb_error_failover_would_duplicate                                 \
+    line_sender_error_failover_would_duplicate
 #define questdb_error_schema_drift line_sender_error_schema_drift
 #define questdb_error_no_schema line_sender_error_no_schema
 #define questdb_error_arrow_export line_sender_error_arrow_export
 #define questdb_error_batch_too_large line_sender_error_batch_too_large
-#define questdb_error_store_resend_required line_sender_error_store_resend_required
+#define questdb_error_store_resend_required                                    \
+    line_sender_error_store_resend_required
 #define questdb_error_symbol_dict_full line_sender_error_symbol_dict_full
 
 /** The protocol used to connect with. */
@@ -722,9 +735,7 @@ line_sender_buffer* line_sender_buffer_clone(
  */
 QUESTDB_CLIENT_API
 bool line_sender_buffer_reserve(
-    line_sender_buffer* buffer,
-    size_t additional,
-    line_sender_error** err_out);
+    line_sender_buffer* buffer, size_t additional, line_sender_error** err_out);
 
 /**
  * Get the current buffer capacity.
@@ -768,8 +779,7 @@ bool line_sender_buffer_rewind_to_bookmark(
  */
 QUESTDB_CLIENT_API
 void line_sender_buffer_clear_bookmark(
-    line_sender_buffer* buffer,
-    line_sender_bookmark bookmark);
+    line_sender_buffer* buffer, line_sender_bookmark bookmark);
 
 /**
  * Mark a rewind point.
@@ -871,12 +881,12 @@ bool line_sender_buffer_table(
  * into the *same* connection-scoped dictionary the chunk API uses: capped at
  * 2,000,000 entries and 256 MiB of UTF-8 across the whole connection, not per
  * buffer or per flush. Exceeding it fails the flush with
- * `line_sender_error_symbol_dict_full`; that code's own documentation lists what
- * each sender flavour must call to retire the connection — including this one,
- * whose remedy is `line_sender_qwpws_close_drain` then `line_sender_close`, in
- * that order, because `line_sender_close` alone drains nothing. See also the
- * symbol-column preamble in `qwp_sender.h`. ILP (TCP/HTTP) and QWP/UDP flushes
- * carry no such dictionary and are unaffected.
+ * `line_sender_error_symbol_dict_full`; that code's own documentation lists
+ * what each sender flavour must call to retire the connection — including this
+ * one, whose remedy is `line_sender_qwpws_close_drain` then
+ * `line_sender_close`, in that order, because `line_sender_close` alone drains
+ * nothing. See also the symbol-column preamble in `qwp_sender.h`. ILP
+ * (TCP/HTTP) and QWP/UDP flushes carry no such dictionary and are unaffected.
  *
  * @param[in] buffer Line buffer object.
  * @param[in] name Column name.
@@ -1004,10 +1014,10 @@ bool line_sender_buffer_column_str(
 /**
  * Record a decimal string value for the given column.
  *
- * When specifying a decimal as a string, use a '.' to separate the whole from the
- * fractional parts. For example, "12.20".
- * Infinity is encoded as "+Infinity" or "-Infinity", while NaN as "NaN".
- * Note that Infinity and NaN values decay to nulls when stored in the database.
+ * When specifying a decimal as a string, use a '.' to separate the whole from
+ * the fractional parts. For example, "12.20". Infinity is encoded as
+ * "+Infinity" or "-Infinity", while NaN as "NaN". Note that Infinity and NaN
+ * values decay to nulls when stored in the database.
  *
  * @param[in] buffer Line buffer object.
  * @param[in] name Column name.
@@ -1019,7 +1029,7 @@ QUESTDB_CLIENT_API
 bool line_sender_buffer_column_dec_str(
     line_sender_buffer* buffer,
     line_sender_column_name name,
-    const char *value,
+    const char* value,
     size_t value_len,
     line_sender_error** err_out);
 
@@ -1054,7 +1064,7 @@ QUESTDB_CLIENT_API
 bool line_sender_buffer_column_dec64_str(
     line_sender_buffer* buffer,
     line_sender_column_name name,
-    const char *value,
+    const char* value,
     size_t value_len,
     line_sender_error** err_out);
 
@@ -1085,7 +1095,7 @@ QUESTDB_CLIENT_API
 bool line_sender_buffer_column_dec128_str(
     line_sender_buffer* buffer,
     line_sender_column_name name,
-    const char *value,
+    const char* value,
     size_t value_len,
     line_sender_error** err_out);
 
@@ -1222,7 +1232,8 @@ bool line_sender_buffer_column_i64_arr_c_major(
     line_sender_error** err_out);
 
 /**
- * Record a multidimensional array of `int64` values with byte strides. QWP-only.
+ * Record a multidimensional array of `int64` values with byte strides.
+ * QWP-only.
  *
  * LONG_ARRAY (`0x12`) is part of the QWP v1 spec. Server-side ingest does
  * not currently implement this wire type; batches using it will be rejected
@@ -1243,7 +1254,8 @@ bool line_sender_buffer_column_i64_arr_byte_strides(
     line_sender_error** err_out);
 
 /**
- * Record a multidimensional array of `int64` values with element strides. QWP-only.
+ * Record a multidimensional array of `int64` values with element strides.
+ * QWP-only.
  *
  * LONG_ARRAY (`0x12`) is part of the QWP v1 spec. Server-side ingest does
  * not currently implement this wire type; batches using it will be rejected
@@ -1530,8 +1542,7 @@ typedef struct line_sender_qwpws_error_view
  * callback call. The callback must not call methods on the same sender.
  */
 typedef void (*line_sender_qwpws_error_cb)(
-    void* user_data,
-    const line_sender_qwpws_error_view* event);
+    void* user_data, const line_sender_qwpws_error_view* event);
 
 /**
  * Accumulates parameters for a new `line_sender` object.
@@ -2056,9 +2067,7 @@ bool line_sender_qwpws_flush_and_keep_and_get_fsn(
  */
 QUESTDB_CLIENT_API
 bool line_sender_qwpws_drive_once(
-    line_sender* sender,
-    bool* progressed_out,
-    line_sender_error** err_out);
+    line_sender* sender, bool* progressed_out, line_sender_error** err_out);
 
 /**
  * Return the highest QWP/WebSocket frame sequence number published locally, or
@@ -2144,8 +2153,7 @@ line_sender_qwpws_error_view line_sender_qwpws_error_get_view(
  */
 QUESTDB_CLIENT_API
 bool line_sender_error_qwpws_get_view(
-    const line_sender_error* error,
-    line_sender_qwpws_error_view* view_out);
+    const line_sender_error* error, line_sender_qwpws_error_view* view_out);
 
 /**
  * Free an owned QWP/WebSocket diagnostic. Passing NULL is a no-op.
@@ -2177,8 +2185,7 @@ bool line_sender_qwpws_errors_dropped(
  */
 QUESTDB_CLIENT_API
 bool line_sender_qwpws_close_drain(
-    line_sender* sender,
-    line_sender_error** err_out);
+    line_sender* sender, line_sender_error** err_out);
 
 /**
  * Send the given buffer of rows to the QuestDB server, clearing the buffer.
@@ -2329,8 +2336,7 @@ typedef struct questdb_connection_event
  * The `event` pointer and every string it references are valid only for
  * the duration of the call. Must not unwind. */
 typedef void (*questdb_connection_event_cb)(
-    void* user_data,
-    const questdb_connection_event* event);
+    void* user_data, const questdb_connection_event* event);
 
 /** Register a connection lifecycle listener on the sender being built.
  * Events are delivered on a dedicated dispatcher thread through a bounded

--- a/include/questdb/ingress/line_sender.hpp
+++ b/include/questdb/ingress/line_sender.hpp
@@ -78,8 +78,7 @@ public:
      * `line_sender::new_buffer()`.
      */
     static line_sender_buffer qwp_udp(
-        size_t init_buf_size = 64 * 1024,
-        size_t max_name_len = 127)
+        size_t init_buf_size = 64 * 1024, size_t max_name_len = 127)
     {
         auto* raw_buffer =
             ::line_sender_buffer_new_qwp_with_max_name_len(max_name_len);
@@ -108,8 +107,7 @@ public:
      * `borrowed_sender::new_buffer()`, which uses the pool configuration.
      */
     static line_sender_buffer qwp_ws(
-        size_t init_buf_size = 64 * 1024,
-        size_t max_name_len = 127)
+        size_t init_buf_size = 64 * 1024, size_t max_name_len = 127)
     {
         auto* raw_buffer =
             ::line_sender_buffer_new_qwp_ws_with_max_name_len(max_name_len);
@@ -163,10 +161,9 @@ public:
             // Clone before freeing the old buffer so a clone failure leaves
             // *this unchanged (strong exception guarantee).
             ::line_sender_buffer* new_impl =
-                other._impl
-                    ? line_sender_error::wrapped_call(
-                          ::line_sender_buffer_clone, other._impl)
-                    : nullptr;
+                other._impl ? line_sender_error::wrapped_call(
+                                  ::line_sender_buffer_clone, other._impl)
+                            : nullptr;
             ::line_sender_buffer_free(_impl);
             _impl = new_impl;
             _init_buf_size = other._init_buf_size;
@@ -396,10 +393,11 @@ public:
      * `error_code::symbol_dict_full`, and the dictionary is only reset by
      * retiring the connection that owns it. For a standalone `line_sender` that
      * means `close_drain()` — checked — and only then letting the sender go;
-     * the destructor and `close()` drain nothing, so every published-but-unacked
-     * frame would be discarded with no wait. See the symbol-column preamble in
-     * `qwp_sender.h` for the per-flavour list. ILP (TCP/HTTP) and QWP/UDP
-     * flushes carry no such dictionary and are unaffected.
+     * the destructor and `close()` drain nothing, so every
+     * published-but-unacked frame would be discarded with no wait. See the
+     * symbol-column preamble in `qwp_sender.h` for the per-flavour list. ILP
+     * (TCP/HTTP) and QWP/UDP flushes carry no such dictionary and are
+     * unaffected.
      *
      * @param name Column name.
      * @param value Column value.
@@ -709,8 +707,9 @@ public:
      *
      * When specifying a decimal as a string, use a '.' to separate the whole
      * from the fractional parts. For example, "12.20".
-     * Infinity is encoded as "+Infinity" or "-Infinity", while NaN as "NaN". 
-     * Note that Infinity and NaN values decay to nulls when stored in the database.
+     * Infinity is encoded as "+Infinity" or "-Infinity", while NaN as "NaN".
+     * Note that Infinity and NaN values decay to nulls when stored in the
+     * database.
      *
      * For better performance and precision control, consider using the binary
      * format via `decimal::decimal_view` instead.
@@ -1323,7 +1322,8 @@ public:
      * service name.
      * @param[in] protocol The protocol to use.
      * @param[in] host The QuestDB database host.
-     * @param[in] port The QuestDB port as service name for the selected protocol.
+     * @param[in] port The QuestDB port as service name for the selected
+     * protocol.
      */
     opts(protocol protocol, utf8_view host, utf8_view port) noexcept
         : _impl{::line_sender_opts_new_service(
@@ -1445,8 +1445,7 @@ public:
      * synchronously from sender API calls such as `flush` and must not call
      * methods on the same sender.
      */
-    opts& qwp_ws_error_handler(
-        std::function<void(const qwp_ws_error&)> handler)
+    opts& qwp_ws_error_handler(std::function<void(const qwp_ws_error&)> handler)
     {
         _qwp_ws_error_handler =
             std::make_shared<std::function<void(const qwp_ws_error&)>>(
@@ -1713,8 +1712,7 @@ private:
     }
 
     static void qwp_ws_error_trampoline(
-        void* user_data,
-        const ::line_sender_qwpws_error_view* view) noexcept
+        void* user_data, const ::line_sender_qwpws_error_view* view) noexcept
     {
         auto* handler =
             static_cast<std::function<void(const qwp_ws_error&)>*>(user_data);
@@ -1810,8 +1808,8 @@ public:
     }
 
     line_sender(const opts& opts)
-        : _impl{
-              line_sender_error::wrapped_call(::line_sender_build, opts._impl)}
+        : _impl{line_sender_error::wrapped_call(
+              ::line_sender_build, opts._impl)}
         , _qwp_ws_error_handler{opts._qwp_ws_error_handler}
     {
     }
@@ -1880,8 +1878,7 @@ public:
         auto version = this->protocol_version();
         auto max_name_len = ::line_sender_get_max_name_len(_impl);
         auto sender_protocol = this->protocol();
-        if (sender_protocol == protocol::ws ||
-            sender_protocol == protocol::wss)
+        if (sender_protocol == protocol::ws || sender_protocol == protocol::wss)
         {
             throw line_sender_error{
                 line_sender_error_code::invalid_api_call,
@@ -2044,10 +2041,7 @@ public:
         ensure_impl();
         ::line_sender_qwpws_fsn fsn{};
         line_sender_error::wrapped_call(
-            ::line_sender_qwpws_flush_and_get_fsn,
-            _impl,
-            buffer._impl,
-            &fsn);
+            ::line_sender_qwpws_flush_and_get_fsn, _impl, buffer._impl, &fsn);
         return optional_fsn(fsn);
     }
 
@@ -2201,8 +2195,7 @@ public:
     void close_drain()
     {
         ensure_impl();
-        line_sender_error::wrapped_call(
-            ::line_sender_qwpws_close_drain, _impl);
+        line_sender_error::wrapped_call(::line_sender_qwpws_close_drain, _impl);
     }
 
     /**

--- a/include/questdb/ingress/line_sender_core.hpp
+++ b/include/questdb/ingress/line_sender_core.hpp
@@ -77,7 +77,8 @@ enum class error_code : int
     protocol_version_error = ::line_sender_error_protocol_version_error,
     invalid_decimal = ::line_sender_error_invalid_decimal,
     server_rejection = ::line_sender_error_server_rejection,
-    arrow_unsupported_column_kind = ::line_sender_error_arrow_unsupported_column_kind,
+    arrow_unsupported_column_kind =
+        ::line_sender_error_arrow_unsupported_column_kind,
     arrow_ingest = ::line_sender_error_arrow_ingest,
     failover_retry = ::line_sender_error_failover_retry,
     role_mismatch = ::line_sender_error_role_mismatch,
@@ -165,7 +166,8 @@ public:
     {
         ::questdb_error* c_err{nullptr};
         auto result = f(std::forward<Args>(args)..., &c_err);
-        if (c_err) throw from_c(c_err);
+        if (c_err)
+            throw from_c(c_err);
         return result;
     }
 
@@ -261,13 +263,10 @@ inline qwp_ws_error qwp_ws_error_from_view(
     const ::line_sender_qwpws_error_view& view)
 {
     return qwp_ws_error{
-        static_cast<qwp_ws_error_category>(
-            static_cast<int>(view.category)),
-        static_cast<qwp_ws_error_policy>(
-            static_cast<int>(view.applied_policy)),
-        view.has_status
-            ? std::optional<uint8_t>{view.status}
-            : std::optional<uint8_t>{},
+        static_cast<qwp_ws_error_category>(static_cast<int>(view.category)),
+        static_cast<qwp_ws_error_policy>(static_cast<int>(view.applied_policy)),
+        view.has_status ? std::optional<uint8_t>{view.status}
+                        : std::optional<uint8_t>{},
         std::string{
             view.message ? view.message : "",
             view.message ? view.message_len : 0},
@@ -362,10 +361,9 @@ public:
 private:
     inline static line_sender_error from_c(::line_sender_error* c_err)
     {
-        const std::unique_ptr<
-            ::line_sender_error,
-            decltype(&::line_sender_error_free)>
-            owned_err{c_err, ::line_sender_error_free};
+        const std::
+            unique_ptr<::line_sender_error, decltype(&::line_sender_error_free)>
+                owned_err{c_err, ::line_sender_error_free};
         line_sender_error_code code = static_cast<line_sender_error_code>(
             static_cast<int>(::line_sender_error_get_code(owned_err.get())));
         size_t c_len{0};

--- a/include/questdb/ingress/line_sender_core.hpp
+++ b/include/questdb/ingress/line_sender_core.hpp
@@ -60,6 +60,9 @@ class pool;
  * The released `questdb::ingress::line_sender_error_code` remains an alias of
  * this type.
  */
+// clang-format off: the Rust test `mirrors_of_the_c_error_code_enum_are_complete`
+// parses this enum expecting exactly one `<short> = ::line_sender_error_<short>,`
+// per line; reflowing a long entry across two lines breaks the mirror check.
 enum class error_code : int
 {
     could_not_resolve_addr = ::line_sender_error_could_not_resolve_addr,
@@ -77,8 +80,7 @@ enum class error_code : int
     protocol_version_error = ::line_sender_error_protocol_version_error,
     invalid_decimal = ::line_sender_error_invalid_decimal,
     server_rejection = ::line_sender_error_server_rejection,
-    arrow_unsupported_column_kind =
-        ::line_sender_error_arrow_unsupported_column_kind,
+    arrow_unsupported_column_kind = ::line_sender_error_arrow_unsupported_column_kind,
     arrow_ingest = ::line_sender_error_arrow_ingest,
     failover_retry = ::line_sender_error_failover_retry,
     role_mismatch = ::line_sender_error_role_mismatch,
@@ -103,6 +105,7 @@ enum class error_code : int
     store_resend_required = ::line_sender_error_store_resend_required,
     symbol_dict_full = ::line_sender_error_symbol_dict_full,
 };
+// clang-format on
 
 // Bridge equality between the C++ `questdb::error_code` and the released C ABI
 // enum `::line_sender_error_code` (identical `int` values), so existing

--- a/include/questdb/ingress/line_sender_decimal.hpp
+++ b/include/questdb/ingress/line_sender_decimal.hpp
@@ -56,7 +56,8 @@ class decimal_str_view
 {
 public:
     decimal_str_view(const char* buf, size_t len)
-        : buf{buf}, len{len}
+        : buf{buf}
+        , len{len}
     {
     }
 

--- a/include/questdb/ingress/qwp_sender.h
+++ b/include/questdb/ingress/qwp_sender.h
@@ -151,30 +151,28 @@ typedef struct qwp_validity
  *
  * In store-and-forward mode, each borrowed sender owns its own
  * `<sender_id>-ingest-<index>` slot, so concurrent borrows are allowed up to
- * `sender_pool_max`. Returning a sender parks that same slot for reuse; dropping a
- * non-recycled sender releases its slot index after the slot lock is closed.
+ * `sender_pool_max`. Returning a sender parks that same slot for reuse;
+ * dropping a non-recycled sender releases its slot index after the slot lock is
+ * closed.
  *
  * The returned sender is bound to the calling thread until returned.
  */
 QUESTDB_CLIENT_API
 qwp_sender* questdb_db_borrow_sender(
-    questdb_db* db,
-    line_sender_error** err_out);
+    questdb_db* db, line_sender_error** err_out);
 
 /**
  * Like `questdb_db_borrow_sender` but retries the connect within `budget_ms`
  * using the pool's reconnect backoff (centered-jittered exponential with
  * a role-reject reset; authentication and protocol-version errors are
  * terminal). On a transient `line_sender_error_failover_retry`, drop the dead
- * sender with `questdb_db_drop_sender` then call this to fail over with the same
- * budget and backoff. `budget_ms == 0` makes a single attempt.
- * Returns NULL on failure and sets `*err_out` if provided.
+ * sender with `questdb_db_drop_sender` then call this to fail over with the
+ * same budget and backoff. `budget_ms == 0` makes a single attempt. Returns
+ * NULL on failure and sets `*err_out` if provided.
  */
 QUESTDB_CLIENT_API
 qwp_sender* questdb_db_borrow_sender_with_retry(
-    questdb_db* db,
-    uint64_t budget_ms,
-    line_sender_error** err_out);
+    questdb_db* db, uint64_t budget_ms, line_sender_error** err_out);
 
 /**
  * Return a sender to the pool. Accepts NULL `sender` and no-ops.
@@ -199,14 +197,12 @@ qwp_sender* questdb_db_borrow_sender_with_retry(
  * call exactly one of the two. Calling both (or either twice) is UB.
  */
 QUESTDB_CLIENT_API
-void questdb_db_return_sender(
-    questdb_db* db,
-    qwp_sender* sender);
+void questdb_db_return_sender(questdb_db* db, qwp_sender* sender);
 
 /**
- * Force-drop a borrowed sender instead of recycling it. Marks the sender terminal
- * before the usual pool-return path runs.
- * Invalidates `sender`. Accepts NULL `sender` and no-ops.
+ * Force-drop a borrowed sender instead of recycling it. Marks the sender
+ * terminal before the usual pool-return path runs. Invalidates `sender`.
+ * Accepts NULL `sender` and no-ops.
  *
  * Use normal return for healthy senders: the return path already closes senders
  * that have latched terminal state, or whose pool has been closed.
@@ -226,9 +222,7 @@ void questdb_db_return_sender(
  * call exactly one of the two. Calling both (or either twice) is UB.
  */
 QUESTDB_CLIENT_API
-void questdb_db_drop_sender(
-    questdb_db* db,
-    qwp_sender* sender);
+void questdb_db_drop_sender(questdb_db* db, qwp_sender* sender);
 
 /**
  * Borrow a direct (pipelined, non-store-and-forward) column-major sender from
@@ -238,8 +232,7 @@ void questdb_db_drop_sender(
  */
 QUESTDB_CLIENT_API
 qwp_direct_sender* questdb_db_borrow_direct_sender(
-    questdb_db* db,
-    line_sender_error** err_out);
+    questdb_db* db, line_sender_error** err_out);
 
 /**
  * Like `questdb_db_borrow_direct_sender` but retries the connect within
@@ -250,9 +243,7 @@ qwp_direct_sender* questdb_db_borrow_direct_sender(
  */
 QUESTDB_CLIENT_API
 qwp_direct_sender* questdb_db_borrow_direct_sender_with_retry(
-    questdb_db* db,
-    uint64_t budget_ms,
-    line_sender_error** err_out);
+    questdb_db* db, uint64_t budget_ms, line_sender_error** err_out);
 
 /**
  * Build a direct (pipelined, non-store-and-forward) column-major sender from a
@@ -266,9 +257,7 @@ qwp_direct_sender* questdb_db_borrow_direct_sender_with_retry(
  */
 QUESTDB_CLIENT_API
 qwp_direct_sender* qwp_direct_sender_from_conf(
-    const char* conf,
-    size_t conf_len,
-    line_sender_error** err_out);
+    const char* conf, size_t conf_len, line_sender_error** err_out);
 
 /**
  * Build a direct (pipelined, non-store-and-forward) column-major sender from a
@@ -284,8 +273,7 @@ qwp_direct_sender* qwp_direct_sender_from_conf(
  */
 QUESTDB_CLIENT_API
 qwp_direct_sender* qwp_direct_sender_from_opts(
-    const line_sender_opts* opts,
-    line_sender_error** err_out);
+    const line_sender_opts* opts, line_sender_error** err_out);
 
 /**
  * Return a direct sender to the pool. Accepts NULL `sender` and no-ops.
@@ -302,9 +290,7 @@ qwp_direct_sender* qwp_direct_sender_from_opts(
  * `sender`: call exactly one of the two. Calling both (or either twice) is UB.
  */
 QUESTDB_CLIENT_API
-void questdb_db_return_direct_sender(
-    questdb_db* db,
-    qwp_direct_sender* sender);
+void questdb_db_return_direct_sender(questdb_db* db, qwp_direct_sender* sender);
 
 /**
  * Force-drop a direct sender, closing its connection instead of recycling it
@@ -331,9 +317,7 @@ void questdb_db_return_direct_sender(
  * function. Calling more than one (or any release function twice) is UB.
  */
 QUESTDB_CLIENT_API
-void questdb_db_drop_direct_sender(
-    questdb_db* db,
-    qwp_direct_sender* sender);
+void questdb_db_drop_direct_sender(questdb_db* db, qwp_direct_sender* sender);
 
 /**
  * Free a standalone `qwp_direct_sender_from_conf` /
@@ -347,8 +331,7 @@ void questdb_db_drop_direct_sender(
  * functions (or either twice) is UB.
  */
 QUESTDB_CLIENT_API
-void qwp_direct_sender_free(
-    qwp_direct_sender* sender);
+void qwp_direct_sender_free(qwp_direct_sender* sender);
 
 /* Reader-pool entry points (`questdb_db_borrow_reader`,
  * `questdb_db_dbg_reader_*_count`) live in `questdb/egress/qwp_reader.h`
@@ -367,8 +350,7 @@ void qwp_direct_sender_free(
  */
 QUESTDB_CLIENT_API
 line_sender_buffer* questdb_db_new_buffer(
-    const questdb_db* db,
-    line_sender_error** err_out);
+    const questdb_db* db, line_sender_error** err_out);
 
 /** Return the configured name limit used by `questdb_db_new_buffer`. */
 QUESTDB_CLIENT_API
@@ -440,9 +422,7 @@ bool qwp_sender_flush_buffer_and_keep_and_get_fsn(
  */
 QUESTDB_CLIENT_API
 qwp_chunk* qwp_chunk_new(
-    const char* table_name,
-    size_t table_name_len,
-    line_sender_error** err_out);
+    const char* table_name, size_t table_name_len, line_sender_error** err_out);
 
 /**
  * Create an empty chunk from a pre-validated `line_sender_table_name`.
@@ -464,8 +444,7 @@ qwp_chunk* qwp_chunk_new(
  */
 QUESTDB_CLIENT_API
 qwp_chunk* qwp_chunk_new_validated(
-    line_sender_table_name table,
-    line_sender_error** err_out);
+    line_sender_table_name table, line_sender_error** err_out);
 
 /**
  * Discard the chunk and release its allocations. Accepts NULL (no-op).
@@ -485,9 +464,7 @@ void qwp_chunk_free(qwp_chunk* chunk);
  * mutating the chunk. A NULL `err_out` is silently ignored.
  */
 QUESTDB_CLIENT_API
-bool qwp_chunk_clear(
-    qwp_chunk* chunk,
-    line_sender_error** err_out);
+bool qwp_chunk_clear(qwp_chunk* chunk, line_sender_error** err_out);
 
 /**
  * Current row count of the chunk; 0 if no column has been appended.
@@ -497,9 +474,7 @@ bool qwp_chunk_clear(
  * ignored.
  */
 QUESTDB_CLIENT_API
-size_t qwp_chunk_row_count(
-    const qwp_chunk* chunk,
-    line_sender_error** err_out);
+size_t qwp_chunk_row_count(const qwp_chunk* chunk, line_sender_error** err_out);
 
 /* -------------------------------------------------------------------------
  * Numeric / fixed-width column appends
@@ -535,48 +510,60 @@ size_t qwp_chunk_row_count(
 QUESTDB_CLIENT_API
 bool qwp_chunk_column_i8(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const int8_t* data, size_t row_count,
+    const char* name,
+    size_t name_len,
+    const int8_t* data,
+    size_t row_count,
     const qwp_validity* validity,
     line_sender_error** err_out);
 
 QUESTDB_CLIENT_API
 bool qwp_chunk_column_i16(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const int16_t* data, size_t row_count,
+    const char* name,
+    size_t name_len,
+    const int16_t* data,
+    size_t row_count,
     const qwp_validity* validity,
     line_sender_error** err_out);
 
 QUESTDB_CLIENT_API
 bool qwp_chunk_column_i32(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const int32_t* data, size_t row_count,
+    const char* name,
+    size_t name_len,
+    const int32_t* data,
+    size_t row_count,
     const qwp_validity* validity,
     line_sender_error** err_out);
 
 QUESTDB_CLIENT_API
 bool qwp_chunk_column_i64(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const int64_t* data, size_t row_count,
+    const char* name,
+    size_t name_len,
+    const int64_t* data,
+    size_t row_count,
     const qwp_validity* validity,
     line_sender_error** err_out);
 
 QUESTDB_CLIENT_API
 bool qwp_chunk_column_f32(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const float* data, size_t row_count,
+    const char* name,
+    size_t name_len,
+    const float* data,
+    size_t row_count,
     const qwp_validity* validity,
     line_sender_error** err_out);
 
 QUESTDB_CLIENT_API
 bool qwp_chunk_column_f64(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const double* data, size_t row_count,
+    const char* name,
+    size_t name_len,
+    const double* data,
+    size_t row_count,
     const qwp_validity* validity,
     line_sender_error** err_out);
 
@@ -592,8 +579,10 @@ bool qwp_chunk_column_f64(
 QUESTDB_CLIENT_API
 bool qwp_chunk_column_bool(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const uint8_t* data, size_t row_count,
+    const char* name,
+    size_t name_len,
+    const uint8_t* data,
+    size_t row_count,
     const qwp_validity* validity,
     line_sender_error** err_out);
 
@@ -604,8 +593,10 @@ bool qwp_chunk_column_bool(
 QUESTDB_CLIENT_API
 bool qwp_chunk_column_uuid(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const uint8_t* data, size_t row_count,
+    const char* name,
+    size_t name_len,
+    const uint8_t* data,
+    size_t row_count,
     const qwp_validity* validity,
     line_sender_error** err_out);
 
@@ -616,8 +607,10 @@ bool qwp_chunk_column_uuid(
 QUESTDB_CLIENT_API
 bool qwp_chunk_column_long256(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const uint8_t* data, size_t row_count,
+    const char* name,
+    size_t name_len,
+    const uint8_t* data,
+    size_t row_count,
     const qwp_validity* validity,
     line_sender_error** err_out);
 
@@ -628,8 +621,10 @@ bool qwp_chunk_column_long256(
 QUESTDB_CLIENT_API
 bool qwp_chunk_column_ipv4(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const uint32_t* data, size_t row_count,
+    const char* name,
+    size_t name_len,
+    const uint32_t* data,
+    size_t row_count,
     const qwp_validity* validity,
     line_sender_error** err_out);
 
@@ -659,8 +654,10 @@ typedef enum qwp_ts_unit
 QUESTDB_CLIENT_API
 bool qwp_chunk_column_ts(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const int64_t* data, size_t row_count,
+    const char* name,
+    size_t name_len,
+    const int64_t* data,
+    size_t row_count,
     uint32_t unit,
     const qwp_validity* validity,
     line_sender_error** err_out);
@@ -669,8 +666,10 @@ bool qwp_chunk_column_ts(
 QUESTDB_CLIENT_API
 bool qwp_chunk_column_date(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const int64_t* data, size_t row_count,
+    const char* name,
+    size_t name_len,
+    const int64_t* data,
+    size_t row_count,
     const qwp_validity* validity,
     line_sender_error** err_out);
 
@@ -711,7 +710,8 @@ bool qwp_chunk_column_date(
 QUESTDB_CLIENT_API
 bool qwp_chunk_column_str(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
+    const char* name,
+    size_t name_len,
     const int32_t* offsets,
     const uint8_t* bytes,
     size_t bytes_len,
@@ -782,41 +782,44 @@ bool qwp_chunk_column_binary(
  * the chunk, or the rows the committed prefix already carried are duplicated.
  *
  * Resetting the dictionary means discarding the connection that owns it — there
- * is no per-sender close. A full dictionary RETIRES the connection on return, so
- * a plain `questdb_db_return_sender` drops it rather than recycling it (the next
- * borrow gets a fresh, empty-dictionary connection, not the same full one) and
- * drains / commits its pending frames best-effort on the way out. So the simplest
- * recovery is to return the sender as usual and borrow a fresh one. Discarding the
- * connection is NOT automatically lossless for frames already flushed on it, so if
- * those must not be lost, drain or commit them AND check first:
+ * is no per-sender close. A full dictionary RETIRES the connection on return,
+ * so a plain `questdb_db_return_sender` drops it rather than recycling it (the
+ * next borrow gets a fresh, empty-dictionary connection, not the same full one)
+ * and drains / commits its pending frames best-effort on the way out. So the
+ * simplest recovery is to return the sender as usual and borrow a fresh one.
+ * Discarding the connection is NOT automatically lossless for frames already
+ * flushed on it, so if those must not be lost, drain or commit them AND check
+ * first:
  *
  *   - Pooled sender: a plain `questdb_db_return_sender` now retires (does NOT
  *     recycle) a full-dictionary connection and drains its queue best-effort
  *     within `close_flush_timeout`; the next borrow is fresh. Call
- *     `qwp_sender_wait` first if the queued frames must not be lost. This matters
- *     with `sf_dir` too: returning while frames are unresolved leaves them (and
- *     the dictionary) in the slot, and the next borrower re-seeds from the slot's
- *     side-file at the same size unless the slot drained first.
- *   - Pooled direct sender: a plain `questdb_db_return_direct_sender` retires the
- *     connection and commits the deferred tail best-effort. Its flushes are
- *     deferred, so for a CHECKED guarantee call `qwp_direct_sender_commit` (or a
- *     waited flush) and confirm it succeeded before the return. Do NOT use
+ *     `qwp_sender_wait` first if the queued frames must not be lost. This
+ * matters with `sf_dir` too: returning while frames are unresolved leaves them
+ * (and the dictionary) in the slot, and the next borrower re-seeds from the
+ * slot's side-file at the same size unless the slot drained first.
+ *   - Pooled direct sender: a plain `questdb_db_return_direct_sender` retires
+ * the connection and commits the deferred tail best-effort. Its flushes are
+ *     deferred, so for a CHECKED guarantee call `qwp_direct_sender_commit` (or
+ * a waited flush) and confirm it succeeded before the return. Do NOT use
  *     `questdb_db_drop_direct_sender` on a full dictionary: it force-drops and
- *     skips the best-effort commit that the normal return performs, so every frame
- *     flushed since the last successful commit is discarded with only a log
+ *     skips the best-effort commit that the normal return performs, so every
+ * frame flushed since the last successful commit is discarded with only a log
  *     warning.
  *   - Standalone direct sender: `qwp_direct_sender_free` performs the same
- *     best-effort commit the pooled return does, so the deferred tail is committed
- *     on the way out; call `qwp_direct_sender_commit` first so the commit's success
- *     is something you checked rather than hoped for. Then `qwp_direct_sender_free`,
- *     then re-open with `qwp_direct_sender_from_conf` / `qwp_direct_sender_from_opts`.
+ *     best-effort commit the pooled return does, so the deferred tail is
+ * committed on the way out; call `qwp_direct_sender_commit` first so the
+ * commit's success is something you checked rather than hoped for. Then
+ * `qwp_direct_sender_free`, then re-open with `qwp_direct_sender_from_conf` /
+ * `qwp_direct_sender_from_opts`.
  *   - Standalone row sender (a `line_sender` opened on a `ws://` / `wss://`
  *     address and flushed with `line_sender_flush*`, which shares this same
  *     connection dictionary): `line_sender_qwpws_close_drain` and check it
  *     succeeded, then `line_sender_close`, then re-open. Do NOT rely on
  *     `line_sender_close` alone — it does not flush, and nothing drains the
  *     QWP/WebSocket queue on the way out, so every published-but-unacked frame
- *     is discarded with no wait. This is the most lossy flavour on a bare close.
+ *     is discarded with no wait. This is the most lossy flavour on a bare
+ * close.
  *
  * `codes[i]` must be in `0 .. dict_len` for non-null rows; null-row
  * codes are not inspected.
@@ -843,30 +846,42 @@ bool qwp_chunk_column_binary(
 QUESTDB_CLIENT_API
 bool qwp_chunk_symbol_i8(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const int8_t* codes, size_t row_count,
-    const int32_t* dict_offsets, size_t dict_offsets_len,
-    const uint8_t* dict_bytes, size_t dict_bytes_len,
+    const char* name,
+    size_t name_len,
+    const int8_t* codes,
+    size_t row_count,
+    const int32_t* dict_offsets,
+    size_t dict_offsets_len,
+    const uint8_t* dict_bytes,
+    size_t dict_bytes_len,
     const qwp_validity* validity,
     line_sender_error** err_out);
 
 QUESTDB_CLIENT_API
 bool qwp_chunk_symbol_i16(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const int16_t* codes, size_t row_count,
-    const int32_t* dict_offsets, size_t dict_offsets_len,
-    const uint8_t* dict_bytes, size_t dict_bytes_len,
+    const char* name,
+    size_t name_len,
+    const int16_t* codes,
+    size_t row_count,
+    const int32_t* dict_offsets,
+    size_t dict_offsets_len,
+    const uint8_t* dict_bytes,
+    size_t dict_bytes_len,
     const qwp_validity* validity,
     line_sender_error** err_out);
 
 QUESTDB_CLIENT_API
 bool qwp_chunk_symbol_i32(
     qwp_chunk* chunk,
-    const char* name, size_t name_len,
-    const int32_t* codes, size_t row_count,
-    const int32_t* dict_offsets, size_t dict_offsets_len,
-    const uint8_t* dict_bytes, size_t dict_bytes_len,
+    const char* name,
+    size_t name_len,
+    const int32_t* codes,
+    size_t row_count,
+    const int32_t* dict_offsets,
+    size_t dict_offsets_len,
+    const uint8_t* dict_bytes,
+    size_t dict_bytes_len,
     const qwp_validity* validity,
     line_sender_error** err_out);
 
@@ -937,12 +952,12 @@ bool qwp_chunk_symbol_i32(
  * `ArrowSchema`; we consume `array->release` on success in the
  * column-sender entry points below, and leave it intact on failure.
  * https://arrow.apache.org/docs/format/CDataInterface.html */
-#ifndef ARROW_C_DATA_INTERFACE
-#    define ARROW_C_DATA_INTERFACE
+#    ifndef ARROW_C_DATA_INTERFACE
+#        define ARROW_C_DATA_INTERFACE
 
-#    define ARROW_FLAG_DICTIONARY_ORDERED 1
-#    define ARROW_FLAG_NULLABLE 2
-#    define ARROW_FLAG_MAP_KEYS_SORTED 4
+#        define ARROW_FLAG_DICTIONARY_ORDERED 1
+#        define ARROW_FLAG_NULLABLE 2
+#        define ARROW_FLAG_MAP_KEYS_SORTED 4
 
 struct ArrowSchema
 {
@@ -971,7 +986,7 @@ struct ArrowArray
     void* private_data;
 };
 
-#endif /* ARROW_C_DATA_INTERFACE */
+#    endif /* ARROW_C_DATA_INTERFACE */
 
 /**
  * Opaque handle wrapping an `ArrowArray` + `ArrowSchema` pair imported
@@ -1180,8 +1195,8 @@ typedef enum qwp_numpy_dtype
     qwp_numpy_u32 = 6, /* → LONG  (8B/row, widen u32→i64)             */
     qwp_numpy_u64 = 7, /* → LONG  (8B/row, reject values > i64::MAX)  */
 
-    qwp_numpy_f32 = 8, /* → FLOAT  (4B/row, direct)                   */
-    qwp_numpy_f64 = 9, /* → DOUBLE (8B/row, sentinel = NaN)           */
+    qwp_numpy_f32 = 8,   /* → FLOAT  (4B/row, direct)                   */
+    qwp_numpy_f64 = 9,   /* → DOUBLE (8B/row, sentinel = NaN)           */
     qwp_numpy_bool = 10, /* → BOOLEAN (bit-packed)                    */
 
     /* Half-precision + time */
@@ -1361,9 +1376,7 @@ bool qwp_chunk_at_seconds(
  * Rejects if a designated timestamp column is already set (and vice
  * versa). Cleared by `qwp_chunk_clear`. */
 QUESTDB_CLIENT_API
-bool qwp_chunk_at_now(
-    qwp_chunk* chunk,
-    line_sender_error** err_out);
+bool qwp_chunk_at_now(qwp_chunk* chunk, line_sender_error** err_out);
 
 /** Pin one scalar nanosecond-precision Unix epoch timestamp as every
  * row's designated timestamp, encoded as a repeated constant (wire type
@@ -1374,9 +1387,7 @@ bool qwp_chunk_at_now(
  * `qwp_chunk_clear`. */
 QUESTDB_CLIENT_API
 bool qwp_chunk_at_scalar_nanos(
-    qwp_chunk* chunk,
-    int64_t nanos,
-    line_sender_error** err_out);
+    qwp_chunk* chunk, int64_t nanos, line_sender_error** err_out);
 
 /* -------------------------------------------------------------------------
  * Flush / sync
@@ -1389,8 +1400,8 @@ bool qwp_chunk_at_scalar_nanos(
  * Every flushed frame is non-deferred and is first accepted into the local
  * store-and-forward queue, which owns delivery. `qwp_sender_flush_chunk`
  * success means local queue acceptance, not server acknowledgement.
- * `qwp_sender_flush_chunk_and_wait` combines local publication of `chunk` as the
- * sync-call boundary with the wait for `ack_level`. `qwp_sender_wait` does
+ * `qwp_sender_flush_chunk_and_wait` combines local publication of `chunk` as
+ * the sync-call boundary with the wait for `ack_level`. `qwp_sender_wait` does
  * not send a frame; it waits for frames already published to the local queue,
  * up to the sync-call boundary, to be acknowledged at `ack_level`.
  *
@@ -1409,9 +1420,7 @@ bool qwp_chunk_at_scalar_nanos(
 
 QUESTDB_CLIENT_API
 bool qwp_sender_flush_chunk(
-    qwp_sender* sender,
-    qwp_chunk* chunk,
-    line_sender_error** err_out);
+    qwp_sender* sender, qwp_chunk* chunk, line_sender_error** err_out);
 
 /**
  * Publish `chunk` locally through the borrowed store-and-forward QWP sender
@@ -1556,9 +1565,7 @@ bool qwp_sender_wait(
  */
 QUESTDB_CLIENT_API
 bool qwp_direct_sender_flush(
-    qwp_direct_sender* sender,
-    qwp_chunk* chunk,
-    line_sender_error** err_out);
+    qwp_direct_sender* sender, qwp_chunk* chunk, line_sender_error** err_out);
 
 /**
  * Direct commit: send the commit boundary for all pipelined frames and block
@@ -1568,9 +1575,7 @@ bool qwp_direct_sender_flush(
  */
 QUESTDB_CLIENT_API
 bool qwp_direct_sender_commit(
-    qwp_direct_sender* sender,
-    uint32_t ack_level,
-    line_sender_error** err_out);
+    qwp_direct_sender* sender, uint32_t ack_level, line_sender_error** err_out);
 
 #ifdef QUESTDB_CLIENT_ENABLE_ARROW
 

--- a/include/questdb/ingress/qwp_sender.hpp
+++ b/include/questdb/ingress/qwp_sender.hpp
@@ -122,8 +122,8 @@ public:
     {
         ::line_sender_table_name table_c{table.size(), table.data()};
         column_chunk chunk;
-        chunk._raw = line_sender_error::wrapped_call(
-            ::qwp_chunk_new_validated, table_c);
+        chunk._raw =
+            line_sender_error::wrapped_call(::qwp_chunk_new_validated, table_c);
         return chunk;
     }
 
@@ -154,8 +154,14 @@ public:
             ::qwp_chunk_free(_raw);
     }
 
-    ::qwp_chunk* c_ptr() noexcept { return _raw; }
-    const ::qwp_chunk* c_ptr() const noexcept { return _raw; }
+    ::qwp_chunk* c_ptr() noexcept
+    {
+        return _raw;
+    }
+    const ::qwp_chunk* c_ptr() const noexcept
+    {
+        return _raw;
+    }
 
     /**
      * Row count locked by the first appended column / designated ts.
@@ -303,7 +309,8 @@ public:
         return *this;
     }
 
-    /** UUID column: 16 bytes per row — low half LE in bytes 0..8, high half LE in bytes 8..16. */
+    /** UUID column: 16 bytes per row — low half LE in bytes 0..8, high half LE
+     * in bytes 8..16. */
     column_chunk& column_uuid(
         std::string_view name,
         const uint8_t* data,
@@ -549,47 +556,31 @@ public:
 
     // -- Designated timestamp -----------------------------------------
 
-    column_chunk& at_micros(
-        const int64_t* data, size_t row_count)
+    column_chunk& at_micros(const int64_t* data, size_t row_count)
     {
         line_sender_error::wrapped_call(
-            ::qwp_chunk_at_micros,
-            _raw,
-            data,
-            row_count);
+            ::qwp_chunk_at_micros, _raw, data, row_count);
         return *this;
     }
 
-    column_chunk& at_nanos(
-        const int64_t* data, size_t row_count)
+    column_chunk& at_nanos(const int64_t* data, size_t row_count)
     {
         line_sender_error::wrapped_call(
-            ::qwp_chunk_at_nanos,
-            _raw,
-            data,
-            row_count);
+            ::qwp_chunk_at_nanos, _raw, data, row_count);
         return *this;
     }
 
-    column_chunk& at_millis(
-        const int64_t* data, size_t row_count)
+    column_chunk& at_millis(const int64_t* data, size_t row_count)
     {
         line_sender_error::wrapped_call(
-            ::qwp_chunk_at_millis,
-            _raw,
-            data,
-            row_count);
+            ::qwp_chunk_at_millis, _raw, data, row_count);
         return *this;
     }
 
-    column_chunk& at_seconds(
-        const int64_t* data, size_t row_count)
+    column_chunk& at_seconds(const int64_t* data, size_t row_count)
     {
         line_sender_error::wrapped_call(
-            ::qwp_chunk_at_seconds,
-            _raw,
-            data,
-            row_count);
+            ::qwp_chunk_at_seconds, _raw, data, row_count);
         return *this;
     }
 
@@ -664,14 +655,10 @@ public:
     arrow_import(
         ::ArrowArray& array,
         const ::ArrowSchema& schema,
-        ::qwp_symbol_mode symbol_mode =
-            ::qwp_symbol_mode_auto)
+        ::qwp_symbol_mode symbol_mode = ::qwp_symbol_mode_auto)
     {
         _raw = line_sender_error::wrapped_call(
-            ::qwp_arrow_import_new,
-            &array,
-            &schema,
-            symbol_mode);
+            ::qwp_arrow_import_new, &array, &schema, symbol_mode);
     }
 
     arrow_import(const arrow_import&) = delete;
@@ -707,8 +694,14 @@ public:
         return ::qwp_arrow_import_len(_raw);
     }
 
-    ::qwp_arrow_import* c_ptr() noexcept { return _raw; }
-    const ::qwp_arrow_import* c_ptr() const noexcept { return _raw; }
+    ::qwp_arrow_import* c_ptr() noexcept
+    {
+        return _raw;
+    }
+    const ::qwp_arrow_import* c_ptr() const noexcept
+    {
+        return _raw;
+    }
 
 private:
     ::qwp_arrow_import* _raw{nullptr};
@@ -767,13 +760,13 @@ public:
     }
 
     /**
-     * Publish `chunk` as a completion boundary, then wait until it and all prior
-     * frames published through this sender reach `level`. Uses the pool-wide
-     * `request_timeout` as the wait's no-progress deadline. Throws on error.
+     * Publish `chunk` as a completion boundary, then wait until it and all
+     * prior frames published through this sender reach `level`. Uses the
+     * pool-wide `request_timeout` as the wait's no-progress deadline. Throws on
+     * error.
      */
     void flush_and_wait(
-        column_chunk& chunk,
-        qwpws_ack_level level = qwpws_ack_level::ok)
+        column_chunk& chunk, qwpws_ack_level level = qwpws_ack_level::ok)
     {
         line_sender_error::wrapped_call(
             ::qwp_sender_flush_chunk_and_wait,
@@ -791,10 +784,7 @@ public:
     {
         ::line_sender_qwpws_fsn fsn{};
         line_sender_error::wrapped_call(
-            ::qwp_sender_flush_chunk_and_get_fsn,
-            _raw,
-            chunk.c_ptr(),
-            &fsn);
+            ::qwp_sender_flush_chunk_and_get_fsn, _raw, chunk.c_ptr(), &fsn);
         return optional_fsn(fsn);
     }
 
@@ -821,8 +811,7 @@ public:
     std::optional<uint64_t> published_fsn() const
     {
         ::line_sender_qwpws_fsn fsn{};
-        line_sender_error::wrapped_call(
-            ::qwp_sender_published_fsn, _raw, &fsn);
+        line_sender_error::wrapped_call(::qwp_sender_published_fsn, _raw, &fsn);
         return optional_fsn(fsn);
     }
 
@@ -833,8 +822,7 @@ public:
     std::optional<uint64_t> acked_fsn() const
     {
         ::line_sender_qwpws_fsn fsn{};
-        line_sender_error::wrapped_call(
-            ::qwp_sender_acked_fsn, _raw, &fsn);
+        line_sender_error::wrapped_call(::qwp_sender_acked_fsn, _raw, &fsn);
         return optional_fsn(fsn);
     }
 
@@ -864,7 +852,8 @@ public:
     /**
      * Publish-only Arrow flush (server-stamped) into the queue. Pair with
      * `wait()`. Ownership: on success `array.release` is consumed; on failure
-     * it may also have been consumed — check before invoking. `schema` borrowed.
+     * it may also have been consumed — check before invoking. `schema`
+     * borrowed.
      */
     void flush_arrow_batch_at_now(
         table_name_view table,
@@ -1043,8 +1032,14 @@ public:
 private:
     friend class borrowed_sender;
 
-    ::qwp_sender* c_ptr() noexcept { return _raw; }
-    const ::qwp_sender* c_ptr() const noexcept { return _raw; }
+    ::qwp_sender* c_ptr() noexcept
+    {
+        return _raw;
+    }
+    const ::qwp_sender* c_ptr() const noexcept
+    {
+        return _raw;
+    }
 
     static std::optional<uint64_t> optional_fsn(
         const ::line_sender_qwpws_fsn& fsn)
@@ -1107,7 +1102,10 @@ public:
         return *this;
     }
 
-    ~borrowed_sender() noexcept { release(); }
+    ~borrowed_sender() noexcept
+    {
+        release();
+    }
 
     /** `true` if this guard currently owns a borrowed sender. */
     explicit operator bool() const noexcept
@@ -1150,8 +1148,7 @@ public:
 
     /** Publish and clear a Buffer, then wait for `level`. */
     void flush_and_wait(
-        line_sender_buffer& buffer,
-        qwpws_ack_level level = qwpws_ack_level::ok)
+        line_sender_buffer& buffer, qwpws_ack_level level = qwpws_ack_level::ok)
     {
         buffer.may_init();
         line_sender_error::wrapped_call(
@@ -1206,13 +1203,13 @@ public:
      *
      * A chunk introducing a symbol past the connection-scoped dictionary's
      * 2,000,000-entry / 256 MiB cap throws `error_code::symbol_dict_full` here.
-     * Retrying a new symbol on this sender cannot succeed: the dictionary belongs
-     * to the connection. A full dictionary retires the connection on return, so
-     * simply letting this guard be destroyed drops it (not recycled) and drains
-     * its queue best-effort — the next borrow gets a fresh connection. Call
-     * `wait()` first if the queued frames must not be lost (`drop_on_return()` is
-     * no longer required for a full dictionary). See the symbol-column preamble in
-     * `qwp_sender.h`.
+     * Retrying a new symbol on this sender cannot succeed: the dictionary
+     * belongs to the connection. A full dictionary retires the connection on
+     * return, so simply letting this guard be destroyed drops it (not recycled)
+     * and drains its queue best-effort — the next borrow gets a fresh
+     * connection. Call `wait()` first if the queued frames must not be lost
+     * (`drop_on_return()` is no longer required for a full dictionary). See the
+     * symbol-column preamble in `qwp_sender.h`.
      */
     void flush(column_chunk& chunk)
     {
@@ -1220,12 +1217,11 @@ public:
     }
 
     /**
-     * Publish `chunk` as a completion boundary, then wait until it and all prior
-     * frames published through this sender reach `level`.
+     * Publish `chunk` as a completion boundary, then wait until it and all
+     * prior frames published through this sender reach `level`.
      */
     void flush_and_wait(
-        column_chunk& chunk,
-        qwpws_ack_level level = qwpws_ack_level::ok)
+        column_chunk& chunk, qwpws_ack_level level = qwpws_ack_level::ok)
     {
         _view.flush_and_wait(chunk, level);
     }
@@ -1394,17 +1390,20 @@ public:
 #endif
 
     /**
-     * Force this borrowed sender to be closed instead of recycled when the guard
-     * is destroyed.
+     * Force this borrowed sender to be closed instead of recycled when the
+     * guard is destroyed.
      *
-     * Use normal destruction for healthy senders: the return path already closes
-     * senders that have latched terminal state, or whose pool has been closed.
-     * Call this after abandoning work or handling an error where the next
-     * borrower must not inherit this backend. If queued store-and-forward
+     * Use normal destruction for healthy senders: the return path already
+     * closes senders that have latched terminal state, or whose pool has been
+     * closed. Call this after abandoning work or handling an error where the
+     * next borrower must not inherit this backend. If queued store-and-forward
      * frames must not be lost, call `wait()` first or configure `sf_dir` for
      * replay.
      */
-    void drop_on_return() noexcept { _force_drop = true; }
+    void drop_on_return() noexcept
+    {
+        _force_drop = true;
+    }
 
 private:
     friend class ::questdb::pool;

--- a/questdb-rs/src/ingress/sender/qwp_ws_driver.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws_driver.rs
@@ -5460,9 +5460,11 @@ mod tests {
     }
 
     #[cfg(feature = "sync-sender-qwp-ws")]
-    fn read_client_frame<S: Read>(stream: &mut S) -> std::io::Result<Vec<u8>> {
+    fn read_client_frame<S: Read>(stream: &mut S) -> std::io::Result<(u8, Vec<u8>)> {
         let mut hdr = [0u8; 2];
         stream.read_exact(&mut hdr)?;
+        let opcode = hdr[0] & 0x0f;
+        assert_ne!(hdr[1] & 0x80, 0, "client WebSocket frame must be masked");
         let len_short = hdr[1] & 0x7f;
         let payload_len = match len_short {
             126 => {
@@ -5484,7 +5486,7 @@ mod tests {
         for (index, byte) in payload.iter_mut().enumerate() {
             *byte ^= mask[index & 3];
         }
-        Ok(payload)
+        Ok((opcode, payload))
     }
 
     #[cfg(feature = "sync-sender-qwp-ws")]
@@ -5514,26 +5516,71 @@ mod tests {
     }
 
     #[cfg(feature = "sync-sender-qwp-ws")]
-    fn serve_qwp_ws_connection<S: Read + Write>(
-        stream: &mut S,
-        frames: usize,
-        payload_tx: mpsc::Sender<Vec<u8>>,
-    ) {
+    fn upgrade_qwp_ws_test_connection<S: Read + Write>(stream: &mut S, durable_ack: bool) {
         let request = read_request_until_blank(stream).unwrap();
         let accept =
             crate::ws::crypto::compute_accept(&header_value(&request, "Sec-WebSocket-Key"));
+        if durable_ack {
+            assert_eq!(header_value(&request, "X-QWP-Request-Durable-Ack"), "true");
+        }
+        let durable_ack_header = if durable_ack {
+            "X-QWP-Durable-Ack: enabled\r\n"
+        } else {
+            ""
+        };
         let response = format!(
             "HTTP/1.1 101 Switching Protocols\r\n\
              Upgrade: websocket\r\n\
              Connection: Upgrade\r\n\
              Sec-WebSocket-Accept: {accept}\r\n\
              X-QWP-Version: 1\r\n\
+             {durable_ack_header}\
              \r\n"
         );
         stream.write_all(response.as_bytes()).unwrap();
+    }
+
+    #[cfg(feature = "sync-sender-qwp-ws")]
+    fn connect_blocking_test_transport(
+        port: u16,
+        durable_ack: bool,
+        traffic_gate: Option<Arc<TrafficGate>>,
+    ) -> BlockingQwpWsTransport {
+        let durable_ack_conf = if durable_ack {
+            "request_durable_ack=on;durable_ack_keepalive_interval_millis=60000;"
+        } else {
+            ""
+        };
+        let builder = crate::ingress::SenderBuilder::from_conf(format!(
+            "ws::addr=127.0.0.1:{port};{durable_ack_conf}"
+        ))
+        .unwrap();
+        let qwp_ws = builder.qwp_ws.unwrap();
+        BlockingQwpWsTransport::connect(
+            "127.0.0.1",
+            port.to_string(),
+            false,
+            None,
+            QwpWsConnectKind::Foreground,
+            qwp_ws,
+            None,
+            Arc::new(AtomicUsize::new(0)),
+            traffic_gate,
+        )
+        .unwrap()
+    }
+
+    #[cfg(feature = "sync-sender-qwp-ws")]
+    fn serve_qwp_ws_connection<S: Read + Write>(
+        stream: &mut S,
+        frames: usize,
+        payload_tx: mpsc::Sender<Vec<u8>>,
+    ) {
+        upgrade_qwp_ws_test_connection(stream, false);
 
         for wire_seq in 0..frames {
-            let payload = read_client_frame(stream).unwrap();
+            let (opcode, payload) = read_client_frame(stream).unwrap();
+            assert_eq!(opcode, OPCODE_BINARY);
             payload_tx.send(payload).unwrap();
             write_ok_response(stream, wire_seq as u64).unwrap();
         }
@@ -5706,6 +5753,95 @@ mod tests {
             payload_rx.recv_timeout(Duration::from_secs(5)).unwrap(),
             expected
         );
+    }
+
+    #[cfg(feature = "sync-sender-qwp-ws")]
+    #[test]
+    fn blocking_transport_emits_durable_keepalive_ping() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            upgrade_qwp_ws_test_connection(&mut stream, true);
+            read_client_frame(&mut stream).unwrap()
+        });
+
+        let mut transport = connect_blocking_test_transport(port, true, None);
+        assert!(transport.send_durable_ack_keepalive_if_due(true).unwrap());
+        assert!(!transport.send_durable_ack_keepalive_if_due(true).unwrap());
+
+        let (opcode, payload) = server.join().unwrap();
+        assert_eq!(opcode, crate::ws::frame::OPCODE_PING);
+        assert!(payload.is_empty());
+    }
+
+    #[cfg(feature = "sync-sender-qwp-ws")]
+    #[test]
+    fn blocking_transport_reconnect_registers_replacement_with_traffic_gate() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = thread::spawn(move || {
+            let mut streams = Vec::new();
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept().unwrap();
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .unwrap();
+                upgrade_qwp_ws_test_connection(&mut stream, false);
+                streams.push(stream);
+            }
+            streams
+        });
+
+        let traffic_gate = Arc::new(TrafficGate::default());
+        let mut transport =
+            connect_blocking_test_transport(port, false, Some(Arc::clone(&traffic_gate)));
+        transport
+            .restart_connection(ReconnectReason::Disconnect)
+            .unwrap();
+        let mut server_streams = server.join().unwrap();
+
+        let (read_started_tx, read_started_rx) = mpsc::channel();
+        let (read_result_tx, read_result_rx) = mpsc::channel();
+        let reader = thread::spawn(move || {
+            read_started_tx.send(()).unwrap();
+            let mut byte = [0u8; 1];
+            read_result_tx
+                .send(transport.stream.read(&mut byte))
+                .unwrap();
+        });
+        read_started_rx
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap();
+        traffic_gate.shutdown().unwrap();
+
+        let result = match read_result_rx.recv_timeout(Duration::from_secs(2)) {
+            Ok(result) => result,
+            Err(err) => {
+                // A missing reconnect registration leaves the replacement read
+                // untouched. Close its peer so the failed test can still join.
+                server_streams.pop();
+                reader.join().unwrap();
+                panic!("replacement socket read was not interrupted: {err}");
+            }
+        };
+        reader.join().unwrap();
+        match result {
+            Ok(0) => {}
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    std::io::ErrorKind::Interrupted
+                        | std::io::ErrorKind::ConnectionAborted
+                        | std::io::ErrorKind::ConnectionReset
+                        | std::io::ErrorKind::NotConnected
+                        | std::io::ErrorKind::BrokenPipe
+                ) => {}
+            result => panic!("unexpected replacement socket read result: {result:?}"),
+        }
     }
 
     #[test]

--- a/questdb-rs/src/ingress/sender/qwp_ws_driver.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws_driver.rs
@@ -5802,34 +5802,38 @@ mod tests {
         transport
             .restart_connection(ReconnectReason::Disconnect)
             .unwrap();
-        let mut server_streams = server.join().unwrap();
+        let _server_streams = server.join().unwrap();
 
-        let (read_started_tx, read_started_rx) = mpsc::channel();
-        let (read_result_tx, read_result_rx) = mpsc::channel();
-        let reader = thread::spawn(move || {
-            read_started_tx.send(()).unwrap();
-            let mut byte = [0u8; 1];
-            read_result_tx
-                .send(transport.stream.read(&mut byte))
-                .unwrap();
-        });
-        read_started_rx
-            .recv_timeout(Duration::from_secs(5))
+        // A short read timeout plus a retry loop instead of one indefinitely
+        // blocking read: on Windows the gate's CancelIoEx only cancels a recv
+        // already in flight, and Winsock shutdown() does not wake one entered
+        // afterwards, so a single read can straddle the shutdown and miss
+        // both wake-ups. Retrying sidesteps the race: once the gate has shut
+        // the replacement socket down, the next read attempt fails
+        // immediately. A missing reconnect registration still fails the test,
+        // because the gate never touches this socket and every attempt times
+        // out until the deadline.
+        transport
+            .stream
+            .set_timeouts(Some(Duration::from_millis(100)), None)
             .unwrap();
+        let reader = thread::spawn(move || {
+            let deadline = std::time::Instant::now() + Duration::from_secs(10);
+            let mut byte = [0u8; 1];
+            loop {
+                match transport.stream.read(&mut byte) {
+                    Err(err)
+                        if matches!(
+                            err.kind(),
+                            std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+                        ) && std::time::Instant::now() < deadline => {}
+                    result => return result,
+                }
+            }
+        });
         traffic_gate.shutdown().unwrap();
 
-        let result = match read_result_rx.recv_timeout(Duration::from_secs(2)) {
-            Ok(result) => result,
-            Err(err) => {
-                // A missing reconnect registration leaves the replacement read
-                // untouched. Close its peer so the failed test can still join.
-                server_streams.pop();
-                reader.join().unwrap();
-                panic!("replacement socket read was not interrupted: {err}");
-            }
-        };
-        reader.join().unwrap();
-        match result {
+        match reader.join().unwrap() {
             Ok(0) => {}
             Err(err)
                 if matches!(
@@ -5840,7 +5844,11 @@ mod tests {
                         | std::io::ErrorKind::NotConnected
                         | std::io::ErrorKind::BrokenPipe
                 ) => {}
-            result => panic!("unexpected replacement socket read result: {result:?}"),
+            // CancelIoEx interrupts an in-flight recv as WSAEINTR (10004) and
+            // a recv issued after Winsock shutdown() fails with WSAESHUTDOWN
+            // (10058); neither maps to a stable `ErrorKind`.
+            Err(err) if matches!(err.raw_os_error(), Some(10004) | Some(10058)) => {}
+            result => panic!("replacement socket read was not interrupted: {result:?}"),
         }
     }
 

--- a/questdb-rs/src/ingress/sender/qwp_ws_driver.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws_driver.rs
@@ -9205,6 +9205,10 @@ mod tests {
 
     #[test]
     fn poison_dwell_driver_holds_terminal_until_window_elapses() {
+        // The 2s window buys stall headroom: the pre-sleep asserts require
+        // the window not to elapse before the second drive, and a scheduler
+        // stall of that size between adjacent statements does not happen. A
+        // shorter window flaked on loaded CI machines.
         let mut driver = QwpWsCoreTestHarness::from_queue_with_rejection_limit_and_window(
             memory_queue(options(8, 1024)),
             FakeOrderedServer::scripted([
@@ -9213,7 +9217,7 @@ mod tests {
                 FakeSendResult::RejectWire { wire_seq: 2 },
             ]),
             2,
-            Duration::from_millis(200),
+            Duration::from_secs(2),
         );
         let receipt = driver.try_submit(b"payload").unwrap();
 
@@ -9234,7 +9238,7 @@ mod tests {
             QwpReceiptStatus::Published { fsn: 0 }
         );
 
-        std::thread::sleep(Duration::from_millis(250));
+        std::thread::sleep(Duration::from_millis(2300));
         assert_eq!(driver.drive_once().unwrap(), DriveOutcome::Terminal);
         assert_eq!(
             driver.receipt_status(receipt),

--- a/questdb-rs/src/tests/qwp_sender_pool.rs
+++ b/questdb-rs/src/tests/qwp_sender_pool.rs
@@ -826,8 +826,10 @@ fn at_cap_borrow_waits_for_a_return_within_acquire_timeout() {
     let held = db.borrow_sender().expect("first borrow fills the cap");
 
     let db2 = std::sync::Arc::clone(&db);
+    // Taken on this thread, before the spawn: a slow spawn may then only
+    // inflate the measured wait, never shrink it under the 100ms floor.
+    let start = std::time::Instant::now();
     let waiter = std::thread::spawn(move || {
-        let start = std::time::Instant::now();
         let borrowed = db2.borrow_sender();
         (start.elapsed(), borrowed.is_ok())
     });
@@ -5285,15 +5287,37 @@ fn manual_reap_closes_idle_buffer_senders() {
     drop(b2);
     assert_eq!(db.free_count(), 2);
 
-    // Reap before the idle timeout — nothing closed.
-    assert_eq!(db.reap_idle(), 0);
-    assert_eq!(db.free_count(), 2);
-
     // Past the timeout: reap the excess sender while preserving `sender_pool_min=1`.
+    // (The pre-timeout "reap closes nothing" half is covered deterministically
+    // by `manual_reap_ignores_senders_below_idle_timeout`.)
     thread::sleep(Duration::from_millis(120));
     let closed = db.reap_idle();
     assert_eq!(closed, 1, "the excess idle Buffer sender must be reaped");
     assert_eq!(db.free_count(), 1, "the warm minimum must remain");
+    drop(db);
+}
+
+/// Pre-timeout half of the manual-reap contract, kept separate so it stays
+/// deterministic: with the default 60s idle timeout nothing can age out
+/// mid-test, so `reap_idle` must close nothing no matter how slowly the test
+/// is scheduled. The post-timeout halves live in `manual_reap_closes_*`.
+#[test]
+fn manual_reap_ignores_senders_below_idle_timeout() {
+    let server = MockServer::spawn_acking(8);
+    let db = QuestDb::connect(&conf_for(
+        server.port(),
+        "sender_pool_min=1;sender_pool_max=3;pool_reap=manual;",
+    ))
+    .unwrap();
+
+    let b1 = db.borrow_sender().expect("b1");
+    let b2 = db.borrow_sender().expect("b2 (grow)");
+    drop(b1);
+    drop(b2);
+    assert_eq!(db.free_count(), 2);
+
+    assert_eq!(db.reap_idle(), 0);
+    assert_eq!(db.free_count(), 2);
     drop(db);
 }
 
@@ -5627,12 +5651,9 @@ fn manual_reap_closes_excess_idle_connections() {
     drop(b3);
     assert_eq!(db.free_count(), 3);
 
-    // Reap before the idle timeout — nothing should be closed.
-    let immediate = db.reap_idle();
-    assert_eq!(immediate, 0);
-    assert_eq!(db.free_count(), 3);
-
     // Wait past the idle timeout, then reap. Must keep `pool_size` warm.
+    // (Pre-timeout behavior is covered by
+    // `manual_reap_ignores_senders_below_idle_timeout`.)
     thread::sleep(Duration::from_millis(120));
     let closed = db.reap_idle();
     assert_eq!(closed, 2, "should reap the two excess-over-pool_size slots");
@@ -7939,12 +7960,9 @@ mod reader_pool {
         drop(b2);
         assert_eq!(db.reader_free_count(), 2);
 
-        // Reap before the idle timeout — nothing closed.
-        let _ = db.reap_idle();
-        assert_eq!(db.reader_free_count(), 2);
-
         // Past the timeout: with `query_pool_min=0` there is no warm floor,
-        // so every idle reader is drained.
+        // so every idle reader is drained. (Pre-timeout behavior is covered
+        // by `manual_reap_ignores_readers_below_idle_timeout`.)
         thread::sleep(Duration::from_millis(120));
         let _ = db.reap_idle();
         assert_eq!(
@@ -7952,6 +7970,29 @@ mod reader_pool {
             0,
             "idle readers past the timeout must be reaped"
         );
+        drop(db);
+    }
+
+    /// Pre-timeout half of the reader manual-reap contract; see
+    /// `manual_reap_ignores_senders_below_idle_timeout` for why it is kept
+    /// separate (default 60s idle timeout keeps it deterministic).
+    #[test]
+    fn manual_reap_ignores_readers_below_idle_timeout() {
+        let server = ReaderMockServer::spawn(8);
+        let db = QuestDb::connect(&conf_for(
+            server.port(),
+            "query_pool_min=0;query_pool_max=3;pool_reap=manual;",
+        ))
+        .unwrap();
+
+        let b1 = db.borrow_reader().expect("b1");
+        let b2 = db.borrow_reader().expect("b2 (grow)");
+        drop(b1);
+        drop(b2);
+        assert_eq!(db.reader_free_count(), 2);
+
+        assert_eq!(db.reap_idle(), 0);
+        assert_eq!(db.reader_free_count(), 2);
         drop(db);
     }
 

--- a/questdb-rs/src/tests/qwp_sender_pool.rs
+++ b/questdb-rs/src/tests/qwp_sender_pool.rs
@@ -3428,7 +3428,31 @@ fn check_store_and_forward_append_timeout_rolls_back_symbols_and_keeps_chunk(ext
     let ts3 = [3_i64];
     let mut third = Chunk::new("trades");
     append_one_symbol_row(&mut third, b"gamma", &ts3);
-    sender.flush(&mut third).unwrap();
+    // `wait(Ok)` confirms server acceptance, not completion of asynchronous
+    // storage maintenance. In file mode the acknowledged segment still needs
+    // its watermark/manifest barriers and trim before byte capacity is
+    // reusable. Retry only that expected backpressure timeout; every failed
+    // attempt must preserve and roll back "gamma" just like "bravo" above.
+    let trim_deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        match sender.flush(&mut third) {
+            Ok(()) => break,
+            Err(err)
+                if err.code() == ErrorCode::SocketError
+                    && err.msg().contains("Store-and-Forward append timed out") =>
+            {
+                assert!(
+                    !third.is_empty(),
+                    "timed-out SFA retry must keep the chunk retryable"
+                );
+                assert!(
+                    Instant::now() < trim_deadline,
+                    "ACKed SFA segments were not trimmed within 30 seconds"
+                );
+            }
+            Err(err) => panic!("unexpected flush failure after ACK release: {err}"),
+        }
+    }
     sender.wait(AckLevel::Ok, Duration::from_secs(30)).unwrap();
     // The ring-filling flushes above put their own frames on the wire; the
     // "gamma" frame is the last one, since every earlier publish has been

--- a/questdb-rs/src/tests/qwp_ws.rs
+++ b/questdb-rs/src/tests/qwp_ws.rs
@@ -4661,7 +4661,11 @@ fn qwp_ws_server_error_response_is_surfaced() {
             b"bad column",
         )
         .unwrap();
-        thread::sleep(Duration::from_millis(50));
+        // Hold the socket open until the client closes it, so a late second
+        // flush cannot race a server-side teardown (the 5s read timeout
+        // above bounds the wait).
+        let mut sink = [0u8; 256];
+        while matches!(stream.read(&mut sink), Ok(n) if n > 0) {}
     });
 
     let mut sender = SenderBuilder::new(Protocol::Ws, "127.0.0.1", port)
@@ -4683,7 +4687,20 @@ fn qwp_ws_server_error_response_is_surfaced() {
     assert!(buf.is_empty());
     assert_eq!(first_fsn, 0);
 
-    thread::sleep(Duration::from_millis(100));
+    // Bounded pump instead of a sleep: the runner thread ingests the error
+    // response and terminalizes the publication in the background, but on a
+    // slow machine a fixed sleep can lose that race and the second flush
+    // then observes a healthy connection. `qwp_ws_terminal_error` probes the
+    // terminal diagnostic without consuming it, so the polls below leave
+    // every later assertion (handler callback, `poll_qwp_ws_error`) intact.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while sender.qwp_ws_terminal_error().unwrap().is_none() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "server rejection was not applied within 5s"
+        );
+        thread::sleep(Duration::from_millis(1));
+    }
 
     buf.table("trades")
         .unwrap()

--- a/questdb-rs/src/tests/qwp_ws.rs
+++ b/questdb-rs/src/tests/qwp_ws.rs
@@ -2359,7 +2359,6 @@ fn qwp_ws_durable_ack_completion_waits_for_durable_confirmation_in_all_progress_
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         let (allow_ack_tx, allow_ack_rx) = mpsc::channel();
-        let (ping_tx, ping_rx) = mpsc::channel();
         let (done_tx, done_rx) = mpsc::channel();
 
         let server = thread::spawn(move || {
@@ -2388,15 +2387,9 @@ fn qwp_ws_durable_ack_completion_waits_for_durable_confirmation_in_all_progress_
             .unwrap();
 
             allow_ack_rx.recv_timeout(Duration::from_secs(5)).unwrap();
-            loop {
-                let (_, opcode, payload) = read_frame(&mut stream).unwrap();
-                if opcode == 0x9 {
-                    write_server_frame(&mut stream, 0xA, &payload, false).unwrap();
-                    write_qwp_durable_ack_response(&mut stream, &[("trades", 10)]).unwrap();
-                    ping_tx.send(payload).unwrap();
-                    break;
-                }
-            }
+            // Keep this test about durable completion. Keepalive scheduling is
+            // covered independently by the transport driver tests.
+            write_qwp_durable_ack_response(&mut stream, &[("trades", 10)]).unwrap();
 
             let _ = done_rx.recv_timeout(Duration::from_secs(5));
         });
@@ -2404,8 +2397,7 @@ fn qwp_ws_durable_ack_completion_waits_for_durable_confirmation_in_all_progress_
         let conf = format!(
             "ws::addr=127.0.0.1:{port};\
              qwp_ws_progress={};\
-             request_durable_ack=on;\
-             durable_ack_keepalive_interval_millis=1;",
+             request_durable_ack=on;",
             progress.name()
         );
         let mut sender = SenderBuilder::from_conf(conf).unwrap().build().unwrap();
@@ -2448,7 +2440,6 @@ fn qwp_ws_durable_ack_completion_waits_for_durable_confirmation_in_all_progress_
         sender
             .wait(crate::ingress::AckLevel::Durable, Duration::from_secs(5))
             .unwrap_or_else(|e| panic!("mode={}: {e}", progress.name()));
-        assert_eq!(ping_rx.recv_timeout(Duration::from_secs(5)).unwrap(), b"");
         assert_eq!(sender.acked_fsn().unwrap(), Some(fsn));
         done_tx.send(()).unwrap();
         server.join().unwrap();
@@ -2756,64 +2747,6 @@ fn qwp_ws_drop_interrupts_blocked_background_send() {
     assert!(
         elapsed < Duration::from_secs(1),
         "drop waited for the socket write timeout: {elapsed:?}"
-    );
-}
-
-#[test]
-fn qwp_ws_drop_interrupts_blocked_send_after_reconnect() {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let port = listener.local_addr().unwrap().port();
-    let (send_started_tx, send_started_rx) = mpsc::channel();
-    let (release_tx, release_rx) = mpsc::channel();
-
-    let server = thread::spawn(move || {
-        let (mut first, _) = listener.accept().unwrap();
-        upgrade_mock_stream(&mut first);
-        drop(first);
-
-        let (mut second, _) = listener.accept().unwrap();
-        socket2::SockRef::from(&second)
-            .set_recv_buffer_size(4096)
-            .unwrap();
-        upgrade_mock_stream(&mut second);
-        second
-            .set_read_timeout(Some(Duration::from_secs(5)))
-            .unwrap();
-        let mut byte = [0u8; 1];
-        second.peek(&mut byte).unwrap();
-        send_started_tx.send(()).unwrap();
-        let _ = release_rx.recv_timeout(Duration::from_secs(10));
-    });
-
-    let conf = format!(
-        "ws::addr=127.0.0.1:{port};\
-         close_flush_timeout_millis=-1;\
-         sf_max_segment_bytes=16777216;"
-    );
-    let mut sender = SenderBuilder::from_conf(&conf).unwrap().build().unwrap();
-    let value = "x".repeat(8 * 1024 * 1024);
-    let mut buf = sender.new_buffer();
-    buf.table("trades")
-        .unwrap()
-        .column_str("payload", value.as_str())
-        .unwrap()
-        .at_now()
-        .unwrap();
-    sender.flush(&mut buf).unwrap();
-
-    send_started_rx
-        .recv_timeout(Duration::from_secs(5))
-        .unwrap();
-
-    let started = Instant::now();
-    drop(sender);
-    let elapsed = started.elapsed();
-    let _ = release_tx.send(());
-    server.join().unwrap();
-
-    assert!(
-        elapsed < Duration::from_secs(1),
-        "drop waited on the replacement socket after reconnect: {elapsed:?}"
     );
 }
 

--- a/questdb-rs/src/tests/qwp_ws.rs
+++ b/questdb-rs/src/tests/qwp_ws.rs
@@ -685,22 +685,30 @@ fn spawn_recycling_server(
                     match read_frame(&mut stream) {
                         Ok((_fin, 0x2, _payload)) => {
                             connections += 1;
-                            shared_count.store(connections, Ordering::Release);
+                            // The client may tear down at any moment once the
+                            // caller has seen enough connections, so a failed
+                            // response write is a legitimate outcome here,
+                            // like the reset/EOF kinds tolerated on the read
+                            // side below.
                             match action {
                                 RecycleServerAction::WriteError => {
-                                    write_qwp_error_response(
+                                    let _ = write_qwp_error_response(
                                         &mut stream,
                                         QWP_STATUS_WRITE_ERROR,
                                         FIRST_WIRE_SEQUENCE,
                                         b"retry later",
-                                    )
-                                    .unwrap();
+                                    );
                                 }
                                 RecycleServerAction::NonOrderlyClose => {
-                                    write_server_close_frame(&mut stream, 1002, "retry later")
-                                        .unwrap();
+                                    let _ =
+                                        write_server_close_frame(&mut stream, 1002, "retry later");
                                 }
                             }
+                            // Published only after the response write: the
+                            // caller drops the sender once it observes the
+                            // count, and publishing earlier would let that
+                            // teardown race the write above.
+                            shared_count.store(connections, Ordering::Release);
                         }
                         Ok((_fin, _opcode, _payload)) => {}
                         Err(err)

--- a/questdb-rs/src/tests/qwp_ws.rs
+++ b/questdb-rs/src/tests/qwp_ws.rs
@@ -650,15 +650,23 @@ fn write_mock_qwp_response(
 fn spawn_recycling_server(
     action: RecycleServerAction,
     run_for: Duration,
-) -> (u16, thread::JoinHandle<usize>) {
+) -> (u16, thread::JoinHandle<usize>, Arc<AtomicUsize>) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     listener.set_nonblocking(true).unwrap();
     let port = listener.local_addr().unwrap().port();
 
+    let connection_count = Arc::new(AtomicUsize::new(0));
+    let shared_count = Arc::clone(&connection_count);
     let handle = thread::spawn(move || {
         let deadline = Instant::now() + run_for;
+        // A stalled client may not manage its second connection inside
+        // `run_for`; keep serving (bounded) until it does, so the callers'
+        // non-vacuity lower bound cannot flip on a slow machine. A longer
+        // quiet window only lowers the connection rate, so the pacing upper
+        // bound stays in the safe direction.
+        let hard_deadline = Instant::now() + Duration::from_secs(10);
         let mut connections = 0usize;
-        while Instant::now() < deadline {
+        while Instant::now() < deadline || (connections < 2 && Instant::now() < hard_deadline) {
             match listener.accept() {
                 Ok((mut stream, _)) => {
                     // The listener is non-blocking so the accept loop can honor
@@ -677,6 +685,7 @@ fn spawn_recycling_server(
                     match read_frame(&mut stream) {
                         Ok((_fin, 0x2, _payload)) => {
                             connections += 1;
+                            shared_count.store(connections, Ordering::Release);
                             match action {
                                 RecycleServerAction::WriteError => {
                                     write_qwp_error_response(
@@ -714,7 +723,7 @@ fn spawn_recycling_server(
         connections
     });
 
-    (port, handle)
+    (port, handle, connection_count)
 }
 
 fn spawn_stalled_after_first_frame_server() -> (u16, mpsc::Receiver<Vec<u8>>, mpsc::Sender<()>) {
@@ -783,7 +792,15 @@ fn spawn_delayed_durable_ack_server() -> (
 
         durable_rx.recv_timeout(Duration::from_secs(5)).unwrap();
         write_qwp_durable_ack_response(&mut stream, &[("trades", 10)]).unwrap();
-        thread::sleep(Duration::from_millis(50));
+        // Hold the socket open until the client has consumed the durable ack
+        // and closed: dropping after a fixed sleep can turn into an RST that
+        // discards the still-buffered ack on a slow client (keepalive pings
+        // land after our last read). The read timeout bounds the hold.
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let mut sink = [0u8; 256];
+        while matches!(stream.read(&mut sink), Ok(n) if n > 0) {}
     });
 
     (port, frame_rx, ok_tx, durable_tx)
@@ -1028,7 +1045,14 @@ fn spawn_upgrade_only_server() -> u16 {
     thread::spawn(move || {
         let (mut stream, _) = listener.accept().unwrap();
         perform_server_upgrade(&mut stream).unwrap();
-        thread::sleep(Duration::from_millis(50));
+        // Never respond, but stay alive until the client closes: dying after
+        // a fixed sleep turns a slow client's later flush/close into an
+        // RST-surfacing path instead of the silent-server path under test.
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let mut sink = [0u8; 256];
+        while matches!(stream.read(&mut sink), Ok(n) if n > 0) {}
     });
 
     port
@@ -2665,7 +2689,13 @@ fn qwp_ws_close_flush_timeout_minus_one_skips_close_drain_wait() {
         upgrade_mock_stream(&mut stream);
         let (_fin, _opcode, payload) = read_frame(&mut stream).unwrap();
         frame_tx.send(payload).unwrap();
-        thread::sleep(Duration::from_millis(500));
+        // Stay silent but alive until the client closes, so a fast
+        // `close_drain` is provably "skipped the wait" and not "server went
+        // away". If close regresses into waiting for the un-acked frame, the
+        // 5s read timeout above ends the hold and unblocks it via EOF, which
+        // the elapsed assertion below then catches.
+        let mut sink = [0u8; 256];
+        while matches!(stream.read(&mut sink), Ok(n) if n > 0) {}
     });
 
     let conf = format!("ws::addr=127.0.0.1:{port};close_flush_timeout_millis=-1;");
@@ -2685,8 +2715,11 @@ fn qwp_ws_close_flush_timeout_minus_one_skips_close_drain_wait() {
 
     let started = Instant::now();
     sender.close_drain().unwrap();
+    // 2s is far above any scheduler stall but well below the ~5s a close that
+    // regressed into waiting for the un-acked frame would take (see the
+    // server hold above).
     assert!(
-        started.elapsed() < Duration::from_millis(250),
+        started.elapsed() < Duration::from_secs(2),
         "close_drain waited despite close_flush_timeout_millis=-1"
     );
     drop(sender);
@@ -5004,7 +5037,7 @@ fn qwp_ws_orderly_close_reconnects_without_poison_strike() {
 
 fn run_paced_recycle_scenario(action: RecycleServerAction) -> usize {
     let run_for = Duration::from_millis(900);
-    let (port, handle) = spawn_recycling_server(action, run_for);
+    let (port, handle, connection_count) = spawn_recycling_server(action, run_for);
     let mut sender = SenderBuilder::new(Protocol::Ws, "127.0.0.1", port)
         .max_frame_rejections(1000)
         .unwrap()
@@ -5028,6 +5061,13 @@ fn run_paced_recycle_scenario(action: RecycleServerAction) -> usize {
     sender.flush_and_get_fsn(&mut buf).unwrap().unwrap();
 
     thread::sleep(run_for);
+    // Keep the sender alive until the reconnect that makes the callers'
+    // lower bound meaningful has happened; bounded by the server's own 10s
+    // hard deadline, after which the count assert fails loudly.
+    let wait_deadline = Instant::now() + Duration::from_secs(10);
+    while connection_count.load(Ordering::Acquire) < 2 && Instant::now() < wait_deadline {
+        thread::sleep(Duration::from_millis(10));
+    }
     drop(sender);
     handle.join().unwrap()
 }
@@ -6917,7 +6957,13 @@ fn spawn_max_batch_size_upgrade_only_server(max_batch_size: Option<usize>) -> u1
     thread::spawn(move || {
         let (mut stream, _) = listener.accept().unwrap();
         upgrade_mock_stream_with_max_batch_size(&mut stream, max_batch_size);
-        thread::sleep(Duration::from_millis(200));
+        // Silent but alive until the client closes; see
+        // `spawn_upgrade_only_server`.
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let mut sink = [0u8; 256];
+        while matches!(stream.read(&mut sink), Ok(n) if n > 0) {}
     });
     port
 }


### PR DESCRIPTION
The C/C++ format check never failed: `clang-format --dry-run` without `-Werror` always exits 0, and CI's `apt install clang-format` failed silently, so an unpinned version checked a stale file list.

- `ci/format_cpp.py`: add `--Werror` in check mode; cover the QWP headers, tests and examples (vendored `doctest.h` excluded).
- CI: `pipx install clang-format==21.1.8`, version asserted — comment reflow differs across clang-format versions.
- Reformat the 949 accumulated violations (whitespace and comment reflow only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified C/C++ formatting requirements and sender completion, retry, queue, and symbol-dictionary behavior.
  * Documented the required formatting-tool version and known comment reflow limitations.

* **Chores**
  * Standardized automated formatting checks on clang-format 21.1.8.
  * Reformatted project headers, tests, and examples without changing behavior or public APIs.

* **Tests**
  * Improved durable acknowledgment and WebSocket integration coverage.
  * Made asynchronous sender and connection-lifecycle tests more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->