### PR TITLE
chore(build): run the macOS CI legs on Apple Silicon agents

### DIFF
--- a/ci/run_fuzz_pipeline.yaml
+++ b/ci/run_fuzz_pipeline.yaml
@@ -13,6 +13,11 @@ pr: none
 # server). Equivalent PR-time jobs live in run_tests_pipeline.yaml
 # (TestQwpWsFuzz / TestQwpEgressLiveServerFuzz); this pipeline is the
 # always-on stability watchdog and the source of Slack #builds alerts.
+#
+# The mac legs pin macOS-15-arm64. The plain macOS-14/15/26 Azure images are
+# Intel x86-64, and QuestDB bundles a macOS native library for aarch64 only,
+# so the server refuses to start on an Intel agent. This mirrors the image
+# questdb/questdb's own macOS legs run on.
 schedules:
   - cron: "0 * * * *"
     displayName: Run QWP/WS + QWP egress fuzz every hour
@@ -30,7 +35,7 @@ stages:
         strategy:
           matrix:
             mac:
-              imageName: "macos-latest"
+              imageName: "macOS-15-arm64"
             windows-2022:
               imageName: "windows-2022"
         pool:
@@ -42,30 +47,7 @@ stages:
             lfs: false
             submodules: false
           - template: templates/compile.yaml
-          # Same JDK 25 dance as the PR-time fuzz job in
-          # run_tests_pipeline.yaml — Linux/Windows hosted agents ship JDK
-          # 25 at $JAVA_HOME_25_X64; macos-latest does not, so we brew it
-          # in. Resolution stays in a single bash step so the Windows
-          # leg's cmd.exe quote handling doesn't leave a stray `"` on
-          # the resolved path.
-          - bash: |
-              set -e
-              if [[ "$AGENT_OS" == "Darwin" ]]; then
-                brew install openjdk@25
-                JDK_HOME="$(brew --prefix openjdk@25)/libexec/openjdk.jdk/Contents/Home"
-                if [ ! -d "$JDK_HOME" ]; then
-                  JDK_HOME="$(/usr/libexec/java_home -v 25 2>/dev/null || true)"
-                fi
-                if [ ! -d "$JDK_HOME" ]; then
-                  echo "JDK 25 not found after brew install" >&2
-                  exit 1
-                fi
-              else
-                JDK_HOME="$JAVA_HOME_25_X64"
-              fi
-              echo "Resolved JDK 25: $JDK_HOME"
-              echo "##vso[task.setvariable variable=JAVA_HOME]$JDK_HOME"
-            displayName: "Resolve JDK 25"
+          - template: templates/resolve_jdk25.yaml
           - template: templates/clone_questdb.yaml
           - template: templates/maven_settings.yaml
           - task: Maven@3
@@ -231,7 +213,7 @@ stages:
             linux:
               imageName: "ubuntu-latest"
             mac:
-              imageName: "macos-latest"
+              imageName: "macOS-15-arm64"
             windows-2022:
               imageName: "windows-2022"
         pool:

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -74,12 +74,18 @@ stages:
           #   displayName: "Publish build directory"
       # mac/windows: run cargo vs native (build + C++ + integration) as two
       # parallel jobs to cut the slow legs' wall-clock. linux stays in RunOn.
+      #
+      # Every mac leg in this file pins macOS-15-arm64. The plain
+      # macOS-14/15/26 Azure images are Intel x86-64, and QuestDB bundles a
+      # macOS native library for aarch64 only, so a job that starts the server
+      # cannot run on an Intel agent. Keeping the cargo-only legs on the same
+      # image tests the one macOS architecture the client ships against.
       - job: RustTests
         displayName: "cargo tests (mac/windows)"
         strategy:
           matrix:
             mac:
-              imageName: "macos-latest"
+              imageName: "macOS-15-arm64"
             windows-msvc-2022:
               imageName: "windows-2022"
             windows-msvc-2025:
@@ -99,7 +105,7 @@ stages:
         strategy:
           matrix:
             mac:
-              imageName: "macos-latest"
+              imageName: "macOS-15-arm64"
             windows-msvc-2022:
               imageName: "windows-2022"
             windows-msvc-2025:
@@ -118,6 +124,7 @@ stages:
           - script: python3 ci/run_all_tests.py cpp
             displayName: "C++ tests"
           # Build QuestDB master for run_all_tests.py's `--repo ./questdb`.
+          - template: templates/resolve_jdk25.yaml
           - template: templates/clone_questdb.yaml
           - task: Maven@3
             displayName: "Compile QuestDB"
@@ -125,11 +132,11 @@ stages:
             inputs:
               mavenPOMFile: "questdb/pom.xml"
               javaHomeOption: "Path"
-              jdkDirectory: "$(JAVA_HOME_25_X64)"
+              jdkDirectory: "$(JAVA_HOME)"
               options: "-DskipTests -Pbuild-web-console$(CLIENT_PROFILE)"
           - script: python3 ci/run_all_tests.py integration
             env:
-              JAVA_HOME: $(JAVA_HOME_25_X64)
+              JAVA_HOME: $(JAVA_HOME)
             displayName: "Integration tests"
           - task: ArchiveFiles@2
             displayName: "Compress QuestDB server log on failure"
