### PR TITLE
fix(ingress): publish the dispatcher close under the inbox mutex

### DIFF
--- a/questdb-rs-ffi/src/lib.rs
+++ b/questdb-rs-ffi/src/lib.rs
@@ -5368,9 +5368,9 @@ mod tests {
         padded.extend_from_slice(&bit_len.to_be_bytes());
 
         let mut words = [0u32; 80];
-        for chunk in padded.chunks_exact(64) {
-            for (idx, word) in chunk.chunks_exact(4).enumerate() {
-                words[idx] = u32::from_be_bytes([word[0], word[1], word[2], word[3]]);
+        for chunk in padded.as_chunks::<64>().0 {
+            for (idx, word) in chunk.as_chunks::<4>().0.iter().enumerate() {
+                words[idx] = u32::from_be_bytes(*word);
             }
             for idx in 16..80 {
                 words[idx] = (words[idx - 3] ^ words[idx - 8] ^ words[idx - 14] ^ words[idx - 16])

--- a/questdb-rs/src/egress/decoder.rs
+++ b/questdb-rs/src/egress/decoder.rs
@@ -1138,7 +1138,7 @@ fn reverse_uuid_rows(buf: ColumnBuffer) -> ColumnBuffer {
         Ok(values) => values,
         Err(shared) => BytesMut::from(&shared[..]),
     };
-    for row in values.chunks_exact_mut(16) {
+    for row in values.as_chunks_mut::<16>().0 {
         row.reverse();
     }
     ColumnBuffer {
@@ -1743,13 +1743,13 @@ fn count_nulls(bitmap: &[u8], row_count: usize) -> usize {
     // bit-scan to find the *position* of a null), switch to
     // `from_le_bytes` — positions are endian-sensitive.
     let body = &bitmap[..full_bytes];
-    let mut chunks = body.chunks_exact(8);
+    let (words, tail) = body.as_chunks::<8>();
     let mut nulls: usize = 0;
-    for c in chunks.by_ref() {
-        let w = u64::from_ne_bytes(c.try_into().unwrap());
+    for c in words {
+        let w = u64::from_ne_bytes(*c);
         nulls += w.count_ones() as usize;
     }
-    for b in chunks.remainder() {
+    for b in tail {
         nulls += b.count_ones() as usize;
     }
     if tail_bits != 0 {
@@ -2309,7 +2309,7 @@ mod tests {
         });
 
         let mut expected = input;
-        for row in expected.chunks_exact_mut(16) {
+        for row in expected.as_chunks_mut::<16>().0 {
             row.reverse();
         }
         assert_eq!(reversed.values, expected);
@@ -2332,7 +2332,7 @@ mod tests {
         });
 
         let mut expected = input.clone();
-        for row in expected.chunks_exact_mut(16) {
+        for row in expected.as_chunks_mut::<16>().0 {
             row.reverse();
         }
         assert_eq!(reversed.values, expected);

--- a/questdb-rs/src/ingress/column_sender/arrow_batch.rs
+++ b/questdb-rs/src/ingress/column_sender/arrow_batch.rs
@@ -925,9 +925,14 @@ fn write_qwp_bitmap_from_arrow(out: &mut Vec<u8>, nulls: &NullBuffer) -> Result<
         let word_bytes = (full_bytes / 8) * 8;
         let (src_words, src_rem) = src_slice.split_at(word_bytes);
         let (dst_words, dst_rem) = dst_slice.split_at_mut(word_bytes);
-        for (dchunk, schunk) in dst_words.chunks_exact_mut(8).zip(src_words.chunks_exact(8)) {
-            let w = u64::from_ne_bytes(schunk.try_into().unwrap());
-            dchunk.copy_from_slice(&(!w).to_ne_bytes());
+        for (dchunk, schunk) in dst_words
+            .as_chunks_mut::<8>()
+            .0
+            .iter_mut()
+            .zip(src_words.as_chunks::<8>().0)
+        {
+            let w = u64::from_ne_bytes(*schunk);
+            *dchunk = (!w).to_ne_bytes();
         }
         for (d, &s) in dst_rem.iter_mut().zip(src_rem) {
             *d = !s;
@@ -1193,7 +1198,7 @@ fn write_uuid_be_payload(out: &mut Vec<u8>, arr: &FixedSizeBinaryArray) -> Resul
             // Bulk path: slice `value_data()` once, starting at the array's
             // own offset, instead of a bounds-checked `value(row)` per row.
             let start = arr.offset() * 16;
-            for row in arr.value_data()[start..start + bytes].chunks_exact(16) {
+            for row in arr.value_data()[start..start + bytes].as_chunks::<16>().0 {
                 out.extend_from_slice(&reverse_uuid_bytes(row));
             }
         }

--- a/questdb-rs/src/ingress/column_sender/conn.rs
+++ b/questdb-rs/src/ingress/column_sender/conn.rs
@@ -1161,24 +1161,18 @@ fn write_ws_header(out: &mut [u8], payload_len: usize, mask_key: [u8; 4]) {
     const BINARY_OPCODE: u8 = 0x2;
     const MASK_BIT: u8 = 0x80;
     out[0] = FIN_BIT | BINARY_OPCODE;
-    let len_bytes;
-    let mask_offset;
-    if payload_len <= 125 {
+    let mask_offset = if payload_len <= 125 {
         out[1] = MASK_BIT | (payload_len as u8);
-        mask_offset = 2;
-        len_bytes = 0;
+        2
     } else if payload_len <= 0xFFFF {
         out[1] = MASK_BIT | 126;
         out[2..4].copy_from_slice(&(payload_len as u16).to_be_bytes());
-        mask_offset = 4;
-        len_bytes = 2;
+        4
     } else {
         out[1] = MASK_BIT | 127;
         out[2..10].copy_from_slice(&(payload_len as u64).to_be_bytes());
-        mask_offset = 10;
-        len_bytes = 8;
-    }
-    let _ = len_bytes;
+        10
+    };
     out[mask_offset..mask_offset + 4].copy_from_slice(&mask_key);
 }
 

--- a/questdb-rs/src/ingress/column_sender/numpy_wire.rs
+++ b/questdb-rs/src/ingress/column_sender/numpy_wire.rs
@@ -2166,7 +2166,7 @@ mod tests {
         // column body subsequence appears exactly once.
         let mut body: Vec<u8> = Vec::new();
         body.push(0u8); // null_flag = 0 (no validity)
-        for row_chunk in rows.chunks_exact(3) {
+        for row_chunk in rows.as_chunks::<3>().0 {
             body.push(1u8); // ndim
             body.extend_from_slice(&3u32.to_le_bytes()); // dim
             for &v in row_chunk {

--- a/questdb-rs/src/ingress/conn_events.rs
+++ b/questdb-rs/src/ingress/conn_events.rs
@@ -131,6 +131,10 @@ struct DispatcherInner<T> {
     closed: AtomicBool,
     dropped: AtomicU64,
     delivered: AtomicU64,
+    /// Set by the worker as it enters `dispatch_loop`, so a test can tell
+    /// a running worker from one that never spawned.
+    #[cfg(test)]
+    worker_started: (Mutex<bool>, Condvar),
 }
 
 impl<T> DispatcherInner<T> {
@@ -139,6 +143,38 @@ impl<T> DispatcherInner<T> {
             Ok(inbox) => inbox,
             Err(poisoned) => poisoned.into_inner(),
         }
+    }
+
+    #[cfg(test)]
+    fn signal_worker_start(&self) {
+        let (started, signal) = &self.worker_started;
+        let mut started = match started.lock() {
+            Ok(started) => started,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *started = true;
+        signal.notify_all();
+    }
+
+    #[cfg(test)]
+    fn wait_for_worker_start(&self, timeout: std::time::Duration) -> bool {
+        let (started, signal) = &self.worker_started;
+        let deadline = std::time::Instant::now() + timeout;
+        let mut started = match started.lock() {
+            Ok(started) => started,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        while !*started {
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                return false;
+            }
+            started = match signal.wait_timeout(started, deadline - now) {
+                Ok((started, _)) => started,
+                Err(poisoned) => poisoned.into_inner().0,
+            };
+        }
+        true
     }
 }
 
@@ -185,6 +221,8 @@ impl<T: std::fmt::Debug + Send + 'static> EventDispatcher<T> {
             closed: AtomicBool::new(false),
             dropped: AtomicU64::new(0),
             delivered: AtomicU64::new(0),
+            #[cfg(test)]
+            worker_started: (Mutex::new(false), Condvar::new()),
         });
         let thread_inner = Arc::clone(&inner);
         let thread = match std::thread::Builder::new()
@@ -231,6 +269,15 @@ impl<T: std::fmt::Debug + Send + 'static> EventDispatcher<T> {
         self.inner.delivered.load(Ordering::Relaxed)
     }
 
+    /// Test-only: block until the worker thread has entered its dispatch
+    /// loop, returning `false` on timeout or when the spawn failed. Lets a
+    /// test that exercises the close/join path prove there was a worker to
+    /// join, rather than passing because no thread was ever created.
+    #[cfg(test)]
+    pub(crate) fn wait_for_worker_start(&self, timeout: std::time::Duration) -> bool {
+        self.thread.is_some() && self.inner.wait_for_worker_start(timeout)
+    }
+
     /// Drop the dispatcher (joining its thread, so any in-flight listener
     /// invocation completes) and return the final `(delivered, dropped)`.
     pub(crate) fn shutdown(self) -> (u64, u64) {
@@ -275,6 +322,8 @@ impl<T> Drop for EventDispatcher<T> {
 }
 
 fn dispatch_loop<T: std::fmt::Debug>(inner: Arc<DispatcherInner<T>>) {
+    #[cfg(test)]
+    inner.signal_worker_start();
     loop {
         let event = {
             let mut inbox = inner.lock_inbox();

--- a/questdb-rs/src/ingress/conn_events.rs
+++ b/questdb-rs/src/ingress/conn_events.rs
@@ -245,8 +245,18 @@ impl<T: std::fmt::Debug + Send + 'static> EventDispatcher<T> {
 
 impl<T> Drop for EventDispatcher<T> {
     fn drop(&mut self) {
-        self.inner.closed.store(true, Ordering::Release);
-        self.inner.available.notify_one();
+        // The inbox mutex is required for the wakeup to reach the
+        // dispatcher: `dispatch_loop` reads `closed` and parks while
+        // holding that same mutex, so publishing the close under it means
+        // the loop either sees the store before parking or is already
+        // registered as a waiter when the notify lands. `offer` discards
+        // events once `closed` is set, so this notify is the last one the
+        // loop can ever receive and the join below depends on it.
+        {
+            let _inbox = self.inner.lock_inbox();
+            self.inner.closed.store(true, Ordering::Release);
+            self.inner.available.notify_one();
+        }
         if let Some(handle) = self.thread.take()
             && handle.thread().id() != std::thread::current().id()
         {
@@ -606,6 +616,35 @@ mod tests {
         drop(dispatcher);
         wait_for(|| Arc::strong_count(&inner) == 1);
         assert!(inner.closed.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn drop_joins_a_dispatcher_thread_that_never_saw_an_event() {
+        // A dispatcher dropped right after construction races its own
+        // thread's first trip through the inbox lock: the thread reads
+        // `closed`, finds the inbox empty and parks. The close is
+        // published under that mutex, so the park stays reachable and
+        // every drop joins. Run the cycle often enough to cover the
+        // window; a stalled join shows up as the recv timeout.
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            for round in 0..20_000u32 {
+                let dispatcher =
+                    ConnectionEventDispatcher::new(Arc::new(|_: &ConnectionEvent| {}), 4);
+                // Sweep the gap so drops land across the whole startup
+                // window, including the instant the thread holds the inbox
+                // lock and is about to park.
+                for _ in 0..(round % 400) {
+                    std::hint::spin_loop();
+                }
+                drop(dispatcher);
+            }
+            let _ = done_tx.send(());
+        });
+        assert!(
+            done_rx.recv_timeout(Duration::from_secs(60)).is_ok(),
+            "a dispatcher drop stalled joining its thread",
+        );
     }
 
     #[test]

--- a/questdb-rs/src/ingress/conn_events.rs
+++ b/questdb-rs/src/ingress/conn_events.rs
@@ -249,9 +249,18 @@ impl<T> Drop for EventDispatcher<T> {
         // dispatcher: `dispatch_loop` reads `closed` and parks while
         // holding that same mutex, so publishing the close under it means
         // the loop either sees the store before parking or is already
-        // registered as a waiter when the notify lands. `offer` discards
-        // events once `closed` is set, so this notify is the last one the
-        // loop can ever receive and the join below depends on it.
+        // registered as a waiter when the notify lands. The loop re-reads
+        // `closed` under the mutex before each park, so only this notify
+        // has to arrive; a surplus one is harmless.
+        //
+        // Keeping events from arriving after the close is what makes every
+        // offered event either delivered or counted in `dropped`, and that
+        // comes from the holders rather than from `offer`, whose `closed`
+        // check runs outside the inbox mutex and is not ordered against
+        // this store: `ConnectionEventSource::offer` and
+        // `RejectionEventSource::publish` hold their own dispatcher mutex
+        // across the whole `offer` call, and `close` takes that same mutex
+        // to remove the dispatcher.
         {
             let _inbox = self.inner.lock_inbox();
             self.inner.closed.store(true, Ordering::Release);
@@ -626,11 +635,30 @@ mod tests {
         // published under that mutex, so the park stays reachable and
         // every drop joins. Run the cycle often enough to cover the
         // window; a stalled join shows up as the recv timeout.
+        //
+        // Against a dispatcher that publishes the close without the inbox
+        // mutex the stall lands within the first few hundred rounds, so
+        // this count carries a wide margin over the window it sweeps.
+        //
+        // The cycle runs on its own thread and reports over a channel so a
+        // stalled join fails this test rather than hanging the suite:
+        // libtest joins the test's own thread, so the same loop written
+        // inline would block `cargo test` with no output at all.
+        const ROUNDS: u32 = 5_000;
         let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let completed = Arc::new(AtomicU64::new(0));
+        let completed_in_thread = Arc::clone(&completed);
         std::thread::spawn(move || {
-            for round in 0..20_000u32 {
+            for round in 0..ROUNDS {
                 let dispatcher =
                     ConnectionEventDispatcher::new(Arc::new(|_: &ConnectionEvent| {}), 4);
+                // A round covers the race only if the thread started:
+                // `named` logs and gives up on a spawn failure, which would
+                // leave every drop a no-op and pass this test vacuously.
+                assert!(
+                    dispatcher.thread.is_some(),
+                    "dispatcher thread failed to spawn"
+                );
                 // Sweep the gap so drops land across the whole startup
                 // window, including the instant the thread holds the inbox
                 // lock and is about to park.
@@ -638,13 +666,22 @@ mod tests {
                     std::hint::spin_loop();
                 }
                 drop(dispatcher);
+                completed_in_thread.store(u64::from(round + 1), Ordering::Relaxed);
             }
             let _ = done_tx.send(());
         });
-        assert!(
-            done_rx.recv_timeout(Duration::from_secs(60)).is_ok(),
-            "a dispatcher drop stalled joining its thread",
-        );
+        match done_rx.recv_timeout(Duration::from_secs(60)) {
+            Ok(()) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => panic!(
+                "only {} of {ROUNDS} drop/join cycles finished in 60s; a stalled \
+                 join reports a few hundred, an overloaded machine reports most \
+                 of them",
+                completed.load(Ordering::Relaxed),
+            ),
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("the drop/join worker panicked")
+            }
+        }
     }
 
     #[test]

--- a/questdb-rs/src/ingress/rejection_events.rs
+++ b/questdb-rs/src/ingress/rejection_events.rs
@@ -195,6 +195,49 @@ mod tests {
     }
 
     #[test]
+    fn close_joins_a_handler_dispatcher_that_never_saw_a_rejection() {
+        // The shape behind the reported hang: a pool closes with a handler
+        // installed and no rejection ever published, so the dispatcher
+        // thread is still on its first trip through the inbox lock. The
+        // close is published under that mutex, so every `close()` joins.
+        //
+        // Runs on its own thread and reports over a channel so a stalled
+        // join fails this test rather than hanging the suite.
+        const ROUNDS: u32 = 2_000;
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let completed = Arc::new(AtomicU64::new(0));
+        let completed_in_thread = Arc::clone(&completed);
+        std::thread::spawn(move || {
+            for round in 0..ROUNDS {
+                let source = RejectionEventSource::with_handler(
+                    QwpWsErrorHandler::new(|_: &QwpWsSenderError| {}),
+                    4,
+                );
+                // Sweep the gap so the close lands across the whole startup
+                // window, including the instant the thread holds the inbox
+                // lock and is about to park.
+                for _ in 0..(round % 400) {
+                    std::hint::spin_loop();
+                }
+                source.close();
+                completed_in_thread.store(u64::from(round + 1), Ordering::Relaxed);
+            }
+            let _ = done_tx.send(());
+        });
+        match done_rx.recv_timeout(Duration::from_secs(60)) {
+            Ok(()) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => panic!(
+                "only {} of {ROUNDS} close cycles finished in 60s; a stalled join \
+                 reports a few hundred, an overloaded machine reports most of them",
+                completed.load(Ordering::Relaxed),
+            ),
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("the close worker panicked")
+            }
+        }
+    }
+
+    #[test]
     fn logging_default_counts_deliveries() {
         let source = RejectionEventSource::logging_default();
         source.publish(rejection(1));

--- a/questdb-rs/src/ingress/rejection_events.rs
+++ b/questdb-rs/src/ingress/rejection_events.rs
@@ -119,6 +119,16 @@ impl RejectionEventSource {
             + live
     }
 
+    /// Test-only: block until the dispatcher's worker thread is running,
+    /// returning `false` on timeout, on a failed spawn, or when there is no
+    /// dispatcher at all.
+    #[cfg(test)]
+    pub(crate) fn wait_for_dispatcher_start(&self, timeout: std::time::Duration) -> bool {
+        self.lock_dispatcher()
+            .as_ref()
+            .is_some_and(|dispatcher| dispatcher.wait_for_worker_start(timeout))
+    }
+
     pub(crate) fn dropped(&self) -> u64 {
         let live = self
             .lock_dispatcher()
@@ -212,6 +222,13 @@ mod tests {
                 let source = RejectionEventSource::with_handler(
                     QwpWsErrorHandler::new(|_: &QwpWsSenderError| {}),
                     4,
+                );
+                // A failed spawn leaves nothing to join, which would make
+                // every close below trivially return; each round only
+                // exercises the join path once its worker is running.
+                assert!(
+                    source.wait_for_dispatcher_start(Duration::from_secs(10)),
+                    "round {round}: the dispatcher worker never started"
                 );
                 // Sweep the gap so the close lands across the whole startup
                 // window, including the instant the thread holds the inbox

--- a/questdb-rs/src/ingress/sender/qwp_ws_sfa_queue.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws_sfa_queue.rs
@@ -4066,7 +4066,9 @@ mod tests {
         assert_eq!(nibbles.len() % 2, 0, "hex fixture has odd length");
 
         nibbles
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| (pair[0] << 4) | pair[1])
             .collect()
     }

--- a/questdb-rs/src/ingress/sender/qwp_ws_sfa_segment.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws_sfa_segment.rs
@@ -1696,7 +1696,9 @@ mod tests {
         assert_eq!(nibbles.len() % 2, 0, "hex fixture has odd length");
 
         nibbles
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| (pair[0] << 4) | pair[1])
             .collect()
     }

--- a/questdb-rs/src/tests/qwp_sender_pool.rs
+++ b/questdb-rs/src/tests/qwp_sender_pool.rs
@@ -720,7 +720,9 @@ fn decode_test_hex(hex: &str) -> Vec<u8> {
         .collect();
     assert_eq!(compact.len() % 2, 0, "hex fixture must contain byte pairs");
     compact
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             let text = std::str::from_utf8(pair).unwrap();
             u8::from_str_radix(text, 16).unwrap()

--- a/questdb-rs/src/tests/qwp_ws.rs
+++ b/questdb-rs/src/tests/qwp_ws.rs
@@ -531,9 +531,9 @@ pub(crate) fn sha1(input: &[u8]) -> [u8; 20] {
     }
     p.extend_from_slice(&bit_len.to_be_bytes());
     let mut w = [0u32; 80];
-    for chunk in p.chunks_exact(64) {
-        for (i, word) in chunk.chunks_exact(4).enumerate() {
-            w[i] = u32::from_be_bytes([word[0], word[1], word[2], word[3]]);
+    for chunk in p.as_chunks::<64>().0 {
+        for (i, word) in chunk.as_chunks::<4>().0.iter().enumerate() {
+            w[i] = u32::from_be_bytes(*word);
         }
         for i in 16..80 {
             w[i] = (w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]).rotate_left(1);

--- a/questdb-rs/src/tests/qwp_ws_java_golden.rs
+++ b/questdb-rs/src/tests/qwp_ws_java_golden.rs
@@ -267,7 +267,7 @@ fn hex_to_bytes(hex: &str) -> Vec<u8> {
     let hex = hex.as_bytes();
     assert_eq!(hex.len() % 2, 0, "hex input must contain whole bytes");
     let mut out = Vec::with_capacity(hex.len() / 2);
-    for chunk in hex.chunks_exact(2) {
+    for chunk in hex.as_chunks::<2>().0 {
         let hi = hex_value(chunk[0]);
         let lo = hex_value(chunk[1]);
         out.push((hi << 4) | lo);

--- a/questdb-rs/src/ws/crypto.rs
+++ b/questdb-rs/src/ws/crypto.rs
@@ -75,9 +75,9 @@ fn sha1(input: &[u8]) -> [u8; 20] {
     padded.extend_from_slice(&bit_len.to_be_bytes());
 
     let mut w = [0u32; 80];
-    for chunk in padded.chunks_exact(64) {
-        for (i, word) in chunk.chunks_exact(4).enumerate() {
-            w[i] = u32::from_be_bytes([word[0], word[1], word[2], word[3]]);
+    for chunk in padded.as_chunks::<64>().0 {
+        for (i, word) in chunk.as_chunks::<4>().0.iter().enumerate() {
+            w[i] = u32::from_be_bytes(*word);
         }
         for i in 16..80 {
             w[i] = (w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]).rotate_left(1);


### PR DESCRIPTION
## The bug

`EventDispatcher::drop` published the close outside the inbox mutex:

```rust
self.inner.closed.store(true, Ordering::Release);
self.inner.available.notify_one();
... handle.join();
```

`dispatch_loop` reads `closed` and parks on that same condvar *while holding the inbox mutex*. Nothing serialises the two, so a drop that lands between the loop's read of `closed` and its park signals zero waiters. `offer` discards events once `closed` is set, so no later signal can arrive — the thread parks for good and the `join` in `drop` blocks forever.

The window is widest right after construction, when the freshly spawned thread makes its first trip through the lock. A dispatcher created and dropped back to back is therefore the most exposed shape.

## Why it matters

Every `questdb_db_connect_with_handlers` installs a rejection handler, so **every pool spawns this thread and joins it in `questdb_db_close`**. Any short-lived pool can stall on close.

It surfaced as a py-questdb-client CI timeout ([Azure build 262974](https://dev.azure.com/questdb/6c9c1a0a-74cf-4f7b-bf65-24ae4f3cd61d/_build/results?buildId=262974), `cibuildwheel macos_cp310_cp311`): a test whose client raises during argument validation and closes without ever connecting hit the 15-minute watchdog. Sampled stacks show both ends exactly:

```
main:                QuestDB.close -> questdb_db_close -> QuestDb::drop
                     -> RejectionEventSource::close -> EventDispatcher::shutdown
                     -> pthread_join                              [blocked]
questdb-rejections:  dispatch_loop -> __psynch_cvwait             [blocked]
```

Looping that client shape locally stalled after 76 / 109 / 150 iterations across three trials.

## The fix

Publish the close under the inbox mutex — the same thing `QuestDb::drop` already does deliberately for the pool condvar (`db.rs`, "Notifying under the mutex avoids the lost-wakeup race"). The dispatch loop is then left with only two possibilities: observe the store before parking, or be registered as a waiter when the notify lands.

No self-deadlock risk: `dispatch_loop` releases the inbox guard before invoking the listener, so a listener that drops the dispatcher is not already holding it.

## Test

`drop_joins_a_dispatcher_thread_that_never_saw_an_event` sweeps the gap between construction and drop across the startup window. It runs the cycle on a worker thread and waits on a channel, so a stall is reported as a receive timeout instead of hanging the suite.

- Without the fix: **fails** (`a dispatcher drop stalled joining its thread`).
- With the fix: **passes** in ~0.6 s, stable over 5 consecutive runs.

## Verification

- `cargo test` in `questdb-rs` — 1690 passed, 0 failed, 23 ignored (plus all doc/integration targets green)
- `cargo test` in `questdb-rs-ffi` — 88 passed, 0 failed
- `cargo fmt` applied; `cargo clippy --tests` clean

## Note

I audited the other condvar sites in `db.rs` and `qwp_ws.rs` for the same pattern; this was the only instance.

- `BackpressureNotifier::notify_all` bumps `generation` **under** its own mutex, and `wait_for_change` reads it under that same mutex — correctly guarded. Every `backpressure.notify_all()` call in `qwp_ws.rs` goes through that method.
- The pool sites in `db.rs` (`InUseSlot::drop`, `SenderSlotRelease::drop`, `finish_*_sender`, reader release, SF recovery) mutate the mutex-protected `state` before notifying, so the mutex serialises them against a waiter that has not parked yet.
- `QuestDb::drop` sets `shutdown` outside the mutex but issues the notify **under** it, which closes the same window from the other side.
- Apart from `BackpressureNotifier::wait_for_change`, every remaining condvar wait in both files is a `wait_timeout`, so a missed wakeup there would cost latency rather than stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of event-dispatcher shutdown and repeated close operations.
  - Prevented shutdown workflows from hanging while dispatchers start or stop.
  - Added stronger safeguards around dispatcher startup failures and worker termination.

- **Tests**
  - Expanded concurrency and shutdown coverage across thousands of repeated cycles.
  - Added clearer detection of startup timeouts and worker failures.
  - Preserved existing hashing, encoding, decoding, and data-transfer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
