### PR TITLE
fix(ingress): hold a GEOHASH value to its claimed precision at encode time

### DIFF
--- a/questdb-rs-ffi/src/lib.rs
+++ b/questdb-rs-ffi/src/lib.rs
@@ -5368,9 +5368,9 @@ mod tests {
         padded.extend_from_slice(&bit_len.to_be_bytes());
 
         let mut words = [0u32; 80];
-        for chunk in padded.chunks_exact(64) {
-            for (idx, word) in chunk.chunks_exact(4).enumerate() {
-                words[idx] = u32::from_be_bytes([word[0], word[1], word[2], word[3]]);
+        for chunk in padded.as_chunks::<64>().0 {
+            for (idx, word) in chunk.as_chunks::<4>().0.iter().enumerate() {
+                words[idx] = u32::from_be_bytes(*word);
             }
             for idx in 16..80 {
                 words[idx] = (words[idx - 3] ^ words[idx - 8] ^ words[idx - 14] ^ words[idx - 16])

--- a/questdb-rs/src/egress/decoder.rs
+++ b/questdb-rs/src/egress/decoder.rs
@@ -1138,7 +1138,7 @@ fn reverse_uuid_rows(buf: ColumnBuffer) -> ColumnBuffer {
         Ok(values) => values,
         Err(shared) => BytesMut::from(&shared[..]),
     };
-    for row in values.chunks_exact_mut(16) {
+    for row in values.as_chunks_mut::<16>().0 {
         row.reverse();
     }
     ColumnBuffer {
@@ -1743,13 +1743,13 @@ fn count_nulls(bitmap: &[u8], row_count: usize) -> usize {
     // bit-scan to find the *position* of a null), switch to
     // `from_le_bytes` — positions are endian-sensitive.
     let body = &bitmap[..full_bytes];
-    let mut chunks = body.chunks_exact(8);
+    let (words, tail) = body.as_chunks::<8>();
     let mut nulls: usize = 0;
-    for c in chunks.by_ref() {
-        let w = u64::from_ne_bytes(c.try_into().unwrap());
+    for c in words {
+        let w = u64::from_ne_bytes(*c);
         nulls += w.count_ones() as usize;
     }
-    for b in chunks.remainder() {
+    for b in tail {
         nulls += b.count_ones() as usize;
     }
     if tail_bits != 0 {
@@ -2309,7 +2309,7 @@ mod tests {
         });
 
         let mut expected = input;
-        for row in expected.chunks_exact_mut(16) {
+        for row in expected.as_chunks_mut::<16>().0 {
             row.reverse();
         }
         assert_eq!(reversed.values, expected);
@@ -2332,7 +2332,7 @@ mod tests {
         });
 
         let mut expected = input.clone();
-        for row in expected.chunks_exact_mut(16) {
+        for row in expected.as_chunks_mut::<16>().0 {
             row.reverse();
         }
         assert_eq!(reversed.values, expected);

--- a/questdb-rs/src/ingress/column_sender/arrow_batch.rs
+++ b/questdb-rs/src/ingress/column_sender/arrow_batch.rs
@@ -925,9 +925,14 @@ fn write_qwp_bitmap_from_arrow(out: &mut Vec<u8>, nulls: &NullBuffer) -> Result<
         let word_bytes = (full_bytes / 8) * 8;
         let (src_words, src_rem) = src_slice.split_at(word_bytes);
         let (dst_words, dst_rem) = dst_slice.split_at_mut(word_bytes);
-        for (dchunk, schunk) in dst_words.chunks_exact_mut(8).zip(src_words.chunks_exact(8)) {
-            let w = u64::from_ne_bytes(schunk.try_into().unwrap());
-            dchunk.copy_from_slice(&(!w).to_ne_bytes());
+        for (dchunk, schunk) in dst_words
+            .as_chunks_mut::<8>()
+            .0
+            .iter_mut()
+            .zip(src_words.as_chunks::<8>().0)
+        {
+            let w = u64::from_ne_bytes(*schunk);
+            *dchunk = (!w).to_ne_bytes();
         }
         for (d, &s) in dst_rem.iter_mut().zip(src_rem) {
             *d = !s;
@@ -1193,7 +1198,7 @@ fn write_uuid_be_payload(out: &mut Vec<u8>, arr: &FixedSizeBinaryArray) -> Resul
             // Bulk path: slice `value_data()` once, starting at the array's
             // own offset, instead of a bounds-checked `value(row)` per row.
             let start = arr.offset() * 16;
-            for row in arr.value_data()[start..start + bytes].chunks_exact(16) {
+            for row in arr.value_data()[start..start + bytes].as_chunks::<16>().0 {
                 out.extend_from_slice(&reverse_uuid_bytes(row));
             }
         }

--- a/questdb-rs/src/ingress/column_sender/arrow_batch.rs
+++ b/questdb-rs/src/ingress/column_sender/arrow_batch.rs
@@ -2063,6 +2063,36 @@ fn geohash_bytes_per_value(bits: u8) -> usize {
     (bits as usize).div_ceil(8)
 }
 
+/// Whether a source value fits the claimed GEOHASH precision.
+///
+/// The wire keeps the low `ceil(bits/8)` bytes of each value and a
+/// geohash's high bits are its coarse position, so a value that does not
+/// fit reaches the database as a valid geohash for somewhere else
+/// entirely. A precision that fills the source width uses every bit,
+/// including the one that reads as a sign, so its top half is stored as
+/// negative numbers and every value is in range; a narrower precision
+/// leaves the sign bit clear, so a negative value there is out of range.
+#[inline]
+fn geohash_value_fits(v: i64, bits: u8, src_width_bits: u32) -> bool {
+    if u32::from(bits) >= src_width_bits {
+        return true;
+    }
+    v >= 0 && v < (1i64 << bits)
+}
+
+#[cold]
+fn geohash_value_out_of_range(v: i64, bits: u8, row: usize) -> Error {
+    fmt!(
+        ArrowIngest,
+        "GEOHASH column: row {} holds {}, which a GEOHASH({}b) cannot carry; \
+         values must be in 0 .. {}",
+        row,
+        v,
+        bits,
+        (1i64 << bits) - 1
+    )
+}
+
 fn write_geohash_payload(out: &mut Vec<u8>, arr: &dyn Array, bits: u8) -> Result<()> {
     let elem = geohash_bytes_per_value(bits);
     let row_count = arr.len();
@@ -2071,47 +2101,32 @@ fn write_geohash_payload(out: &mut Vec<u8>, arr: &dyn Array, bits: u8) -> Result
     try_reserve_bytes(out, 1 + non_null * elem, label)?;
     write_qwp_varint(out, bits as u64);
     let dt = arr.data_type();
+
+    // Each arm reads the column at its own width, holds every non-null
+    // value to the claimed precision, and writes the low `elem` bytes.
+    // The bound is here, at the truncation, so every client that reaches
+    // this encoder is held to it.
+    macro_rules! write_rows {
+        ($ty:ty, $width_bits:expr) => {{
+            let a = arr.as_any().downcast_ref::<$ty>().unwrap();
+            for row in 0..row_count {
+                if arr.is_null(row) {
+                    continue;
+                }
+                let v = a.value(row) as i64;
+                if !geohash_value_fits(v, bits, $width_bits) {
+                    return Err(geohash_value_out_of_range(v, bits, row));
+                }
+                out.extend_from_slice(&(v as u64).to_le_bytes()[..elem]);
+            }
+        }};
+    }
+
     match dt {
-        DataType::Int8 => {
-            let a = arr.as_any().downcast_ref::<Int8Array>().unwrap();
-            for row in 0..row_count {
-                if arr.is_null(row) {
-                    continue;
-                }
-                let v = a.value(row) as u64;
-                out.extend_from_slice(&v.to_le_bytes()[..elem]);
-            }
-        }
-        DataType::Int16 => {
-            let a = arr.as_any().downcast_ref::<Int16Array>().unwrap();
-            for row in 0..row_count {
-                if arr.is_null(row) {
-                    continue;
-                }
-                let v = a.value(row) as u64;
-                out.extend_from_slice(&v.to_le_bytes()[..elem]);
-            }
-        }
-        DataType::Int32 => {
-            let a = arr.as_any().downcast_ref::<Int32Array>().unwrap();
-            for row in 0..row_count {
-                if arr.is_null(row) {
-                    continue;
-                }
-                let v = a.value(row) as u64;
-                out.extend_from_slice(&v.to_le_bytes()[..elem]);
-            }
-        }
-        DataType::Int64 => {
-            let a = arr.as_any().downcast_ref::<Int64Array>().unwrap();
-            for row in 0..row_count {
-                if arr.is_null(row) {
-                    continue;
-                }
-                let v = a.value(row) as u64;
-                out.extend_from_slice(&v.to_le_bytes()[..elem]);
-            }
-        }
+        DataType::Int8 => write_rows!(Int8Array, 8),
+        DataType::Int16 => write_rows!(Int16Array, 16),
+        DataType::Int32 => write_rows!(Int32Array, 32),
+        DataType::Int64 => write_rows!(Int64Array, 64),
         other => {
             return Err(fmt!(
                 ArrowIngest,
@@ -7436,6 +7451,62 @@ mod tests {
         let field = Field::new("g", DataType::Int64, true)
             .with_metadata(metadata(&[(crate::arrow_metadata::GEOHASH_BITS, "60")]));
         let rb = single_col_batch(field, b.finish());
+        assert_ok_with_table_count(&rb, 1);
+    }
+
+    fn geohash_batch<A: Array + 'static>(dt: DataType, bits: &str, arr: A) -> RecordBatch {
+        let field = Field::new("g", dt, true)
+            .with_metadata(metadata(&[(crate::arrow_metadata::GEOHASH_BITS, bits)]));
+        single_col_batch(field, arr)
+    }
+
+    #[test]
+    fn geohash_value_wider_than_its_precision_is_refused_naming_the_row() {
+        // The wire keeps the low `ceil(bits/8)` bytes, and a geohash's
+        // high bits are its coarse position, so a value that does not fit
+        // would arrive as a valid geohash for somewhere else entirely.
+        let mut b = Int64Builder::new();
+        b.append_value(0);
+        b.append_value(1i64 << 60);
+        let rb = geohash_batch(DataType::Int64, "60", b.finish());
+        let err = encode_err(&rb);
+        assert_eq!(err.code(), ErrorCode::ArrowIngest);
+        assert!(err.msg().contains("row 1"), "{}", err.msg());
+        assert!(err.msg().contains("GEOHASH(60b)"), "{}", err.msg());
+        assert!(err.msg().contains("'g'"), "{}", err.msg());
+    }
+
+    #[test]
+    fn geohash_negative_value_below_full_width_is_refused() {
+        // A precision narrower than the column leaves the sign bit clear,
+        // so a negative value is out of range rather than the top half of
+        // the space.
+        let mut b = Int32Builder::new();
+        b.append_value(-1);
+        let rb = geohash_batch(DataType::Int32, "20", b.finish());
+        let err = encode_err(&rb);
+        assert_eq!(err.code(), ErrorCode::ArrowIngest);
+        assert!(err.msg().contains("row 0"), "{}", err.msg());
+    }
+
+    #[test]
+    fn geohash_filling_the_column_width_keeps_its_negative_half() {
+        // A 32-bit precision in an `int32` uses every bit, including the
+        // one that reads as a sign, so its top half sits in the column as
+        // negative numbers and every value is in range.
+        let mut b = Int32Builder::new();
+        b.append_value(-1);
+        b.append_value(i32::MIN);
+        let rb = geohash_batch(DataType::Int32, "32", b.finish());
+        assert_ok_with_table_count(&rb, 1);
+    }
+
+    #[test]
+    fn geohash_null_row_carries_no_value_to_check() {
+        let mut b = Int32Builder::new();
+        b.append_null();
+        b.append_value(7);
+        let rb = geohash_batch(DataType::Int32, "20", b.finish());
         assert_ok_with_table_count(&rb, 1);
     }
 

--- a/questdb-rs/src/ingress/column_sender/conn.rs
+++ b/questdb-rs/src/ingress/column_sender/conn.rs
@@ -1161,24 +1161,18 @@ fn write_ws_header(out: &mut [u8], payload_len: usize, mask_key: [u8; 4]) {
     const BINARY_OPCODE: u8 = 0x2;
     const MASK_BIT: u8 = 0x80;
     out[0] = FIN_BIT | BINARY_OPCODE;
-    let len_bytes;
-    let mask_offset;
-    if payload_len <= 125 {
+    let mask_offset = if payload_len <= 125 {
         out[1] = MASK_BIT | (payload_len as u8);
-        mask_offset = 2;
-        len_bytes = 0;
+        2
     } else if payload_len <= 0xFFFF {
         out[1] = MASK_BIT | 126;
         out[2..4].copy_from_slice(&(payload_len as u16).to_be_bytes());
-        mask_offset = 4;
-        len_bytes = 2;
+        4
     } else {
         out[1] = MASK_BIT | 127;
         out[2..10].copy_from_slice(&(payload_len as u64).to_be_bytes());
-        mask_offset = 10;
-        len_bytes = 8;
-    }
-    let _ = len_bytes;
+        10
+    };
     out[mask_offset..mask_offset + 4].copy_from_slice(&mask_key);
 }
 

--- a/questdb-rs/src/ingress/column_sender/encoder.rs
+++ b/questdb-rs/src/ingress/column_sender/encoder.rs
@@ -820,7 +820,9 @@ unsafe fn encode_column(
             row_count: numpy_rows,
         } => {
             debug_assert_eq!(numpy_rows, row_count);
-            unsafe { numpy_wire::emit_into_wire(out, dtype, data, numpy_rows, validity)? };
+            unsafe {
+                numpy_wire::emit_into_wire(out, dtype, data, numpy_rows, validity, &col.name)?
+            };
         }
     }
     Ok(())

--- a/questdb-rs/src/ingress/column_sender/numpy_wire.rs
+++ b/questdb-rs/src/ingress/column_sender/numpy_wire.rs
@@ -2332,7 +2332,7 @@ mod tests {
         // column body subsequence appears exactly once.
         let mut body: Vec<u8> = Vec::new();
         body.push(0u8); // null_flag = 0 (no validity)
-        for row_chunk in rows.chunks_exact(3) {
+        for row_chunk in rows.as_chunks::<3>().0 {
             body.push(1u8); // ndim
             body.extend_from_slice(&3u32.to_le_bytes()); // dim
             for &v in row_chunk {

--- a/questdb-rs/src/ingress/column_sender/numpy_wire.rs
+++ b/questdb-rs/src/ingress/column_sender/numpy_wire.rs
@@ -32,6 +32,7 @@
 //! else. The numpy entry point can build (and run at full coverage)
 //! without the `arrow` Cargo feature.
 
+use std::ptr;
 use std::slice;
 
 use crate::ingress::{MAX_ARRAY_DIMS, MAX_NDARRAY_LEAF_ELEMS};
@@ -414,6 +415,7 @@ pub(crate) unsafe fn emit_into_wire(
     data: *const u8,
     row_count: usize,
     validity: Option<&ValidityDescriptor>,
+    column: &str,
 ) -> Result<()> {
     use NumpyDtype as D;
     match dtype {
@@ -595,16 +597,16 @@ pub(crate) unsafe fn emit_into_wire(
 
         // ---- Geohash (bits byte + bitmap-encoded width-N rows) ----
         D::GeohashI8 { bits } => unsafe {
-            emit_geohash::<1>(out, bits, data, row_count, validity)?
+            emit_geohash::<1>(out, bits, data, row_count, validity, column)?
         },
         D::GeohashI16 { bits } => unsafe {
-            emit_geohash::<2>(out, bits, data, row_count, validity)?
+            emit_geohash::<2>(out, bits, data, row_count, validity, column)?
         },
         D::GeohashI32 { bits } => unsafe {
-            emit_geohash::<4>(out, bits, data, row_count, validity)?
+            emit_geohash::<4>(out, bits, data, row_count, validity, column)?
         },
         D::GeohashI64 { bits } => unsafe {
-            emit_geohash::<8>(out, bits, data, row_count, validity)?
+            emit_geohash::<8>(out, bits, data, row_count, validity, column)?
         },
 
         // ---- f64 ndarray (DOUBLE_ARRAY, bitmap-encoded nulls) ----
@@ -1203,6 +1205,11 @@ unsafe fn emit_decimal<const N: usize>(
 /// The encoder writes the low `elem` bytes of each source int, matching
 /// `arrow_batch::write_geohash_payload`. Caller has validated `bits` is
 /// within the source dtype's representable range.
+///
+/// Every non-null value is held to the claimed precision first. The
+/// truncation is here, so the bound is here too, and it runs as its own
+/// pass so the whole-column memcpy stays available to the values that
+/// pass it.
 #[inline]
 unsafe fn emit_geohash<const SRC: usize>(
     out: &mut Vec<u8>,
@@ -1210,6 +1217,7 @@ unsafe fn emit_geohash<const SRC: usize>(
     data: *const u8,
     row_count: usize,
     validity: Option<&ValidityDescriptor>,
+    column: &str,
 ) -> Result<()> {
     let elem = (bits as usize).div_ceil(8);
     if elem > SRC {
@@ -1218,7 +1226,9 @@ unsafe fn emit_geohash<const SRC: usize>(
             "numpy geohash bits ({bits}) exceeds source dtype width ({SRC} bytes)"
         ));
     }
-    match validity.filter(|v| v.has_nulls()) {
+    let with_nulls = validity.filter(|v| v.has_nulls());
+    unsafe { check_geohash_range::<SRC>(bits, data, row_count, with_nulls, column)? };
+    match with_nulls {
         None => {
             out.push(0);
             out.reserve(1 + elem * row_count);
@@ -1246,6 +1256,60 @@ unsafe fn emit_geohash<const SRC: usize>(
                     out.extend_from_slice(row);
                 }
             }
+        }
+    }
+    Ok(())
+}
+
+/// Refuse a GEOHASH value the claimed precision cannot hold, naming the
+/// column and the row.
+///
+/// A geohash's high bits are its coarse position, so a value truncated
+/// to `bits` reaches the database as a valid geohash for somewhere else
+/// entirely. A precision that fills the source width uses every bit,
+/// including the one that reads as a sign, so its top half is stored as
+/// negative numbers and every value is in range; a narrower precision
+/// leaves the sign bit clear, so a negative value there is out of range.
+///
+/// # Safety
+///
+/// `data` must point at `row_count` contiguous `SRC`-byte signed ints,
+/// and `validity` (when present) must describe those same rows.
+unsafe fn check_geohash_range<const SRC: usize>(
+    bits: u8,
+    data: *const u8,
+    row_count: usize,
+    validity: Option<&ValidityDescriptor>,
+    column: &str,
+) -> Result<()> {
+    if bits as usize >= SRC * 8 {
+        return Ok(());
+    }
+    let max = (1i64 << bits) - 1;
+    for i in 0..row_count {
+        if let Some(v) = validity
+            && !unsafe { v.is_valid(i) }
+        {
+            continue;
+        }
+        let mut buf = [0u8; 8];
+        unsafe { ptr::copy_nonoverlapping(data.add(i * SRC), buf.as_mut_ptr(), SRC) };
+        // Sign-extend the source width into an `i64` so a negative
+        // value reads as negative whatever width it arrived in.
+        let raw = u64::from_le_bytes(buf);
+        let shift = 64 - SRC * 8;
+        let value = ((raw << shift) as i64) >> shift;
+        if value < 0 || value > max {
+            return Err(error::fmt!(
+                InvalidApiCall,
+                "column {:?}: row {} holds {}, which a GEOHASH({}b) cannot \
+                 carry; values must be in 0 .. {}",
+                column,
+                i,
+                value,
+                bits,
+                max
+            ));
         }
     }
     Ok(())
@@ -1507,6 +1571,108 @@ mod tests {
             D::F64Ndarray { ndim: 2, shape }.source_elem_size().unwrap(),
             2 * 3 * 8
         );
+    }
+
+    fn geohash_chunk_err(
+        dtype: NumpyDtype,
+        raw: &[u8],
+        validity: Option<&Validity<'_>>,
+    ) -> crate::Error {
+        let ts: Vec<i64> = (0..raw_rows(dtype, raw)).map(|i| i as i64 + 1).collect();
+        let mut chunk = Chunk::new("t");
+        unsafe {
+            chunk
+                .push_numpy_deferred("g", dtype, raw.as_ptr(), ts.len(), validity)
+                .unwrap();
+        }
+        chunk.at_nanos(&ts).unwrap();
+        encode_err(&chunk)
+    }
+
+    fn raw_rows(dtype: NumpyDtype, raw: &[u8]) -> usize {
+        raw.len() / dtype.source_elem_size().unwrap()
+    }
+
+    #[test]
+    fn geohash_value_wider_than_its_precision_is_refused_naming_column_and_row() {
+        // The wire keeps the low `ceil(bits/8)` bytes, so a value that does
+        // not fit would arrive as a valid geohash for somewhere else. The
+        // whole-column memcpy path (elem == SRC) is the one that used to
+        // carry it through unread, so exercise it: bits 60 over an i64.
+        let raw: Vec<u8> = [0i64, 1i64 << 60]
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect();
+        let err = geohash_chunk_err(NumpyDtype::GeohashI64 { bits: 60 }, &raw, None);
+        assert_eq!(err.code(), crate::ErrorCode::InvalidApiCall);
+        assert!(err.msg().contains("row 1"), "{}", err.msg());
+        assert!(err.msg().contains("GEOHASH(60b)"), "{}", err.msg());
+        assert!(err.msg().contains("\"g\""), "{}", err.msg());
+    }
+
+    #[test]
+    fn geohash_negative_value_below_full_width_is_refused() {
+        // A precision narrower than the source leaves the sign bit clear,
+        // so a negative value is out of range, not the top of the space.
+        let raw: Vec<u8> = (-1i32).to_le_bytes().to_vec();
+        let err = geohash_chunk_err(NumpyDtype::GeohashI32 { bits: 20 }, &raw, None);
+        assert_eq!(err.code(), crate::ErrorCode::InvalidApiCall);
+        assert!(err.msg().contains("row 0"), "{}", err.msg());
+    }
+
+    #[test]
+    fn geohash_filling_the_source_width_keeps_its_negative_half() {
+        // A 32-bit precision in an `int32` uses every bit, including the
+        // one that reads as a sign, so its top half sits in the source as
+        // negative numbers and every value is in range.
+        let src = [-1i32, i32::MIN];
+        let raw: Vec<u8> = src.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let ts = [1i64, 2];
+        let mut chunk = Chunk::new("t");
+        unsafe {
+            chunk
+                .push_numpy_deferred(
+                    "g",
+                    NumpyDtype::GeohashI32 { bits: 32 },
+                    raw.as_ptr(),
+                    2,
+                    None,
+                )
+                .unwrap();
+        }
+        chunk.at_nanos(&ts).unwrap();
+        let out = encode(&chunk);
+        let expected: Vec<u8> = raw.clone();
+        assert!(
+            out.windows(expected.len()).any(|w| w == expected),
+            "a full-width geohash column must reach the wire unchanged"
+        );
+    }
+
+    #[test]
+    fn geohash_null_row_carries_no_value_to_check() {
+        // Row 0 is null and holds a value no precision could carry; only
+        // the rows that go out are held to the precision.
+        let src = [i32::MAX, 7i32];
+        let raw: Vec<u8> = src.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let bits = [0b0000_0010u8]; // row 0 null
+        let validity = Validity::from_bitmap(&bits, 2).unwrap();
+        let ts = [1i64, 2];
+        let mut chunk = Chunk::new("t");
+        unsafe {
+            chunk
+                .push_numpy_deferred(
+                    "g",
+                    NumpyDtype::GeohashI32 { bits: 20 },
+                    raw.as_ptr(),
+                    2,
+                    Some(&validity),
+                )
+                .unwrap();
+        }
+        chunk.at_nanos(&ts).unwrap();
+        let out = encode(&chunk);
+        assert!(!out.is_empty());
     }
 
     #[test]

--- a/questdb-rs/src/ingress/sender/qwp_ws_sfa_queue.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws_sfa_queue.rs
@@ -4066,7 +4066,9 @@ mod tests {
         assert_eq!(nibbles.len() % 2, 0, "hex fixture has odd length");
 
         nibbles
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| (pair[0] << 4) | pair[1])
             .collect()
     }

--- a/questdb-rs/src/ingress/sender/qwp_ws_sfa_segment.rs
+++ b/questdb-rs/src/ingress/sender/qwp_ws_sfa_segment.rs
@@ -1696,7 +1696,9 @@ mod tests {
         assert_eq!(nibbles.len() % 2, 0, "hex fixture has odd length");
 
         nibbles
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| (pair[0] << 4) | pair[1])
             .collect()
     }

--- a/questdb-rs/src/tests/qwp_sender_pool.rs
+++ b/questdb-rs/src/tests/qwp_sender_pool.rs
@@ -720,7 +720,9 @@ fn decode_test_hex(hex: &str) -> Vec<u8> {
         .collect();
     assert_eq!(compact.len() % 2, 0, "hex fixture must contain byte pairs");
     compact
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             let text = std::str::from_utf8(pair).unwrap();
             u8::from_str_radix(text, 16).unwrap()

--- a/questdb-rs/src/tests/qwp_ws.rs
+++ b/questdb-rs/src/tests/qwp_ws.rs
@@ -531,9 +531,9 @@ pub(crate) fn sha1(input: &[u8]) -> [u8; 20] {
     }
     p.extend_from_slice(&bit_len.to_be_bytes());
     let mut w = [0u32; 80];
-    for chunk in p.chunks_exact(64) {
-        for (i, word) in chunk.chunks_exact(4).enumerate() {
-            w[i] = u32::from_be_bytes([word[0], word[1], word[2], word[3]]);
+    for chunk in p.as_chunks::<64>().0 {
+        for (i, word) in chunk.as_chunks::<4>().0.iter().enumerate() {
+            w[i] = u32::from_be_bytes(*word);
         }
         for i in 16..80 {
             w[i] = (w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]).rotate_left(1);

--- a/questdb-rs/src/tests/qwp_ws_java_golden.rs
+++ b/questdb-rs/src/tests/qwp_ws_java_golden.rs
@@ -267,7 +267,7 @@ fn hex_to_bytes(hex: &str) -> Vec<u8> {
     let hex = hex.as_bytes();
     assert_eq!(hex.len() % 2, 0, "hex input must contain whole bytes");
     let mut out = Vec::with_capacity(hex.len() / 2);
-    for chunk in hex.chunks_exact(2) {
+    for chunk in hex.as_chunks::<2>().0 {
         let hi = hex_value(chunk[0]);
         let lo = hex_value(chunk[1]);
         out.push((hi << 4) | lo);

--- a/questdb-rs/src/ws/crypto.rs
+++ b/questdb-rs/src/ws/crypto.rs
@@ -75,9 +75,9 @@ fn sha1(input: &[u8]) -> [u8; 20] {
     padded.extend_from_slice(&bit_len.to_be_bytes());
 
     let mut w = [0u32; 80];
-    for chunk in padded.chunks_exact(64) {
-        for (i, word) in chunk.chunks_exact(4).enumerate() {
-            w[i] = u32::from_be_bytes([word[0], word[1], word[2], word[3]]);
+    for chunk in padded.as_chunks::<64>().0 {
+        for (i, word) in chunk.as_chunks::<4>().0.iter().enumerate() {
+            w[i] = u32::from_be_bytes(*word);
         }
         for i in 16..80 {
             w[i] = (w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]).rotate_left(1);


### PR DESCRIPTION
Split out of #189, which bundled this with an unrelated dispatcher lost-wakeup
fix. No code changes: commit `79e3ebb9` cherry-picked onto `main`. #189 now
carries only the dispatcher fix, which its title and body already described.

## The problem

The Arrow and NumPy column encoders truncate a GEOHASH value to the low
`ceil(bits/8)` bytes. A geohash's high bits are its coarse position
(`GeoHashes.java:215` interleaves and shifts right by `64 - bits`; `widen` at
`:316` lowers precision with a right shift), so a value wider than the declared
precision does not arrive as an error — it arrives as a well-formed geohash for
somewhere else entirely.

## The change

Every non-null value is held to the claimed precision at the point of
truncation, naming the column and the row.

- **Arrow** (`arrow_batch.rs`): the four hand-rolled per-dtype loops collapse
  into one `write_rows!` macro that range-checks before truncating.
  Error: `ArrowIngest`.
- **NumPy** (`numpy_wire.rs`): `check_geohash_range::<SRC>` runs as a pass ahead
  of the emit path so the whole-column memcpy stays available. `emit_into_wire`
  gains a `column: &str` so the message can name the column.
  Error: `InvalidApiCall`.

## Behaviour change

User-visible and reachable from Rust, C, C++ and Python: a flush that previously
succeeded — silently storing a mis-located geohash — now fails. There is no
changelog in this repo and `doc/` does not document geohash, so this needs a
release note.

## Open findings — not ready to merge as-is

**1. The new bound is wrong at both ends (blocking).** The QWP wire has a
sentinel NULL mode: with no null bitmap, the server decodes all-ones over
`ceil(bits/8)` bytes as NULL (`QwpGeoHashColumnCursor.java:72-76`, with
`valueSize = (precision + 7) / 8` at `:164`).

- The check now *rejects* that sentinel at 113 of 116 reachable `(dtype, bits)`
  combinations, including `GEOHASH(60b)` — so a bitmap-less column using `-1`
  for NULL, which previously ingested as SQL NULL, hard-fails the whole flush.
- Conversely the advertised maximum, `values must be in 0 .. (1<<bits)-1`, *is*
  the sentinel at the seven byte-aligned precisions (8/16/24/32/40/48/56). Worse,
  `use_bitmap = kind_supports_sparse_nulls(kind) && null_count > 0`
  (`arrow_batch.rs:3281`) means the same value lands as a real geohash when the
  batch has any null row and as NULL when it has none.
- The `bits >= src_width_bits` exemption's premise ("every value is in range")
  is contradicted by `ColumnType.java:61-68` — `GEOBYTE_MAX_BITS = 7`,
  `GEOSHORT = 15`, `GEOINT = 31`, `GEOLONG = 60`; a real geohash never occupies
  the top bit of its storage width. Two new tests
  (`geohash_filling_the_{column,source}_width_keeps_its_negative_half`) assert
  `-1` reaches the wire, so fixing this means deleting tests.

**2. Measured hot-path regression.** `check_geohash_range` skips only at
`bits >= SRC*8`, and `GeohashI64` caps at 60, so every i64 geohash column pays a
full extra pass. On a 16M-row no-null `bits=60` flush: 12.06 ms -> 20.44 ms
(**+69%**), column-only encode 3.9x slower; +35% with nulls. A branchless
OR-reduce measured at +2.31 ms instead of +8.38 (3.6x cheaper) with identical
messages and all tests passing. Separately, the arrow guard is not hoisted out of
the row loop — Int32/bits=32, where the check is a tautology, still costs +6%.

**3. Cross-surface inconsistency.** Four geohash value surfaces, three
behaviours: `bind_geohash` checks and returns `InvalidBind` (documented for
geohash range at `line_sender.h:177-179`); the two paths here check and return
`ArrowIngest` / `InvalidApiCall` with different message shapes; and
`Buffer::column_geohash` (`buffer.rs:1538`) still truncates silently — the
surface C/C++/Python expose directly, and the oracle
`system_test/arrow_fuzz_common.py` compares the Arrow path against.

**4. Error loses the column name on the Chunk path.** `encoder.rs:815` calls
`write_arrow_column_body` with a bare `?` and no `decorate_column`, so
`qwp_chunk_append_arrow_column` reports `GEOHASH column: row N ...` with no
column name — while the numpy arm ten lines below, changed by this commit, now
names its column.

## Verification

`cargo fmt --check` clean; `cargo clippy --tests` clean (the one
`useless use of vec!` warning is pre-existing in `polars.rs`);
`cargo test --lib --features=almost-all-features,arrow,polars` 2419 passed,
0 failed, 23 ignored, including all 35 geohash tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent invalid GEOHASH values from being silently truncated.
  * Reports the affected column and row when a GEOHASH value exceeds its declared precision or is negative.
  * Preserves valid full-width signed GEOHASH values and correctly ignores null entries.
  * Improved error reporting for invalid GEOHASH data across Arrow and NumPy ingestion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->