@@ -386,7 +393,7 @@ stages:
         strategy:
           matrix:
             mac:
-              imageName: "macos-latest"
+              imageName: "macOS-15-arm64"
             windows-2022:
               imageName: "windows-2022"
         pool:
@@ -398,32 +405,7 @@ stages:
             lfs: false
             submodules: false
           - template: templates/compile.yaml
-          # Linux and Windows runners ship with JDK 25 at $JAVA_HOME_25_X64.
-          # macOS-latest doesn't, so we brew-install openjdk@25 there and
-          # discover its install location with `brew --prefix`. Both
-          # paths set JAVA_HOME via a single bash step so the Windows
-          # version doesn't trip on cmd.exe's quote handling
-          # (`echo "##vso[...]$x"` in cmd preserves the surrounding
-          # quotes, which previously made Maven@3 see a stray `"` at
-          # the end of the JDK path).
-          - bash: |
-              set -e
-              if [[ "$AGENT_OS" == "Darwin" ]]; then
-                brew install openjdk@25
-                JDK_HOME="$(brew --prefix openjdk@25)/libexec/openjdk.jdk/Contents/Home"
-                if [ ! -d "$JDK_HOME" ]; then
-                  JDK_HOME="$(/usr/libexec/java_home -v 25 2>/dev/null || true)"
-                fi
-                if [ ! -d "$JDK_HOME" ]; then
-                  echo "JDK 25 not found after brew install" >&2
-                  exit 1
-                fi
-              else
-                JDK_HOME="$JAVA_HOME_25_X64"
-              fi
-              echo "Resolved JDK 25: $JDK_HOME"
-              echo "##vso[task.setvariable variable=JAVA_HOME]$JDK_HOME"
-            displayName: "Resolve JDK 25"
+          - template: templates/resolve_jdk25.yaml
           - template: templates/clone_questdb.yaml
           - template: templates/maven_settings.yaml
           - task: Maven@3

--- a/ci/templates/compile.yaml
+++ b/ci/templates/compile.yaml
@@ -21,16 +21,19 @@ steps:
       rustup default $(toolchain)
     condition: ne(variables['toolchain'], '')
     displayName: "Update and set Rust toolchain"
+  # Keyed on the agent OS, not the image label: the macOS legs run on
+  # macOS-15-arm64, the Linux legs run on both hosted and self-hosted images,
+  # and only the OS decides whether the dependencies come from Homebrew or pip.
   - script: |
       brew install numpy apache-arrow
       python3 -m pip install --break-system-packages pyarrow polars
       echo "##vso[task.setvariable variable=CMAKE_PREFIX_PATH]$(brew --prefix)"
-    condition: eq(variables['imageName'], 'macos-latest')
+    condition: eq(variables['Agent.OS'], 'Darwin')
     displayName: "Install numpy + pyarrow + polars + apache-arrow on macOS"
   - script: |
       python -m pip install --upgrade pip
       pip install numpy pyarrow polars tzdata
-    condition: ne(variables['imageName'], 'macos-latest')
+    condition: ne(variables['Agent.OS'], 'Darwin')
     env:
       PIP_BREAK_SYSTEM_PACKAGES: "1"
     displayName: "Install Python Dependencies"

--- a/ci/templates/resolve_jdk25.yaml
+++ b/ci/templates/resolve_jdk25.yaml
@@ -1,0 +1,44 @@
+# Resolve a JDK 25 into $(JAVA_HOME) for every hosted agent family that
+# builds QuestDB from source.
+#
+# Linux and Windows hosted agents expose it as $JAVA_HOME_25_X64. The
+# macOS-15-arm64 image exposes $JAVA_HOME_25_ARM64 instead, with
+# `/usr/libexec/java_home -v 25` and a Homebrew install as fallbacks.
+# Resolution stays in a single bash step so the Windows leg's cmd.exe quote
+# handling doesn't leave a stray `"` on the resolved path (which Maven@3
+# then takes as part of the JDK directory).
+steps:
+  - bash: |
+      set -e
+      if [[ "$AGENT_OS" == "Darwin" ]]; then
+        # QuestDB ships a macOS native library for aarch64 only, so an Intel
+        # agent - or an x86-64 JDK running under Rosetta - cannot start the
+        # server the system tests need. Assert the architecture here so an
+        # image swap fails with this message rather than as a FatalError out
+        # of io.questdb.std.Os.loadLib several minutes later.
+        if [ "$(uname -m)" != "arm64" ]; then
+          echo "Expected an arm64 macOS agent, got $(uname -m); x86-64 macOS is not a supported QuestDB platform" >&2
+          exit 1
+        fi
+        JDK_HOME="${JAVA_HOME_25_ARM64:-}"
+        if [ ! -d "$JDK_HOME" ]; then
+          JDK_HOME="$(/usr/libexec/java_home -v 25 2>/dev/null || true)"
+        fi
+        if [ ! -d "$JDK_HOME" ]; then
+          brew install openjdk@25
+          JDK_HOME="$(brew --prefix openjdk@25)/libexec/openjdk.jdk/Contents/Home"
+        fi
+        if [ ! -x "$JDK_HOME/bin/java" ]; then
+          echo "JDK 25 not found on this agent. Available:" >&2
+          /usr/libexec/java_home -V 2>&1 || true
+          exit 1
+        fi
+        # `-version` goes to stderr; keep it visible so the log records which
+        # architecture the JVM itself reports.
+        "$JDK_HOME/bin/java" -XshowSettings:properties -version 2>&1 | grep -E 'os\.arch|java\.version' || true
+      else
+        JDK_HOME="$JAVA_HOME_25_X64"
+      fi
+      echo "Resolved JDK 25: $JDK_HOME"
+      echo "##vso[task.setvariable variable=JAVA_HOME]$JDK_HOME"
+    displayName: "Resolve JDK 25"


### PR DESCRIPTION
## What broke

The hourly fuzz pipeline has failed on its macOS leg every run since
2026-08-25 15:00 UTC — always on the same commit, always before a single test
started. QuestDB refused to boot:

```
io.questdb.std.ex.FatalError: QuestDB does not support x86-64 (Intel) macOS,
no native library is bundled for it. Supported platforms: macOS aarch64,
Linux x86-64, Linux aarch64, Windows x86-64.
	at io.questdb.std.Os.loadLib(Os.java:348)
```

which `system_test/fixture.py` reports as `RuntimeError: QuestDB died during
startup.` ([build 264770](https://dev.azure.com/questdb/questdb/_build/results?buildId=264770&view=results))

Nothing changed on our side. Every one of these jobs clones questdb master and
builds the server from source, and questdb/questdb#7555 landed at 14:44 UTC
that same day: it deletes the `darwin-x86-64` dylibs from the jar and moves
questdb's own macOS test legs to Apple Silicon. Azure's `macos-latest` image is
Intel — the failing run resolved its JDK under `/usr/local/opt`, the x86-64
Homebrew prefix — so the jar we build no longer carries a library that agent
can load. The last green run was 14:00 UTC, the first red one 15:00 UTC.

The PR-time pipeline had not run since 13:00 UTC that day, so it has not gone
red yet, but it would fail identically on the next PR.

## What changed

Every macOS leg in both pipelines now asks for `macOS-15-arm64`, the image
questdb/questdb switched to. That covers the three jobs that start a server
(`NativeTests`, and `TestQwpWsFuzz` in each pipeline) and also the two that
only run cargo (`RustTests`, `TestQwpEgressFuzz`). aarch64 is the only macOS
build the client ships, so there is no reason to keep testing the other one.

Finding the JDK moves into a new template, `ci/templates/resolve_jdk25.yaml`,
shared by the three server-building jobs instead of being copied into two of
them. On macOS it reads `$JAVA_HOME_25_ARM64`, which the arm64 image sets, and
falls back to `/usr/libexec/java_home -v 25` and then to a Homebrew install; on
Linux and Windows it reads `$JAVA_HOME_25_X64` as before. It also stops with a
clear message when the agent is not arm64 — the fixture starts the server from
`$JAVA_HOME/bin/java`, so an Intel JDK there is exactly what produced the
`FatalError` above several minutes into the run.

Two supporting changes fall out of the image swap:

- `NativeTests` read the JDK straight from `$(JAVA_HOME_25_X64)`, which does
  not exist on an arm64 image, so it now uses the shared template and
  `$(JAVA_HOME)`.
- The two steps in `compile.yaml` that install the Python and Arrow
  dependencies chose between Homebrew and pip by comparing the image name to
  `macos-latest`. Renaming the image would have quietly sent the macOS legs
  down the pip branch and skipped `apache-arrow`, so they now check the agent's
  operating system instead.

The second commit bumps the `questdb` submodule to `4777a4e7`, the commit that
dropped Intel macOS support, so a local run reproduces what CI sees.

## Validation

- Both pipelines expand and validate against the real Azure YAML parser via the
  `pipelines/{id}/preview` API (`previewRun: true`, so nothing was queued).
- `macOS-15-arm64` is confirmed live in this org: questdb's own `macwin` build
  264683 logs `image=macOS-15-arm64 arch=arm64 os=15.7.7` and resolves JDK 25 at
  `/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/25.0.3-9.0/arm64/Contents/Home`
  — the first branch of the new template, so the Homebrew fallback never runs on
  the happy path.
- The resolution script passes `shellcheck` and was executed for all four paths:
  arm64 with the variable set, an Intel agent (fails with the intended message,
  never reaching brew), Linux/Windows, and a resolved directory with no
  `bin/java`.

Not proven without a real run: that the Maven build and the fuzz suite complete
end to end on that image. questdb's own macOS legs already build the same jar
there, so the residual risk is narrow — Homebrew `apache-arrow`/`numpy` on
arm64, and wall-clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated macOS CI and fuzz-testing jobs to use consistent ARM64 macOS 15 environments.
  - Improved Java 25 setup across supported build agents, with validation and clearer failure reporting.
  - Standardized platform detection for dependency installation.
  - Updated the bundled QuestDB component to a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->