### PR TITLE
[DO NOT MERGE] ci: diagnose macOS QWP add-column stalls

### DIFF
--- a/ci/diagnostics/decode_kernel_capture.py
+++ b/ci/diagnostics/decode_kernel_capture.py
@@ -1,0 +1,61 @@
+"""Decode retained kernel samples with retained symbol information. No workload."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import zipfile
+
+SOURCES = (
+    (268494, 'qwp-ws-macos-show-columns/run-3/kernel-stacks/spindump.raw',
+     '7afefee742916e36b06f36eafacd2a5e65cce02a1687ee32c01c0bc90e80db14', 'spindump.raw'),
+    (268472, 'qwp-ws-macos-show-columns/run-4/kernel-stacks/spindump.txt',
+     'f880f248ccd07c49254441eb14d95ead1617077d2f0834e987abf9d0003715ea', 'symbols.spindump'),
+)
+
+
+def extract_member(archive_path, member, expected_hash, destination):
+    with zipfile.ZipFile(archive_path) as archive:
+        if archive.getinfo(member).file_size > 64 * 1024**2:
+            raise RuntimeError('oversized decoder input')
+        data = archive.read(member)
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != expected_hash:
+        raise RuntimeError(f'decoder input hash mismatch: {actual}')
+    destination.write_bytes(data)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('directory', type=Path)
+    args = parser.parse_args()
+    directory = args.directory.resolve()
+    directory.mkdir(parents=True, exist_ok=False)
+    (directory / 'tmp').mkdir()
+    if shutil.disk_usage(directory).free < 2 * 1024**3:
+        raise RuntimeError('less than 2 GiB free for decoder inputs')
+    source_dir = Path('build-exp/kernel-decode-input').resolve()
+    source_dir.mkdir(parents=True, exist_ok=False)
+    for build, member, digest, filename in SOURCES:
+        archive = source_dir / f'{build}.zip'
+        url = (f'https://dev.azure.com/questdb/questdb/_apis/build/builds/{build}/artifacts'
+               '?artifactName=qwp-ws-macos-show-columns&api-version=7.1&%24format=zip')
+        subprocess.run(['curl', '--fail', '--location', '--silent', '--show-error',
+                        '--max-time', '90', url, '--output', str(archive)],
+                       timeout=95, check=True)
+        extract_member(archive, member, digest, directory / filename)
+    (directory / 'inputs.json').write_text(json.dumps(SOURCES, indent=2) + '\n')
+    controller = Path(__file__).with_name('kernel_wait_preflight.py').resolve()
+    with (directory / 'decode.log').open('w') as log:
+        subprocess.run(['sudo', '-n', 'env', f'TMPDIR={directory / "tmp"}',
+                        sys.executable, str(controller), str(directory), '--decode',
+                        '--symbols', str(directory / 'symbols.spindump')],
+                       stdout=log, stderr=subprocess.STDOUT, timeout=75, check=True,
+                       env=dict(os.environ, TMPDIR=str(directory / 'tmp')))
+
+
+if __name__ == '__main__':
+    main()

--- a/ci/diagnostics/decode_kernel_capture.py
+++ b/ci/diagnostics/decode_kernel_capture.py
@@ -31,15 +31,19 @@ def extract_member(archive_path, member, expected_hash, destination):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('directory', type=Path)
+    parser.add_argument('--symbols-only', action='store_true',
+                        help='Fetch the pinned symbol report before a workload; do not decode or sample')
+    parser.add_argument('--source-directory', type=Path, default=Path('build-exp/kernel-decode-input'))
     args = parser.parse_args()
     directory = args.directory.resolve()
     directory.mkdir(parents=True, exist_ok=False)
     (directory / 'tmp').mkdir()
     if shutil.disk_usage(directory).free < 2 * 1024**3:
         raise RuntimeError('less than 2 GiB free for decoder inputs')
-    source_dir = Path('build-exp/kernel-decode-input').resolve()
+    source_dir = args.source_directory.resolve()
     source_dir.mkdir(parents=True, exist_ok=False)
-    for build, member, digest, filename in SOURCES:
+    sources = SOURCES[1:] if args.symbols_only else SOURCES
+    for build, member, digest, filename in sources:
         archive = source_dir / f'{build}.zip'
         url = (f'https://dev.azure.com/questdb/questdb/_apis/build/builds/{build}/artifacts'
                '?artifactName=qwp-ws-macos-show-columns&api-version=7.1&%24format=zip')
@@ -47,7 +51,9 @@ def main():
                         '--max-time', '90', url, '--output', str(archive)],
                        timeout=95, check=True)
         extract_member(archive, member, digest, directory / filename)
-    (directory / 'inputs.json').write_text(json.dumps(SOURCES, indent=2) + '\n')
+    (directory / 'inputs.json').write_text(json.dumps(sources, indent=2) + '\n')
+    if args.symbols_only:
+        return
     controller = Path(__file__).with_name('kernel_wait_preflight.py').resolve()
     with (directory / 'decode.log').open('w') as log:
         subprocess.run(['sudo', '-n', 'env', f'TMPDIR={directory / "tmp"}',

--- a/ci/diagnostics/decode_system_trace.py
+++ b/ci/diagnostics/decode_system_trace.py
@@ -1,0 +1,131 @@
+"""Export unexamined VM/scheduler data from an existing recording, no workload.
+
+The source is pinned to build 268363/run-4's already captured short ping stall.
+Its interpretation must not be promoted to the original build 266336's cause.
+"""
+import argparse
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import shutil
+import subprocess
+import sys
+import time
+import xml.etree.ElementTree as ET
+import zipfile
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'system_test'))
+from qwp_ws_trace_export import inspect_rows
+
+SOURCE_URL = ('https://dev.azure.com/questdb/questdb/_apis/build/builds/268363/artifacts'
+              '?artifactName=qwp-ws-macos-system-trace&api-version=7.1&%24format=zip')
+SOURCE_HASH = '374b4d0a7d37d315c4f1c10b6a609ff568b405985ed6398a46af8946dbc6be70'
+PREFIX = 'qwp-ws-macos-system-trace/run-4/'
+
+
+def selections(toc):
+    result = []
+    for index, table in enumerate(ET.parse(toc).findall('./run/data/table'), 1):
+        schema = table.get('schema')
+        codes = table.get('codes', '')
+        if (schema in ('context-switch', 'virtual-memory', 'system-load')
+                or schema == 'kdebug' and ('0x1,0x30' in codes or '0x1,0x40' in codes)):
+            result.append((index, dict(table.attrib)))
+    if not {'context-switch', 'virtual-memory'} <= {r[1]['schema'] for r in result}:
+        raise RuntimeError('recording lacks the required VM/context-switch tables')
+    return result
+
+
+def extract(archive_path, destination):
+    with zipfile.ZipFile(archive_path) as archive:
+        for item in archive.infolist():
+            if not item.filename.startswith(PREFIX):
+                continue
+            relative = PurePosixPath(item.filename[len(PREFIX):])
+            if '..' in relative.parts or relative.is_absolute():
+                raise ValueError('unsafe artifact path')
+            if relative == PurePosixPath('.'):
+                continue
+            if relative.parts[0] != 'system.trace' and relative.name not in (
+                    'system-trace-toc.xml', 'watchdog.jsonl', 'jvm-pauses.log'):
+                continue
+            target = destination / relative
+            if item.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+            else:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with archive.open(item) as src, target.open('xb') as dst:
+                    shutil.copyfileobj(src, dst)
+
+
+def content_hash(archive_path):
+    # Azure may regenerate ZIP headers. Pin names and bytes, not packaging.
+    digest = hashlib.sha256()
+    with zipfile.ZipFile(archive_path) as archive:
+        for name in sorted(n for n in archive.namelist()
+                           if n.startswith(PREFIX) and not n.endswith('/')):
+            with archive.open(name) as stream:
+                file_digest = hashlib.sha256()
+                for chunk in iter(lambda: stream.read(1024 * 1024), b''):
+                    file_digest.update(chunk)
+                file_hash = file_digest.digest()
+            digest.update(name.encode() + b'\0' + file_hash)
+    return digest.hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('directory', type=Path)
+    parser.add_argument('--source-directory', type=Path,
+                        default=Path('build-exp/trace-decode-input'))
+    args = parser.parse_args()
+    directory = args.directory.resolve()
+    directory.mkdir(exist_ok=False, parents=True)
+    source_directory = args.source_directory.resolve()
+    source_directory.mkdir(exist_ok=False, parents=True)
+    if shutil.disk_usage(source_directory).free < 2 * 1024**3:
+        raise RuntimeError('insufficient space to download and decode the recording')
+    source = source_directory / 'source.zip'
+    subprocess.run(['curl', '--fail', '--location', '--silent', '--show-error',
+                    '--max-time', '90', SOURCE_URL, '--output', str(source)], check=True, timeout=95)
+    actual_hash = content_hash(source)
+    if actual_hash != SOURCE_HASH:
+        raise RuntimeError(f'recording hash differs: {actual_hash}')
+    extract(source, source_directory)
+    for name in ('system-trace-toc.xml', 'watchdog.jsonl', 'jvm-pauses.log'):
+        shutil.copyfile(source_directory / name, directory / name)
+    shutil.copyfile(source_directory / 'system.trace/form.template', directory / 'form.template')
+    toc = directory / 'decoded-toc.xml'
+    deadline = time.monotonic() + 240
+    results = []
+    with (directory / 'export.log').open('w') as log:
+        # Use this xctrace version's actual table ordering, not stale positions
+        # from a TOC produced by the original worker's Xcode installation.
+        subprocess.run(['/usr/bin/xcrun', 'xctrace', 'export', '--input',
+                        str(source_directory / 'system.trace'), '--toc', '--output', str(toc)],
+                       stdout=log, stderr=subprocess.STDOUT, timeout=30, check=True)
+        target = ET.parse(toc).find('./run/info/target/process')
+        pid = int(target.get('pid'))
+        if pid != 26020:
+            raise RuntimeError(f'unexpected recorded target PID: {pid}')
+        for index, attributes in selections(toc):
+            if shutil.disk_usage(directory).free < 2 * 1024**3:
+                raise RuntimeError('insufficient space for trace export')
+            path = directory / f'raw-table-{index}.xml'
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError('export-only budget exhausted')
+            subprocess.run(['/usr/bin/xcrun', 'xctrace', 'export', '--input',
+                            str(source_directory / 'system.trace'), '--xpath',
+                            f'/trace-toc/run[1]/data/table[{index}]', '--output', str(path)],
+                           stdout=log, stderr=subprocess.STDOUT,
+                           timeout=min(45, remaining), check=True)
+            results.append(dict(file=path.name, attributes=attributes,
+                                **inspect_rows(path, pid, deadline)))
+    (directory / 'export-summary.json').write_text(json.dumps(
+        dict(source_build=268363, source_attempt=4, source_sha256=actual_hash,
+             target_pid=pid, tables=results), indent=2) + '\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/ci/diagnostics/fd_cache_close/CloseFaultAgent.java
+++ b/ci/diagnostics/fd_cache_close/CloseFaultAgent.java
@@ -1,0 +1,145 @@
+package diagnostic;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.ProtectionDomain;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/** Local, Linux-only fault injection. No server sources or binaries are modified. */
+public final class CloseFaultAgent {
+    private static final AtomicBoolean FIRED = new AtomicBoolean();
+    private static Path directory;
+    private static String mode;
+    private static long delayMillis;
+
+    public static void premain(String arguments, Instrumentation instrumentation) throws Exception {
+        directory = Path.of(arguments);
+        mode = Files.readString(directory.resolve("mode")).trim();
+        delayMillis = Long.parseLong(Files.readString(directory.resolve("delay-ms")).trim());
+        if (!Arrays.asList("baseline", "outside", "inside").contains(mode) || delayMillis < 0 || delayMillis > 15000) {
+            throw new IllegalArgumentException("Invalid diagnostic mode/delay");
+        }
+        instrumentation.addTransformer(new Transformer());
+    }
+
+    public static void beforeClose(int osFd, boolean inside) {
+        if (osFd <= 2 || FIRED.get() || inside != mode.equals("inside")
+                || !Thread.currentThread().getName().startsWith("shared-write_")
+                || !Files.exists(directory.resolve("arm"))) {
+            return;
+        }
+        try {
+            String path = Files.readSymbolicLink(Path.of("/proc/self/fd/" + osFd)).toString();
+            if (!path.startsWith(directory.resolve("data/db/fault_o3~").toString())
+                    || Arrays.stream(Thread.currentThread().getStackTrace())
+                    .noneMatch(frame -> frame.getClassName().equals("io.questdb.cairo.O3Utils"))) {
+                return;
+            }
+            if (!FIRED.compareAndSet(false, true)) {
+                return;
+            }
+            var field = Class.forName("io.questdb.std.Files").getDeclaredField("fdCache");
+            field.setAccessible(true);
+            boolean held = Thread.holdsLock(field.get(null));
+            if (held != inside) {
+                throw new IllegalStateException("Unexpected FdCache ownership: " + held);
+            }
+            String details = "mode=" + mode + "\nthread=" + Thread.currentThread().getName()
+                    + "\nfd=" + osFd + "\npath=" + path + "\nmonitorHeld=" + held
+                    + "\nepochMs=" + System.currentTimeMillis() + "\nnanoTime=" + System.nanoTime()
+                    + "\n" + Arrays.toString(Thread.currentThread().getStackTrace()) + "\n";
+            Files.writeString(directory.resolve("fault-start"), details);
+            long start = System.nanoTime();
+            if (!mode.equals("baseline")) {
+                Thread.sleep(delayMillis);
+            }
+            Files.writeString(directory.resolve("fault-end"),
+                    "epochMs=" + System.currentTimeMillis() + "\nheldMs=" + (System.nanoTime() - start) / 1e6 + "\n");
+        } catch (Throwable error) {
+            error.printStackTrace();
+            try {
+                Files.writeString(directory.resolve("fault-error"), error.toString());
+            } catch (Exception ignored) {
+                // The harness also rejects a missing fault-end marker.
+            }
+        }
+    }
+
+    private static final class Transformer implements ClassFileTransformer {
+        @Override
+        public byte[] transform(ClassLoader loader, String name, Class<?> redefining,
+                                ProtectionDomain domain, byte[] bytes) {
+            boolean cache = name.equals("io/questdb/std/FdCache");
+            boolean o3 = name.equals("io/questdb/cairo/O3Utils");
+            if (!cache && !o3) {
+                return null;
+            }
+            ClassReader reader = new ClassReader(bytes);
+            ClassWriter writer = new ClassWriter(reader, ClassWriter.COMPUTE_MAXS);
+            int[] injections = {0};
+            reader.accept(new ClassVisitor(Opcodes.ASM9, writer) {
+                @Override
+                public MethodVisitor visitMethod(int access, String method, String descriptor,
+                                                 String signature, String[] exceptions) {
+                    MethodVisitor delegate = super.visitMethod(access, method, descriptor, signature, exceptions);
+                    boolean cacheClose = cache && method.equals("close") && descriptor.equals("(J)I");
+                    boolean o3Close = o3 && method.equals("close")
+                            && descriptor.equals("(Lio/questdb/std/FilesFacade;J)V");
+                    if (!cacheClose && !o3Close) {
+                        return delegate;
+                    }
+                    return new MethodVisitor(Opcodes.ASM9, delegate) {
+                        @Override
+                        public void visitCode() {
+                            super.visitCode();
+                            if (o3Close) {
+                                // The high 32 bits of QuestDB's unique fd contain the OS fd.
+                                super.visitVarInsn(Opcodes.LLOAD, 1);
+                                super.visitIntInsn(Opcodes.BIPUSH, 32);
+                                super.visitInsn(Opcodes.LUSHR);
+                                super.visitInsn(Opcodes.L2I);
+                                super.visitInsn(Opcodes.ICONST_0);
+                                hook();
+                            }
+                        }
+
+                        @Override
+                        public void visitMethodInsn(int opcode, String owner, String method,
+                                                    String desc, boolean isInterface) {
+                            if (cacheClose && opcode == Opcodes.INVOKESTATIC
+                                    && owner.equals("io/questdb/std/Files")
+                                    && method.equals("close0") && desc.equals("(I)I")) {
+                                // Preserve the native call's fd argument; the synchronized method's monitor is held.
+                                super.visitInsn(Opcodes.DUP);
+                                super.visitInsn(Opcodes.ICONST_1);
+                                hook();
+                            }
+                            super.visitMethodInsn(opcode, owner, method, desc, isInterface);
+                        }
+
+                        private void hook() {
+                            super.visitMethodInsn(Opcodes.INVOKESTATIC, "diagnostic/CloseFaultAgent",
+                                    "beforeClose", "(IZ)V", false);
+                            injections[0]++;
+                        }
+                    };
+                }
+            }, 0);
+            try {
+                Files.writeString(directory.resolve(cache ? "transform-cache" : "transform-o3"),
+                        Integer.toString(injections[0]));
+            } catch (Exception error) {
+                throw new IllegalStateException(error);
+            }
+            return writer.toByteArray();
+        }
+    }
+}

--- a/ci/diagnostics/fd_cache_close/MANIFEST.MF
+++ b/ci/diagnostics/fd_cache_close/MANIFEST.MF
@@ -1,0 +1,1 @@
+Premain-Class: diagnostic.CloseFaultAgent

--- a/ci/diagnostics/fd_cache_close/README.md
+++ b/ci/diagnostics/fd_cache_close/README.md
@@ -1,0 +1,157 @@
+# Controlled O3 close / FdCache experiment
+
+Local-only diagnostic harness. It does not edit QuestDB sources or the server
+JAR, change the existing fuzz test, or queue CI. Requires Linux, JDK 25, ASM
+9.8, Python with the system-test dependencies, and a built C client library.
+
+## Question and prediction
+
+Can one slow O3 file close stop otherwise unrelated QWP ingestion because
+`FdCache.close()` holds a process-wide monitor across native `Files.close0()`?
+
+The same six-second O3 delay should leave unrelated-table ACKs responsive
+outside the monitor, but delay ACKs that need the monitor when injected inside.
+The thread dump must connect the O3 lock owner to the affected network workers;
+elapsed time alone is insufficient evidence.
+
+## Fixed workload and controls
+
+Every trial launches a fresh server, pinned to three CPUs, with three HTTP
+workers, three shared-write workers and two WAL-apply workers. Heap is 256 MiB
+initial / 1 GiB maximum. All data, temporary files and artifacts are on the
+repository's ext4 volume, never `/tmp`.
+
+1. Create a 32-column WAL table `fault_o3`, insert 4,096 ordered rows, and wait
+   for application.
+2. Warm three separate QWP connections/writers on three unrelated tables.
+3. Arm a one-shot fault and insert 256 older rows into `fault_o3`.
+4. At an O3 shared-write worker's close of this table's data file, either inject
+   no delay (`baseline`), sleep outside `FdCache` (`outside`), or sleep immediately
+   before `Files.close0()` while holding `FdCache` (`inside`).
+5. Send one row per QWP connection, normally adding a column to force writer
+   schema/segment work. Measure publish-to-ACK completion, probe `/ping` on new
+   connections, capture a JVM thread dump, and validate all resulting rows.
+
+The reported ACK latency starts before row construction/publication and ends
+after `wait()` confirms the frame's ACK. It is not a measurement of just the
+socket round trip. Each `/ping` has a 500 ms timeout and a 100 ms inter-probe gap.
+
+The agent checks the actual file path, O3 call stack, shared-write thread name,
+and `Thread.holdsLock(Files.fdCache)`. Native calls are preserved. The injected
+sleep models time spent holding the monitor; it does **not** simulate an actual
+kernel close, slow disk, APFS, or memory pressure. All modes use the same agent.
+
+## Results, 2026-09-08
+
+Server JAR manifest: `12a33d651e51e2682e7a448c8db5168fc72dfad3`.
+Runtime: Corretto 25.0.4+7-LTS on Linux x86-64, not the original macOS/Temurin
+environment. Exact commands, binary hashes, runtime and CPU affinity are in
+each trial's `identity.json`.
+
+Nine primary trials used balanced order:
+`baseline, outside, inside, inside, baseline, outside, outside, inside, baseline`.
+
+| Injection | Trials | ACK latency, all three senders | Ping timeouts |
+|---|---:|---:|---:|
+| None | 3 | 24.5–34.0 ms | 0 |
+| Six seconds outside monitor | 3 | 24.2–29.8 ms | 0 |
+| Six seconds inside monitor | 3 | 6,012.7–6,034.3 ms | 10 per trial |
+
+All 13 completed trials (nine primary plus four controls below) recovered,
+acknowledged every probe frame, and passed row-count/value checks. Three earlier
+`smoke-*` setup attempts did not produce results and are not included.
+
+### Two propagation paths, not just exhausted HTTP workers
+
+In `inside-1`, all three HTTP workers were blocked in WAL segment-roll closes,
+waiting on the exact `FdCache` monitor held by the sleeping O3 worker.
+
+In `inside-2` and `inside-3`, one HTTP worker was blocked while closing an HTTP
+socket in the serial network dispatcher; the other two HTTP workers were idle.
+`Net.close()` also goes through `Files.close()` and the same monitor. The serial
+dispatcher cannot run on another worker while its current invocation is stuck.
+
+Four further trials used **unchanged-schema**, already-open QWP writers:
+
+- Send immediately: inside-monitor ACKs completed in 1.2–1.6 ms, showing ordinary
+  WAL appends do not inherently wait for O3. But subsequent fresh `/ping`
+  connections timed out. The dump showed `Net.accept()` blocked while registering
+  its socket through `FdCache.createUniqueFdNonCached()`.
+- Wait 1.2 seconds after the fault, allowing the ping connection to block the
+  dispatcher, then send on the existing QWP connections: all three ACKs waited
+  4,793.5–4,793.9 ms, the remaining fault duration. No schema change was needed.
+- Corresponding outside-monitor controls acknowledged in 1.7–3.9 ms immediately
+  and 0.6–1.6 ms after 1.2 seconds, with no ping timeouts.
+
+The fresh-connection probe is therefore an explicit participant in the second
+mechanism, not a passive observer. New SQL/HTTP connections and disconnects can
+encounter the same path in real workloads.
+
+Source chain at the pinned server revision:
+
+- `O3CopyJob.copyTail` -> `O3Utils.close` -> `Files.close` -> synchronized
+  `FdCache.close` -> native `Files.close0`.
+- WAL rolling: `WalWriter.openColumnFiles` -> `MemoryPMARImpl.close` ->
+  `Vm.bestEffortClose` -> `Files.close`.
+- Socket acceptance: `Net.accept` -> `Files.createUniqueFd` -> synchronized
+  `FdCache.createUniqueFdNonCached`.
+- `SynchronizedJob.run` holds its serial-job ownership until `runSerially`
+  returns. Both Linux and macOS dispatchers use the shared accept path.
+
+### Interpretation and limits
+
+**Established:** a slow O3 close under the global FD monitor can delay unrelated
+WAL ingestion directly, or stall the serial dispatcher and thereby existing
+network connections. Slowing O3 outside that monitor did not have these effects.
+
+**Not established:** that this caused Azure build 266336's original 74.7-second
+interruption or 120-second close-drain failure. Nor does this identify what made
+the original native file operations slow. The later CI O3/FdCache dump is from
+another test. The macOS short-onset capture showed filesystem operations, not
+this induced monitor-wait signature.
+
+The preflight found high host-wide I/O pressure (full PSI avg10 approximately
+62–74% during accepted trials), and the repository volume was 98% full, with
+about 44 GiB available before the experiment. Those remain systemic caveats,
+not evidence that this test saturated disk. Interleaved controls completed
+quickly despite that background. The independent observer's maximum gap was
+103.1 ms; maximum JVM safepoint across complete runs, including startup, was
+67.6 ms. Neither explains the six-second delay.
+
+This is synchronization evidence, not a hardware-bottleneck study or a
+production optimization. CPU frequency/thermals, memory bandwidth, controller
+queues, device errors and per-process storage latency were not measured.
+Host CPU/memory/I/O PSI, memory/VM statistics and disk counters are retained at
+100 ms intervals; they cannot attribute host-wide pressure to QuestDB.
+
+## Re-run
+
+From the client repository, set paths to an ASM 9.8 JAR and the pinned QuestDB
+JAR. Use a new result directory for each invocation; existing directories are
+rejected. Choose three available physical cores for `taskset` on your machine.
+
+```bash
+export ASM_JAR=/path/to/asm-9.8.jar
+export SERVER_JAR=/path/to/questdb.jar
+export TMPDIR="$PWD/build-exp/fd-cache-close/tmp"
+mkdir -p "$TMPDIR" build-exp/fd-cache-close/classes
+javac -J-Djava.io.tmpdir="$TMPDIR" -cp "$ASM_JAR" \
+  -d build-exp/fd-cache-close/classes ci/diagnostics/fd_cache_close/CloseFaultAgent.java
+jar -J-Djava.io.tmpdir="$TMPDIR" --create --file build-exp/fd-cache-close/agent.jar \
+  --manifest ci/diagnostics/fd_cache_close/MANIFEST.MF \
+  -C build-exp/fd-cache-close/classes .
+PYTHONDONTWRITEBYTECODE=1 taskset -c 0-2 python3 ci/diagnostics/fd_cache_close/run.py \
+  build-exp/fd-cache-close/new-inside inside \
+  --server "$SERVER_JAR" --agent build-exp/fd-cache-close/agent.jar --asm "$ASM_JAR"
+python3 ci/diagnostics/fd_cache_close/analyze.py build-exp/fd-cache-close
+```
+
+Repeat with `baseline` and `outside`, using fresh directory names. For the
+dispatcher controls, add `--probe-schema stable`, then also
+`--probe-delay-ms 1200`. The default delay is 6,000 ms; the agent rejects delays
+above 15 seconds. Do not run this agent against a production instance.
+
+Artifacts are retained under `build-exp/fd-cache-close/`: `analysis.json`, each
+trial's `result.json`, `events.json`, `fault-start`, `fault-end`, `server.log`
+(including the thread dump), `jvm-pauses.log`, `host.jsonl` and `identity.json`.
+No CI changes or production fixes are included.

--- a/ci/diagnostics/fd_cache_close/analyze.py
+++ b/ci/diagnostics/fd_cache_close/analyze.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Summarize completed trials and independently inspect their thread dumps."""
+import argparse
+from collections import defaultdict
+import json
+from pathlib import Path
+import re
+import statistics
+
+
+def thread_blocks(log):
+    return dict(re.findall(r'^"([^"]+)"([^\n]*\n.*?)(?=\n\n)', log, re.M | re.S))
+
+
+def analyze(root):
+    groups = defaultdict(list)
+    trials = []
+    for path in sorted(root.glob('*/result.json')):
+        result = json.loads(path.read_text())
+        directory = path.parent
+        blocks = thread_blocks((directory / 'server.log').read_text())
+        fault = result['fault']
+        owner = blocks.get(fault['thread'], '')
+        owner_ids = re.findall(r'- locked <([^>]+)> \(a io.questdb.std.FdCache\)', owner)
+        network_waiters = []
+        dispatcher_waiters = []
+        for name, block in blocks.items():
+            if name.startswith('shared-network_') and any(
+                    f'- waiting to lock <{monitor}> (a io.questdb.std.FdCache)' in block
+                    for monitor in owner_ids):
+                network_waiters.append(name)
+                if 'io.questdb.network.IODispatcherLinux.runSerially' in block:
+                    dispatcher_waiters.append(name)
+        pauses = [int(value) / 1e6 for value in re.findall(
+            r'Total: (\d+) ns', (directory / 'jvm-pauses.log').read_text())]
+        gaps = []
+        io_pressure = []
+        prior = None
+        with (directory / 'host.jsonl').open() as stream:
+            for line in stream:
+                sample = json.loads(line)
+                if prior is not None:
+                    gaps.append(sample['epoch_ms'] - prior)
+                prior = sample['epoch_ms']
+                io_pressure.extend(float(value) for value in re.findall(
+                    r'^full avg10=([\d.]+)', sample['pressure/io'], re.M))
+        assert result['correctness'] == 'passed'
+        assert fault['monitorHeld'] == str(result['mode'] == 'inside').lower()
+        assert len(result['ack_ms']) == 3
+        card = dict(directory=directory.name, mode=result['mode'],
+                    probe_schema=result.get('probe_schema', 'add'),
+                    probe_delay_ms=result.get('probe_delay_ms', 0),
+                    ack_ms=result['ack_ms'], ping_errors=result['ping_errors'],
+                    max_ping_ms=result['max_ping_ms'],
+                    delay_observed_ms=float(result['fault_end']['heldMs']),
+                    network_fd_waiters=network_waiters, dispatcher_fd_waiters=dispatcher_waiters,
+                    max_safepoint_ms=max(pauses, default=0),
+                    max_observer_gap_ms=max(gaps, default=0),
+                    host_io_full_avg10_range=[min(io_pressure), max(io_pressure)])
+        trials.append(card)
+        groups[(card['mode'], card['probe_schema'], card['probe_delay_ms'])].append(card)
+    summary = []
+    for (mode, schema, delay), cards in sorted(groups.items()):
+        latencies = [latency for card in cards for latency in card['ack_ms']]
+        summary.append(dict(mode=mode, probe_schema=schema, probe_delay_ms=delay, runs=len(cards),
+                            ack_ms_range=[min(latencies), max(latencies)],
+                            ack_ms_median=statistics.median(latencies),
+                            ping_errors=sum(card['ping_errors'] for card in cards),
+                            max_ping_ms=max(card['max_ping_ms'] for card in cards)))
+    return dict(summary=summary, trials=trials)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('root', type=Path)
+    args = parser.parse_args()
+    result = analyze(args.root)
+    (args.root / 'analysis.json').write_text(json.dumps(result, indent=2))
+    print(json.dumps(result, indent=2))

--- a/ci/diagnostics/fd_cache_close/run.py
+++ b/ci/diagnostics/fd_cache_close/run.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Fixed-work local fault experiment, not a macOS/disk reproduction."""
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+from pathlib import Path
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.parse
+import urllib.request
+
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO / 'system_test'))
+import questdb_line_sender as qls
+
+
+def await_condition(predicate, timeout=30):
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        if time.monotonic() > deadline:
+            raise TimeoutError('Condition not reached')
+        time.sleep(0.02)
+
+
+def fields(path):
+    return dict(line.split('=', 1) for line in path.read_text().splitlines() if '=' in line and not line.startswith('['))
+
+
+def run(args):
+    directory = args.directory.resolve()
+    directory.mkdir(parents=True, exist_ok=False)
+    (directory / 'tmp').mkdir()
+    (directory / 'data/conf').mkdir(parents=True)
+    (directory / 'mode').write_text(args.mode)
+    (directory / 'delay-ms').write_text(str(args.delay_ms))
+    with socket.socket() as reservation:
+        reservation.bind(('127.0.0.1', 0))
+        port = reservation.getsockname()[1]
+    (directory / 'data/conf/server.conf').write_text(f'''
+http.bind.to=127.0.0.1:{port}
+http.min.enabled=false
+pg.enabled=false
+line.tcp.enabled=false
+line.udp.enabled=false
+qwp.udp.enabled=false
+telemetry.enabled=false
+shared.network.worker.count=3
+shared.write.worker.count=3
+wal.apply.worker.count=2
+cairo.commit.lag=0
+cairo.writer.data.append.page.size=64k
+cairo.writer.data.index.value.append.page.size=64k
+''')
+    command = [args.java, '-Xms256m', '-Xmx1g', '-XX:ActiveProcessorCount=3',
+               '-XX:+UnlockExperimentalVMOptions', '-ea',
+               f'-Djava.io.tmpdir={directory / "tmp"}',
+               '--add-exports=java.base/jdk.internal.vm=io.questdb',
+               '-cp', str(args.asm.resolve()),
+               '--add-reads=io.questdb=ALL-UNNAMED',
+               '--add-opens=io.questdb/io.questdb.std=ALL-UNNAMED',
+               f'-javaagent:{args.agent.resolve()}={directory}',
+               f'-Xlog:gc*,safepoint=debug:file={directory / "jvm-pauses.log"}:utctime,uptimemillis,level,tags',
+               '-p', str(args.server.resolve()), '-m', 'io.questdb/io.questdb.ServerMain',
+               '-d', str(directory / 'data')]
+    environment = dict(os.environ, TMPDIR=str(directory / 'tmp'))
+    identity = dict(command=command, mode=args.mode, delay_ms=args.delay_ms, probe_schema=args.probe_schema,
+                    probe_delay_ms=args.probe_delay_ms,
+                    affinity=sorted(os.sched_getaffinity(0)), uname=list(os.uname()),
+                    server_sha256=hashlib.sha256(args.server.read_bytes()).hexdigest(),
+                    agent_sha256=hashlib.sha256(args.agent.read_bytes()).hexdigest(),
+                    harness_sha256=hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+                    client_sha256=hashlib.sha256((REPO / 'build/libquestdb_client.so').read_bytes()).hexdigest(),
+                    java_version=subprocess.check_output([args.java, '-version'], stderr=subprocess.STDOUT, text=True))
+    assert len(identity['affinity']) == 3, 'Launch under taskset on exactly three CPUs'
+    (directory / 'identity.json').write_text(json.dumps(identity, indent=2))
+    events = []
+    event_lock = threading.Lock()
+    stop = threading.Event()
+
+    def record(kind, **values):
+        with event_lock:
+            events.append(dict(kind=kind, epoch_ms=time.time_ns() / 1e6, **values))
+
+    def http(path, timeout=20):
+        with urllib.request.urlopen(f'http://127.0.0.1:{port}{path}', timeout=timeout) as response:
+            return response.read()
+
+    def sql(query):
+        return json.loads(http('/exec?' + urllib.parse.urlencode({'query': query})))
+
+    def count(table, expected):
+        return sql(f'select count() from {table}')['dataset'][0][0] == expected
+
+    def observer():
+        # Host pressure is context, not attribution to this server.
+        with (directory / 'host.jsonl').open('w') as output:
+            while not stop.wait(0.1):
+                sample = dict(epoch_ms=time.time_ns() / 1e6)
+                for name in ['pressure/cpu', 'pressure/memory', 'pressure/io', 'meminfo', 'vmstat', 'diskstats']:
+                    sample[name] = Path('/proc', name).read_text()
+                output.write(json.dumps(sample) + '\n')
+
+    def ping_loop():
+        while not stop.is_set():
+            start = time.monotonic()
+            try:
+                http('/ping', timeout=0.5)
+                record('ping', duration_ms=(time.monotonic() - start) * 1000, error=None)
+            except Exception as error:
+                record('ping', duration_ms=(time.monotonic() - start) * 1000, error=str(error))
+            stop.wait(0.1)
+
+    def sender(name):
+        result = qls.Sender.from_conf(
+            f'ws::addr=127.0.0.1:{port};sender_id={name};sf_dir={directory / name};')
+        result.__enter__()
+        return result
+
+    def send(producer, table, new_column=False, row_id=1):
+        start = time.monotonic()
+        record('send-start', table=table, new_column=new_column, row_id=row_id)
+        producer.table(table).column('id', row_id)
+        if new_column:
+            producer.column('added', 42)
+        producer.at(1704110400000000000 + (1000 if row_id == 2 else 0))
+        producer.flush()
+        fsn = producer.published_fsn()
+        record('published', table=table, fsn=fsn)
+        producer.wait(timeout_millis=20000)
+        assert producer.acked_fsn() == fsn
+        error = producer.poll_qwp_ws_error()
+        assert error is None, str(error)
+        elapsed = (time.monotonic() - start) * 1000
+        record('acked', table=table, fsn=fsn, duration_ms=elapsed, new_column=new_column)
+        return elapsed
+
+    senders = []
+    threads = []
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=4)
+    process = None
+    try:
+        with (directory / 'server.log').open('w') as output:
+            process = subprocess.Popen(command, env=environment, cwd=directory, stdout=output, stderr=subprocess.STDOUT)
+            def ready():
+                if process.poll() is not None:
+                    raise RuntimeError(f'Server exited: {process.returncode}; inspect {directory / "server.log"}')
+                try:
+                    http('/ping', timeout=0.25)
+                    return True
+                except OSError:
+                    return False
+            await_condition(ready)
+            record('server-ready', pid=process.pid, version=sql('select build()'))
+            columns = ','.join(f'c{i} long' for i in range(32))
+            sql(f'create table fault_o3 ({columns}, ts timestamp) timestamp(ts) partition by day wal')
+            values = ','.join('x' for _ in range(32))
+            sql(f"insert into fault_o3 select {values}, timestamp_sequence('2024-01-01T12:00:00.000Z', 1000L) from long_sequence(4096)")
+            await_condition(lambda: count('fault_o3', 4096))
+            for i in range(3):
+                sql(f'create table probe{i} (id long, ts timestamp) timestamp(ts) partition by day wal')
+                senders.append(sender(f'producer{i}'))
+                send(senders[-1], f'probe{i}')
+                await_condition(lambda i=i: count(f'probe{i}', 1))
+            for target in (observer, ping_loop):
+                thread = threading.Thread(target=target, daemon=True)
+                thread.start()
+                threads.append(thread)
+            time.sleep(0.5)
+            (directory / 'arm').touch()
+            trigger = pool.submit(sql, f"insert into fault_o3 select {values}, timestamp_sequence('2024-01-01T00:00:00.000Z', 1000L) from long_sequence(256)")
+            await_condition(lambda: (directory / 'fault-start').exists(), timeout=15)
+            record('observed-fault-start')
+            time.sleep(args.probe_delay_ms / 1000)
+            probes = [pool.submit(send, producer, f'probe{i}', args.probe_schema == 'add', 2)
+                      for i, producer in enumerate(senders)]
+            time.sleep(0.4)
+            record('thread-dump-request')
+            os.kill(process.pid, signal.SIGQUIT)
+            latencies = [probe.result(timeout=25) for probe in probes]
+            trigger.result(timeout=25)
+            await_condition(lambda: (directory / 'fault-end').exists())
+            assert not (directory / 'fault-error').exists()
+            assert (directory / 'transform-cache').read_text() == '2'
+            assert (directory / 'transform-o3').read_text() == '1'
+            start_details = fields(directory / 'fault-start')
+            assert start_details['monitorHeld'] == str(args.mode == 'inside').lower()
+            await_condition(lambda: count('fault_o3', 4352))
+            for i in range(3):
+                await_condition(lambda i=i: count(f'probe{i}', 2))
+                if args.probe_schema == 'add':
+                    assert sql(f'select id, added from probe{i} order by id')['dataset'] == [[1, None], [2, 42]]
+                else:
+                    assert sql(f'select id from probe{i} order by id')['dataset'] == [[1], [2]]
+            time.sleep(0.5)
+            stop.set()
+            for thread in threads:
+                thread.join(timeout=2)
+            pings = [event for event in events if event['kind'] == 'ping']
+            result = dict(mode=args.mode, probe_schema=args.probe_schema, probe_delay_ms=args.probe_delay_ms,
+                          ack_ms=latencies,
+                          ping_errors=sum(p['error'] is not None for p in pings),
+                          max_ping_ms=max(p['duration_ms'] for p in pings),
+                          fault=start_details, fault_end=fields(directory / 'fault-end'), correctness='passed')
+            (directory / 'result.json').write_text(json.dumps(result, indent=2))
+            print(json.dumps({key: value for key, value in result.items() if key not in ('fault', 'fault_end')}
+                             | {'directory': str(directory), 'monitor_held': start_details['monitorHeld']}), flush=True)
+    finally:
+        stop.set()
+        # Shutdown only this harness's child JVM, including on failed setup/fault validation.
+        if process is not None and process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=25)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+        pool.shutdown(wait=True, cancel_futures=True)
+        for producer in senders:
+            producer.close(False)
+        for thread in threads:
+            thread.join(timeout=2)
+        (directory / 'events.json').write_text(json.dumps(events, indent=2))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('directory', type=Path)
+    parser.add_argument('mode', choices=['baseline', 'outside', 'inside'])
+    parser.add_argument('--server', type=Path, required=True)
+    parser.add_argument('--agent', type=Path, required=True)
+    parser.add_argument('--asm', type=Path, required=True)
+    parser.add_argument('--java', default='java')
+    parser.add_argument('--delay-ms', type=int, default=6000)
+    parser.add_argument('--probe-schema', choices=['add', 'stable'], default='add')
+    parser.add_argument('--probe-delay-ms', type=int, default=0)
+    run(parser.parse_args())

--- a/ci/diagnostics/kernel_wait_preflight.py
+++ b/ci/diagnostics/kernel_wait_preflight.py
@@ -26,10 +26,13 @@ def raw_command(time_limit=25):
             '-timelimit', str(time_limit), '-noProcessingWhileSampling']
 
 
-def decode_command(directory):
-    return ['/usr/sbin/spindump', '-i', str(directory / 'spindump.raw'),
+def decode_command(directory, symbols=None):
+    args = ['/usr/sbin/spindump', '-i', str(directory / 'spindump.raw'),
             '-o', str(directory / 'spindump.txt'), '-timeline', '-symbolicate',
             '-noBinary', '-timestampsInCallTrees', 'all', '-timelimit', '60']
+    if symbols is not None:
+        args.extend(['-symbols', str(symbols)])
+    return args
 
 
 def inspect_report(report):
@@ -85,6 +88,7 @@ def main():
     parser.add_argument('--record', action='store_true')
     parser.add_argument('--record-raw', action='store_true')
     parser.add_argument('--decode', action='store_true')
+    parser.add_argument('--symbols', type=Path)
     parser.add_argument('--limit', type=int, choices=(25, 45), default=45)
     args = parser.parse_args()
     if args.record_raw:
@@ -109,7 +113,7 @@ def main():
         sys.stdout.buffer.write(result.stdout)
         return
     if args.decode:
-        subprocess.run(decode_command(args.directory), timeout=65, check=True)
+        subprocess.run(decode_command(args.directory, args.symbols), timeout=65, check=True)
         result = inspect_report((args.directory / 'spindump.txt').read_text(errors='replace'))
         (args.directory / 'decode-validation.json').write_text(json.dumps(result) + '\n')
         if not result['named_kernel_frame_lines']:

--- a/ci/diagnostics/kernel_wait_preflight.py
+++ b/ci/diagnostics/kernel_wait_preflight.py
@@ -11,18 +11,25 @@ import sys
 import time
 
 
-def command(directory):
+def command(directory, time_limit=45):
     return ['/usr/sbin/spindump', '-notarget', '3', '20',
             '-o', str(directory / 'spindump.txt'), '-timeline', '-symbolicate',
-            '-timelimit', '45', '-timestampsInCallTrees', 'all']
+            '-timelimit', str(time_limit), '-timestampsInCallTrees', 'all',
+            '-noProcessingWhileSampling']
 
 
 def inspect_report(report):
     # This is an access check, not proof of a filesystem bottleneck. Keep the
     # actual text so kernel symbols and thread identities can be inspected.
-    frames = [line.strip() for line in report.splitlines()
-              if re.match(r'^\s*\d+\s+\*', line)]
-    named = [line for line in frames if re.match(r'^\d+\s+\*[A-Za-z_]', line)]
+    frames, named = [], []
+    for line in report.splitlines():
+        # Report v60 uses '*156 function'; older reports can place '*' after
+        # the count. An image-list entry '*0xffff...' is not a sampled frame.
+        match = re.match(r'^\s*(?:\*\d+\s+|\d+\s+\*)(.*)', line)
+        if match:
+            frames.append(line.strip())
+            if re.match(r'[A-Za-z_]', match[1]):
+                named.append(line.strip())
     return dict(kernel_frame_lines=len(frames), named_kernel_frame_lines=len(named),
                 apfs_present='apfs_transaction_flusher' in report,
                 virtio_present='AppleVirtIO' in report,
@@ -62,11 +69,16 @@ def main():
     parser.add_argument('directory', type=Path)
     parser.add_argument('--workload', action='store_true')
     parser.add_argument('--record', action='store_true')
+    parser.add_argument('--limit', type=int, choices=(25, 45), default=45)
     args = parser.parse_args()
     if args.record:
         # This small controller runs as root, so subprocess timeout can kill
         # and reap its actual recorder child, not merely an intervening sudo.
-        subprocess.run(command(args.directory), timeout=60, check=True)
+        subprocess.run(command(args.directory, args.limit), timeout=args.limit+5, check=True)
+        result = inspect_report((args.directory / 'spindump.txt').read_text(errors='replace'))
+        (args.directory / 'recorder-validation.json').write_text(json.dumps(result) + '\n')
+        if not result['named_kernel_frame_lines']:
+            raise RuntimeError('recorder returned no named kernel frames')
         return
     if args.workload:
         workload(args.directory)
@@ -84,7 +96,7 @@ def main():
                                  env=environment)
     (directory / 'spindump-help.txt').write_text(help_result.stdout)
     for option in ('-notarget', '-o <path>', '-timeline', '-symbolicate',
-                   '-timelimit', '-timestampsincalltrees'):
+                   '-timelimit', '-timestampsincalltrees', '-noprocessingwhilesampling'):
         if option not in help_result.stdout.lower():
             raise RuntimeError(f'installed recorder does not advertise {option}')
     child = None

--- a/ci/diagnostics/kernel_wait_preflight.py
+++ b/ci/diagnostics/kernel_wait_preflight.py
@@ -18,6 +18,20 @@ def command(directory, time_limit=45):
             '-noProcessingWhileSampling']
 
 
+def raw_command(directory, time_limit=25):
+    # Save the sample before expensive symbol lookup. The installed Mac help
+    # explicitly supports binary-only output and deferred symbolication.
+    return ['/usr/sbin/spindump', '-notarget', '3', '20',
+            '-o', str(directory / 'spindump.raw'), '-noText', '-noSymbolicate',
+            '-timelimit', str(time_limit), '-noProcessingWhileSampling']
+
+
+def decode_command(directory):
+    return ['/usr/sbin/spindump', '-i', str(directory / 'spindump.raw'),
+            '-o', str(directory / 'spindump.txt'), '-timeline', '-symbolicate',
+            '-noBinary', '-timestampsInCallTrees', 'all', '-timelimit', '60']
+
+
 def inspect_report(report):
     # This is an access check, not proof of a filesystem bottleneck. Keep the
     # actual text so kernel symbols and thread identities can be inspected.
@@ -69,8 +83,26 @@ def main():
     parser.add_argument('directory', type=Path)
     parser.add_argument('--workload', action='store_true')
     parser.add_argument('--record', action='store_true')
+    parser.add_argument('--record-raw', action='store_true')
+    parser.add_argument('--decode', action='store_true')
     parser.add_argument('--limit', type=int, choices=(25, 45), default=45)
     args = parser.parse_args()
+    if args.record_raw:
+        subprocess.run(raw_command(args.directory, args.limit), timeout=args.limit+5, check=True)
+        size = (args.directory / 'spindump.raw').stat().st_size
+        if not size:
+            raise RuntimeError('empty raw kernel capture')
+        # Nonempty is transport validation only, not proof of usable stacks.
+        (args.directory / 'recorder-validation.json').write_text(json.dumps(
+            dict(format='raw', bytes=size, decoded=False)) + '\n')
+        return
+    if args.decode:
+        subprocess.run(decode_command(args.directory), timeout=65, check=True)
+        result = inspect_report((args.directory / 'spindump.txt').read_text(errors='replace'))
+        (args.directory / 'decode-validation.json').write_text(json.dumps(result) + '\n')
+        if not result['named_kernel_frame_lines']:
+            raise RuntimeError('decoded capture has no named kernel frames')
+        return
     if args.record:
         # This small controller runs as root, so subprocess timeout can kill
         # and reap its actual recorder child, not merely an intervening sudo.

--- a/ci/diagnostics/kernel_wait_preflight.py
+++ b/ci/diagnostics/kernel_wait_preflight.py
@@ -13,7 +13,8 @@ import time
 
 def command(directory):
     return ['/usr/sbin/spindump', '-notarget', '3', '20',
-            '-file', str(directory / 'spindump.txt'), '-timeline', '-symbolicate']
+            '-o', str(directory / 'spindump.txt'), '-timeline', '-symbolicate',
+            '-timelimit', '45', '-timestampsInCallTrees', 'all']
 
 
 def inspect_report(report):
@@ -82,7 +83,8 @@ def main():
                                  stderr=subprocess.STDOUT, text=True, timeout=10,
                                  env=environment)
     (directory / 'spindump-help.txt').write_text(help_result.stdout)
-    for option in ('-notarget', '-file', '-timeline', '-symbolicate'):
+    for option in ('-notarget', '-o <path>', '-timeline', '-symbolicate',
+                   '-timelimit', '-timestampsincalltrees'):
         if option not in help_result.stdout.lower():
             raise RuntimeError(f'installed recorder does not advertise {option}')
     child = None

--- a/ci/diagnostics/kernel_wait_preflight.py
+++ b/ci/diagnostics/kernel_wait_preflight.py
@@ -18,11 +18,11 @@ def command(directory, time_limit=45):
             '-noProcessingWhileSampling']
 
 
-def raw_command(directory, time_limit=25):
+def raw_command(time_limit=25):
     # Save the sample before expensive symbol lookup. The installed Mac help
     # explicitly supports binary-only output and deferred symbolication.
     return ['/usr/sbin/spindump', '-notarget', '3', '20',
-            '-o', str(directory / 'spindump.raw'), '-noText', '-noSymbolicate',
+            '-noFile', '-noText', '-noSymbolicate',
             '-timelimit', str(time_limit), '-noProcessingWhileSampling']
 
 
@@ -88,13 +88,25 @@ def main():
     parser.add_argument('--limit', type=int, choices=(25, 45), default=45)
     args = parser.parse_args()
     if args.record_raw:
-        subprocess.run(raw_command(args.directory, args.limit), timeout=args.limit+5, check=True)
-        size = (args.directory / 'spindump.raw').stat().st_size
-        if not size:
+        try:
+            result = subprocess.run(raw_command(args.limit), timeout=args.limit+5,
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            # Preserve partial bytes and the actual native-tool diagnostic,
+            # not only the wrapper's traceback. Parent marks them incomplete.
+            if exc.stdout:
+                sys.stdout.buffer.write(exc.stdout)
+            if exc.stderr:
+                sys.stderr.buffer.write(exc.stderr)
+            raise
+        if not result.stdout:
             raise RuntimeError('empty raw kernel capture')
-        # Nonempty is transport validation only, not proof of usable stacks.
-        (args.directory / 'recorder-validation.json').write_text(json.dumps(
-            dict(format='raw', bytes=size, decoded=False)) + '\n')
+        if len(result.stdout) > 64 * 1024**2:
+            raise RuntimeError('raw kernel capture exceeds 64 MiB artifact limit')
+        # Parent drains these pipes in memory. Never open an output file in
+        # the recording process: the filesystem is the resource under test.
+        sys.stderr.buffer.write(result.stderr)
+        sys.stdout.buffer.write(result.stdout)
         return
     if args.decode:
         subprocess.run(decode_command(args.directory), timeout=65, check=True)

--- a/ci/diagnostics/kernel_wait_preflight.py
+++ b/ci/diagnostics/kernel_wait_preflight.py
@@ -1,0 +1,125 @@
+"""Check hosted-Mac kernel-stack access before paying for another server build."""
+import argparse
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+
+def command(directory):
+    return ['/usr/sbin/spindump', '-notarget', '3', '20',
+            '-file', str(directory / 'spindump.txt'), '-timeline', '-symbolicate']
+
+
+def inspect_report(report):
+    # This is an access check, not proof of a filesystem bottleneck. Keep the
+    # actual text so kernel symbols and thread identities can be inspected.
+    frames = [line.strip() for line in report.splitlines()
+              if re.match(r'^\s*\d+\s+\*', line)]
+    named = [line for line in frames if re.match(r'^\d+\s+\*[A-Za-z_]', line)]
+    return dict(kernel_frame_lines=len(frames), named_kernel_frame_lines=len(named),
+                apfs_present='apfs_transaction_flusher' in report,
+                virtio_present='AppleVirtIO' in report,
+                kernel_examples=named[:10])
+
+
+def workload(directory):
+    payload = os.urandom(65536)
+    fd = os.open(directory / 'smoke.data', os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        (directory / 'workload-ready').touch()
+        started = time.monotonic()
+        with (directory / 'workload.jsonl').open('x') as log:
+            # At most 6.25 MiB application writes, one small file, ten seconds
+            # before starting another cycle. No full-disk or pressure stress.
+            for cycle in range(100):
+                if time.monotonic() - started >= 10:
+                    break
+                for name, operation in (
+                        ('truncate', lambda: os.ftruncate(fd, 0)),
+                        ('write', lambda: os.pwrite(fd, payload, 0)),
+                        ('fsync', lambda: os.fsync(fd))):
+                    begin = time.monotonic_ns()
+                    result = operation()
+                    if name == 'write' and result != len(payload):
+                        raise RuntimeError('short smoke write')
+                    log.write(json.dumps(dict(cycle=cycle, stage=name,
+                        start_ns=begin, elapsed_ns=time.monotonic_ns()-begin)) + '\n')
+                    log.flush()
+                time.sleep(0.05)
+    finally:
+        os.close(fd)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('directory', type=Path)
+    parser.add_argument('--workload', action='store_true')
+    parser.add_argument('--record', action='store_true')
+    args = parser.parse_args()
+    if args.record:
+        # This small controller runs as root, so subprocess timeout can kill
+        # and reap its actual recorder child, not merely an intervening sudo.
+        subprocess.run(command(args.directory), timeout=60, check=True)
+        return
+    if args.workload:
+        workload(args.directory)
+        return
+    if sys.platform != 'darwin':
+        raise RuntimeError('kernel-stack preflight requires macOS')
+    directory = args.directory.resolve()
+    directory.mkdir(parents=True, exist_ok=False)
+    (directory / 'tmp').mkdir()
+    environment = dict(os.environ, TMPDIR=str(directory / 'tmp'))
+    if shutil.disk_usage(directory).free < 2 * 1024**3:
+        raise RuntimeError('less than 2 GiB free for recorder preflight')
+    help_result = subprocess.run(['/usr/sbin/spindump', '-h'], stdout=subprocess.PIPE,
+                                 stderr=subprocess.STDOUT, text=True, timeout=10,
+                                 env=environment)
+    (directory / 'spindump-help.txt').write_text(help_result.stdout)
+    for option in ('-notarget', '-file', '-timeline', '-symbolicate'):
+        if option not in help_result.stdout.lower():
+            raise RuntimeError(f'installed recorder does not advertise {option}')
+    child = None
+    with (directory / 'workload-process.log').open('x') as child_log:
+        try:
+            child = subprocess.Popen([sys.executable, __file__, str(directory), '--workload'],
+                                     stdout=child_log, stderr=subprocess.STDOUT, env=environment)
+            deadline = time.monotonic() + 5
+            while not (directory / 'workload-ready').exists():
+                if child.poll() is not None or time.monotonic() > deadline:
+                    raise RuntimeError('filesystem smoke helper did not become ready')
+                time.sleep(0.05)
+            with (directory / 'recorder.log').open('x') as recorder_log:
+                subprocess.run(['sudo', '-n', 'env',
+                                f'TMPDIR={directory / "tmp"}', sys.executable,
+                                str(Path(__file__).resolve()), str(directory), '--record'],
+                               stdout=recorder_log,
+                               stderr=subprocess.STDOUT, timeout=75, check=True,
+                               env=environment)
+            child.wait(timeout=15)
+            if child.returncode:
+                raise RuntimeError(f'smoke helper failed: {child.returncode}')
+        finally:
+            if child is not None and child.poll() is None:
+                child.terminate()
+                try:
+                    child.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    child.kill()
+                    child.wait(timeout=3)
+    report = (directory / 'spindump.txt').read_text(errors='replace')
+    result = dict(platform=platform.platform(), command=command(directory),
+                  **inspect_report(report))
+    (directory / 'validation.json').write_text(json.dumps(result, indent=2) + '\n')
+    if not result['named_kernel_frame_lines']:
+        raise RuntimeError('no named kernel frames: do not claim kernel-wait access')
+
+
+if __name__ == '__main__':
+    main()

--- a/ci/diagnostics/show_columns/ProbeTest.java
+++ b/ci/diagnostics/show_columns/ProbeTest.java
@@ -1,0 +1,15 @@
+import io.questdb.griffin.engine.table.ShowColumnsProbe;
+
+/** Isolated observer test: injected delay is never included in the CI overlay. */
+public class ProbeTest {
+    public static void main(String[] args) throws Exception {
+        var fast = ShowColumnsProbe.begin("fast");
+        fast.stage("cursor-ready");
+        fast.finish("cursor-close");
+        var slow = ShowColumnsProbe.begin("injected-test-only");
+        slow.stage("metadata-read-lock-wait");
+        Thread.sleep(6200);
+        slow.finish("open-error:Injected");
+        Thread.sleep(300);
+    }
+}

--- a/ci/diagnostics/show_columns/README.md
+++ b/ci/diagnostics/show_columns/README.md
@@ -40,6 +40,13 @@ observer. The queue is bounded to 8192 records and loss is explicitly rejected.
 
 The observer is a JVM daemon and can be paused with the JVM. Its file writes can
 also block. Missing telemetry is a diagnostic failure, not a healthy result.
+After first observing telemetry, the external watchdog also captures when the
+TSV stops advancing for five seconds, even without a Java slow-query marker.
+This detects loss of observer progress, not its cause: JVM suspension, observer
+scheduling, and blocked diagnostic file output remain distinguishable suspects.
+It does not cover a pause before the helper first publishes data, and cannot
+capture during a host-wide pause that prevents the watchdog itself from running.
+Isolated one-second ping failures still do not trigger this arm.
 The harness retains independent Python heartbeat and JVM pause logs. An exe log
 without cursor-enter can indicate delay before the probe, or lost/delayed
 telemetry; it is not evidence of a metadata lock wait.

--- a/ci/diagnostics/show_columns/README.md
+++ b/ci/diagnostics/show_columns/README.md
@@ -1,0 +1,71 @@
+# Focused SHOW COLUMNS stage probe
+
+Purpose: locate loss of progress in the original slow metadata query, not treat
+later short ping stalls as a reproduction. No production fix or timeout change.
+
+`prepare.py` reads one source file from server revision
+`12a33d651e51e2682e7a448c8db5168fc72dfad3` using git show, checks each replacement
+anchor occurs exactly once, and compiles an isolated `--patch-module io.questdb`
+JAR against the built server. It preserves source/JAR hashes and patched source
+in the output directory. No server checkout files are changed. Compilation uses
+the pinned server's JetBrains annotations 17.0.0 dependency from Maven's cache.
+
+Only `QWP_WS_SHOW_COLUMNS_OVERLAY` plus the existing diagnostic fixture gates
+activate it. The normal product/test configuration is unchanged. The observer
+requires `-Dqwp.show.columns.dir=RUN_DIR`, supplied by the fixture. Overlay output,
+runtime temporary files and test data stay on the workspace filesystem.
+
+## Interpretation
+
+TSV fields: wall milliseconds, monotonic nanoseconds, local query ID, Java thread
+ID, thread name, table, stage, elapsed nanoseconds since cursor entry. Query IDs
+are probe-local, not QueryProgress IDs. Correlate table and wall time with server
+logs. Java thread IDs are not native thread IDs; JVM dumps contain both.
+
+`stage` denotes an operation about to run, not its completion. `cursor-ready`
+means initialization and resource releases finished. `iteration-breaker` persists
+while rows are emitted or response sending is suspended; a long duration there
+does not prove the timeout-check method itself blocked. Repeated identical
+iteration stages on the same thread are suppressed. `reader-close` also covers
+the subsequent metadata-lock release. Exceptions retain their original behavior.
+
+At five seconds active, the observer records a marker once per JVM; the external
+watchdog samples native/JVM stacks. Do not interpret post-trigger samples as the
+entire preceding interval. Normal queries perform no diagnostic file I/O on the
+request worker. There is still allocation/queue overhead; this is not a zero-cost
+observer. The queue is bounded to 8192 records and loss is explicitly rejected.
+
+The observer is a JVM daemon and can be paused with the JVM. Its file writes can
+also block. Missing telemetry is a diagnostic failure, not a healthy result.
+The harness retains independent Python heartbeat and JVM pause logs. An exe log
+without cursor-enter can indicate delay before the probe, or lost/delayed
+telemetry; it is not evidence of a metadata lock wait.
+
+## Local validation
+
+No Mac or additional CI worker is needed to validate the probe:
+
+```sh
+mkdir -p build-exp/show-columns-test-tmp
+TMPDIR="$PWD/build-exp/show-columns-test-tmp" PYTHONDONTWRITEBYTECODE=1 \
+  python3 -m unittest discover -s ci/diagnostics/show_columns -p 'test_*.py'
+python3 ci/diagnostics/show_columns/prepare.py \
+  --repo /path/to/questdb --jar /path/to/questdb/core/target/questdb-10.0.2-SNAPSHOT.jar \
+  --output build-exp/query-probe
+PYTHONDONTWRITEBYTECODE=1 python3 ci/diagnostics/show_columns/smoke.py \
+  --jar /path/to/questdb/core/target/questdb-10.0.2-SNAPSHOT.jar \
+  --overlay build-exp/query-probe/show-columns-probe.jar \
+  --output build-exp/query-smoke
+```
+
+Choose fresh output directories. The smoke launches and stops a baseline and
+an overlaid server on loopback, restricts JVM sizing and Linux CPU affinity to
+three CPUs, compares SQL results, and requires all normal stages. ProbeTest.java
+injects a delay into a standalone helper test; it is never packaged in the
+server overlay or used in CI's fuzz workload.
+
+Validated locally: baseline/overlay SQL results identical for repeated SHOW
+COLUMNS and after ADD COLUMN; all expected stages recorded; no false slow
+trigger. Standalone six-second delay triggers at the expected stage, and fast
+completion and exception completion are retained. These validate instrumentation,
+not the original macOS failure or performance equivalence.

--- a/ci/diagnostics/show_columns/README.md
+++ b/ci/diagnostics/show_columns/README.md
@@ -9,6 +9,9 @@ anchor occurs exactly once, and compiles an isolated `--patch-module io.questdb`
 JAR against the built server. It preserves source/JAR hashes and patched source
 in the output directory. No server checkout files are changed. Compilation uses
 the pinned server's JetBrains annotations 17.0.0 dependency from Maven's cache.
+The overlay deliberately has no manifest: a generated manifest shadows the
+server's build metadata under --patch-module. The smoke test requires the
+original version/commit and identical build() results with and without the patch.
 
 Only `QWP_WS_SHOW_COLUMNS_OVERLAY` plus the existing diagnostic fixture gates
 activate it. The normal product/test configuration is unchanged. The observer
@@ -69,3 +72,7 @@ COLUMNS and after ADD COLUMN; all expected stages recorded; no false slow
 trigger. Standalone six-second delay triggers at the expected stage, and fast
 completion and exception completion are retained. These validate instrumentation,
 not the original macOS failure or performance equivalence.
+
+Build 268391 exposed the generated-manifest problem before any fuzz test ran.
+The strengthened smoke reproduces that failure with the old overlay and passes
+with the manifest-free overlay. Its result is not a server-stall reproduction.

--- a/ci/diagnostics/show_columns/README.md
+++ b/ci/diagnostics/show_columns/README.md
@@ -37,6 +37,10 @@ watchdog samples native/JVM stacks. Do not interpret post-trigger samples as the
 entire preceding interval. Normal queries perform no diagnostic file I/O on the
 request worker. There is still allocation/queue overhead; this is not a zero-cost
 observer. The queue is bounded to 8192 records and loss is explicitly rejected.
+Native sampling finishes before SIGQUIT is sent: HotSpot prints SIGQUIT dumps
+at a safepoint, and blocked dump output can itself extend the JVM pause. Native
+samples still begin after detection; the subsequent Java stacks are later
+snapshots, not simultaneous observations of the same state.
 
 The observer is a JVM daemon and can be paused with the JVM. Its file writes can
 also block. Missing telemetry is a diagnostic failure, not a healthy result.

--- a/ci/diagnostics/show_columns/README.md
+++ b/ci/diagnostics/show_columns/README.md
@@ -87,3 +87,23 @@ not the original macOS failure or performance equivalence.
 Build 268391 exposed the generated-manifest problem before any fuzz test ran.
 The strengthened smoke reproduces that failure with the old overlay and passes
 with the manifest-free overlay. Its result is not a server-stall reproduction.
+
+## Bounded query-overlap arm
+
+`QWP_WS_QUERY_READER=1` adds one external, serial HTTP reader after the first
+real fuzz cursor appears in the stage log. It repeatedly reads that observed
+weather table, with 200 ms between completed requests, at most 300 requests,
+and no new request after 60 seconds or workload completion. The five-second
+socket timeout matches the test; the first error stops the reader permanently.
+This is deliberately changed query traffic, not an unchanged original replay.
+
+`query-reader.jsonl` records request boundaries and errors using both clocks.
+Its bounded event buffer is persisted only when the reader stops. Match those
+boundaries and the table against server query IDs/stages; do not infer that a
+timed-out HTTP request ever started executing. A separate watchdog thread keeps
+the filesystem helper's process-CPU measurements free of reader CPU time.
+
+This arm uses `QWP_WS_DISK_MODE=probe` with the mapped helper: one tiny cycle
+per second, never the paired arm's high-rate load. Four attempts on one Mac,
+stopping on the first capture/failure, bound worker use. Slow query/observer
+loss/workload failure triggers capture; isolated ping failures remain telemetry.

--- a/ci/diagnostics/show_columns/ShowColumnsProbe.java
+++ b/ci/diagnostics/show_columns/ShowColumnsProbe.java
@@ -1,0 +1,114 @@
+package io.questdb.griffin.engine.table;
+
+import java.io.BufferedWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** Investigation-only module overlay. Query threads never write diagnostic files. */
+public final class ShowColumnsProbe {
+    private static final ConcurrentHashMap<Long, ShowColumnsProbe> ACTIVE = new ConcurrentHashMap<>();
+    private static final ConcurrentLinkedQueue<String> EVENTS = new ConcurrentLinkedQueue<>();
+    private static final AtomicInteger QUEUED = new AtomicInteger();
+    private static final AtomicLong DROPPED = new AtomicLong();
+    private static final AtomicLong IDS = new AtomicLong();
+    private static final long SLOW_NS = 5_000_000_000L;
+    private static final Path DIRECTORY = Path.of(System.getProperty("qwp.show.columns.dir"));
+    private final long id = IDS.incrementAndGet();
+    private final long started = System.nanoTime();
+    private final String table;
+    private volatile String stage;
+    private volatile long threadId;
+    private volatile String threadName;
+    private volatile boolean finished;
+
+    static {
+        Thread observer = new Thread(ShowColumnsProbe::observe, "show-columns-observer");
+        observer.setDaemon(true);
+        observer.start();
+    }
+
+    private ShowColumnsProbe(CharSequence table) {
+        this.table = table.toString().replace('\t', ' ').replace('\n', ' ').replace('\r', ' ');
+        stage("cursor-enter");
+        ACTIVE.put(id, this);
+    }
+
+    public static ShowColumnsProbe begin(CharSequence table) {
+        return new ShowColumnsProbe(table);
+    }
+
+    public void stage(String next) {
+        if (next.equals(stage) && threadId == Thread.currentThread().threadId()) return;
+        threadId = Thread.currentThread().threadId();
+        threadName = Thread.currentThread().getName();
+        stage = next;
+        enqueue(line(next));
+    }
+
+    public void finish(String reason) {
+        if (!finished) {
+            finished = true;
+            stage(reason);
+            ACTIVE.remove(id);
+        }
+    }
+
+    private String line(String event) {
+        return System.currentTimeMillis() + "\t" + System.nanoTime() + "\t" + id
+                + "\t" + threadId + "\t" + threadName + "\t" + table + "\t" + event
+                + "\t" + (System.nanoTime() - started);
+    }
+
+    private static void enqueue(String line) {
+        if (QUEUED.incrementAndGet() <= 8192) {
+            EVENTS.offer(line);
+        } else {
+            QUEUED.decrementAndGet();
+            DROPPED.incrementAndGet();
+        }
+    }
+
+    private static void observe() {
+        boolean captured = false;
+        long heartbeat = 0;
+        try (BufferedWriter out = Files.newBufferedWriter(DIRECTORY.resolve("show-columns.tsv"))) {
+            out.write("wall_ms\tnano_time\tquery_id\tjava_thread_id\tthread\ttable\tstage\telapsed_ns\n");
+            while (true) {
+                String event;
+                while ((event = EVENTS.poll()) != null) {
+                    QUEUED.decrementAndGet();
+                    out.write(event);
+                    out.newLine();
+                }
+                long now = System.nanoTime();
+                if (now - heartbeat >= 1_000_000_000L) {
+                    heartbeat = now;
+                    out.write(System.currentTimeMillis() + "\t" + now + "\t0\t0\tobserver\t-\theartbeat dropped=" + DROPPED.get() + "\t0\n");
+                    for (ShowColumnsProbe probe : ACTIVE.values()) {
+                        out.write(probe.line("active:" + probe.stage));
+                        out.newLine();
+                        if (!captured && !probe.finished && now - probe.started >= SLOW_NS) {
+                            // Persist the stage before asking the external watchdog for stacks.
+                            out.flush();
+                            Files.writeString(DIRECTORY.resolve("show-columns-slow"), probe.line("slow:" + probe.stage) + "\n");
+                            captured = true;
+                        }
+                    }
+                }
+                out.flush();
+                Thread.sleep(100);
+            }
+        } catch (Throwable error) {
+            error.printStackTrace();
+            try {
+                Files.writeString(DIRECTORY.resolve("show-columns-error"), error.toString());
+            } catch (Throwable ignored) {
+                // The harness also checks telemetry presence and completion.
+            }
+        }
+    }
+}

--- a/ci/diagnostics/show_columns/prepare.py
+++ b/ci/diagnostics/show_columns/prepare.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Build a diagnostic overlay from the exact revision; never edit server checkout."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+
+REVISION = '12a33d651e51e2682e7a448c8db5168fc72dfad3'
+SOURCE = 'core/src/main/java/io/questdb/griffin/engine/table/ShowColumnsRecordCursorFactory.java'
+
+
+def instrument(source):
+    def replace(old, new):
+        nonlocal source
+        if source.count(old) != 1:
+            raise ValueError(f'Expected exactly one source anchor: {old!r}')
+        source = source.replace(old, new)
+
+    replace('        executionContext.getCircuitBreaker().statefulThrowExceptionIfTrippedTimeThrottled();\n        return cursor.of(executionContext, tableToken, tokenPosition);',
+            '''        cursor.probe = ShowColumnsProbe.begin(tableToken.getTableName());
+        try {
+            cursor.probe.stage("initial-breaker");
+            executionContext.getCircuitBreaker().statefulThrowExceptionIfTrippedTimeThrottled();
+            cursor.of(executionContext, tableToken, tokenPosition);
+            cursor.probe.stage("cursor-ready");
+            return cursor;
+        } catch (Throwable error) {
+            cursor.probe.finish("open-error:" + error.getClass().getSimpleName());
+            throw error;
+        }''')
+    replace('        private CairoTable cairoTable;', '        private CairoTable cairoTable;\n        private ShowColumnsProbe probe;')
+    replace('            cairoTable = null;', '            if (probe != null) probe.finish("cursor-close");\n            cairoTable = null;')
+    replace('            circuitBreaker.statefulThrowExceptionIfTripped();', '''            probe.stage("iteration-breaker");
+            try {
+                circuitBreaker.statefulThrowExceptionIfTripped();
+            } catch (Throwable error) {
+                probe.finish("iteration-error:" + error.getClass().getSimpleName());
+                throw error;
+            }''')
+    replace('            engine.getMetadataCache().hydrateTableOnDemand(tableToken);', '''            probe.stage("hydrate-enter");
+            engine.getMetadataCache().hydrateTableOnDemand(tableToken);
+            probe.stage("metadata-read-lock-wait");''')
+    replace('                final CairoTable cairoTable = metadataRO.getTable(tableToken);', '''                probe.stage("metadata-read-lock-held");
+                final CairoTable cairoTable = metadataRO.getTable(tableToken);''')
+    replace('                    try (TableReader tableReader = engine.getReader(tableToken)) {\n                        return of(cairoTable, tableReader);\n                    }', '''                    probe.stage("reader-open");
+                    try (TableReader tableReader = engine.getReader(tableToken)) {
+                        probe.stage("symbol-sizes");
+                        of(cairoTable, tableReader);
+                        probe.stage("reader-close");
+                        return this;
+                    }''')
+    return source
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--repo', type=Path, required=True)
+    parser.add_argument('--jar', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--annotations', type=Path, default=Path.home() / '.m2/repository/org/jetbrains/annotations/17.0.0/annotations-17.0.0.jar')
+    args = parser.parse_args()
+    original = subprocess.check_output(['git', '-C', str(args.repo), 'show', f'{REVISION}:{SOURCE}'], text=True)
+    patched = instrument(original)
+    args.output.mkdir(parents=True, exist_ok=False)
+    (args.output / 'tmp').mkdir()
+    source_dir = args.output / 'src/io/questdb/griffin/engine/table'
+    source_dir.mkdir(parents=True)
+    (source_dir / 'ShowColumnsRecordCursorFactory.java').write_text(patched)
+    helper = Path(__file__).with_name('ShowColumnsProbe.java').read_text()
+    (source_dir / 'ShowColumnsProbe.java').write_text(helper)
+    classes = args.output / 'classes'
+    subprocess.run(['javac', f'-J-Djava.io.tmpdir={args.output / "tmp"}', '--patch-module', f'io.questdb={args.output / "src"}',
+                    '-p', os.pathsep.join(map(str, (args.jar, args.annotations))), '-d', str(classes),
+                    *map(str, sorted(source_dir.glob('*.java')))], check=True)
+    subprocess.run(['jar', f'-J-Djava.io.tmpdir={args.output / "tmp"}', '--create', '--file', str(args.output / 'show-columns-probe.jar'),
+                    '-C', str(classes), '.'], check=True)
+    (args.output / 'identity.json').write_text(json.dumps(dict(
+        server_revision=REVISION,
+        server_jar_sha256=hashlib.sha256(args.jar.read_bytes()).hexdigest(),
+        original_source_sha256=hashlib.sha256(original.encode()).hexdigest(),
+        patched_source_sha256=hashlib.sha256(patched.encode()).hexdigest(),
+        helper_sha256=hashlib.sha256(helper.encode()).hexdigest(),
+    ), indent=2) + '\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/ci/diagnostics/show_columns/prepare.py
+++ b/ci/diagnostics/show_columns/prepare.py
@@ -74,7 +74,9 @@ def main():
     subprocess.run(['javac', f'-J-Djava.io.tmpdir={args.output / "tmp"}', '--patch-module', f'io.questdb={args.output / "src"}',
                     '-p', os.pathsep.join(map(str, (args.jar, args.annotations))), '-d', str(classes),
                     *map(str, sorted(source_dir.glob('*.java')))], check=True)
-    subprocess.run(['jar', f'-J-Djava.io.tmpdir={args.output / "tmp"}', '--create', '--file', str(args.output / 'show-columns-probe.jar'),
+    # A generated manifest shadows the server's /META-INF/MANIFEST.MF under
+    # --patch-module and makes BuildInformationHolder return "unknown".
+    subprocess.run(['jar', f'-J-Djava.io.tmpdir={args.output / "tmp"}', '--create', '--no-manifest', '--file', str(args.output / 'show-columns-probe.jar'),
                     '-C', str(classes), '.'], check=True)
     (args.output / 'identity.json').write_text(json.dumps(dict(
         server_revision=REVISION,

--- a/ci/diagnostics/show_columns/smoke.py
+++ b/ci/diagnostics/show_columns/smoke.py
@@ -52,7 +52,10 @@ def run(root, jar, overlay):
                         raise RuntimeError(f'Server failed; inspect {root / "server.log"}')
                     time.sleep(.1)
             sql('create table probe (s symbol, v double, ts timestamp) timestamp(ts) partition by day wal')
-            results = []
+            build = sql('select build()')
+            assert 'QuestDB 10.0.2-SNAPSHOT' in build['dataset'][0][0], build
+            assert '12a33d651e51e2682e7a448c8db5168fc72dfad3' in build['dataset'][0][0], build
+            results = [build]
             for _ in range(3):
                 results.append(sql('show columns from probe'))
             sql('alter table probe add column extra long')

--- a/ci/diagnostics/show_columns/smoke.py
+++ b/ci/diagnostics/show_columns/smoke.py
@@ -1,0 +1,90 @@
+"""Local fixed-work baseline/overlay comparison; not a macOS reproduction."""
+import argparse
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import time
+import urllib.parse
+import urllib.request
+
+from validate import validate
+
+
+def run(root, jar, overlay):
+    root.mkdir(parents=True, exist_ok=False)
+    (root / 'data/conf').mkdir(parents=True)
+    (root / 'tmp').mkdir()
+    with socket.socket() as sock:
+        sock.bind(('127.0.0.1', 0))
+        port = sock.getsockname()[1]
+    (root / 'data/conf/server.conf').write_text(
+        f'http.bind.to=127.0.0.1:{port}\nhttp.min.enabled=false\npg.enabled=false\n'
+        'line.tcp.enabled=false\nline.udp.enabled=false\nqwp.udp.enabled=false\n'
+        'telemetry.enabled=false\nshared.network.worker.count=3\nshared.write.worker.count=3\n')
+    command = ['java', '-Xms128m', '-Xmx512m', '-XX:ActiveProcessorCount=3', '-ea',
+               '-XX:+UnlockExperimentalVMOptions', '--add-exports=java.base/jdk.internal.vm=io.questdb',
+               f'-Djava.io.tmpdir={root / "tmp"}']
+    if overlay:
+        command += ['--patch-module', f'io.questdb={overlay}', f'-Dqwp.show.columns.dir={root}']
+    command += ['-p', str(jar), '-m', 'io.questdb/io.questdb.ServerMain', '-d', str(root / 'data')]
+    if hasattr(os, 'sched_getaffinity'):
+        command = ['taskset', '-c', ','.join(map(str, sorted(os.sched_getaffinity(0))[:3]))] + command
+    (root / 'command.json').write_text(json.dumps(command))
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+    def sql(query):
+        with opener.open(f'http://127.0.0.1:{port}/exec?' + urllib.parse.urlencode({'query': query}), timeout=10) as response:
+            return json.load(response)
+
+    with (root / 'server.log').open('w') as log:
+        child = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT,
+                                 env=dict(os.environ, TMPDIR=str(root / 'tmp')))
+        try:
+            deadline = time.monotonic() + 30
+            while True:
+                try:
+                    sql('select 1')
+                    break
+                except Exception:
+                    if child.poll() is not None or time.monotonic() > deadline:
+                        raise RuntimeError(f'Server failed; inspect {root / "server.log"}')
+                    time.sleep(.1)
+            sql('create table probe (s symbol, v double, ts timestamp) timestamp(ts) partition by day wal')
+            results = []
+            for _ in range(3):
+                results.append(sql('show columns from probe'))
+            sql('alter table probe add column extra long')
+            results.append(sql('show columns from probe'))
+            # Allow asynchronous telemetry to flush before terminating the JVM.
+            time.sleep(1.2)
+            if overlay:
+                validate(root)
+                stages = (root / 'show-columns.tsv').read_text()
+                for stage in ('initial-breaker', 'hydrate-enter', 'metadata-read-lock-wait',
+                              'metadata-read-lock-held', 'reader-open', 'symbol-sizes',
+                              'reader-close', 'cursor-ready', 'iteration-breaker', 'cursor-close'):
+                    assert '\t' + stage + '\t' in stages, stage
+                assert not (root / 'show-columns-slow').exists()
+            return results
+        finally:
+            child.terminate()
+            try:
+                child.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                child.kill()
+                child.wait()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--jar', type=Path, required=True)
+    parser.add_argument('--overlay', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    root = args.output.resolve()
+    baseline = run(root / 'baseline', args.jar.resolve(), None)
+    instrumented = run(root / 'instrumented', args.jar.resolve(), args.overlay.resolve())
+    assert baseline == instrumented, (baseline, instrumented)
+    print('PASS: identical SQL results; all query stages observed; no false slow trigger')

--- a/ci/diagnostics/show_columns/test_probe.py
+++ b/ci/diagnostics/show_columns/test_probe.py
@@ -1,0 +1,46 @@
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+import prepare
+import validate
+
+
+class ProbeTest(unittest.TestCase):
+    def test_anchor_drift_is_rejected(self):
+        with self.assertRaises(ValueError):
+            prepare.instrument('unexpected revision')
+
+    def test_observer_captures_slow_stage_and_completed_requests(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sources = Path(__file__).parent
+            subprocess.run(['javac', f'-J-Djava.io.tmpdir={root}', '-d', str(root), str(sources / 'ShowColumnsProbe.java'),
+                            str(sources / 'ProbeTest.java')], check=True)
+            subprocess.run(['java', '-XX:ActiveProcessorCount=3',
+                            f'-Djava.io.tmpdir={root}',
+                            f'-Dqwp.show.columns.dir={root}', '-cp', str(root), 'ProbeTest'],
+                           check=True, timeout=15)
+            validate.validate(root)
+            marker = (root / 'show-columns-slow').read_text().split('\t')
+            self.assertEqual(marker[6], 'slow:metadata-read-lock-wait')
+            self.assertGreaterEqual(int(marker[7]), 5_000_000_000)
+            rows = (root / 'show-columns.tsv').read_text()
+            self.assertIn('cursor-close', rows)
+            self.assertIn('open-error:Injected', rows)
+            self.assertNotIn('show-columns-error', os.listdir(root))
+
+    def test_validation_rejects_missing_or_dropped_events(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for body in ('header\n',
+                         'header\n0\t0\t0\t0\tobserver\t-\theartbeat dropped=1\t0\n'):
+                (root / 'show-columns.tsv').write_text(body)
+                with self.assertRaises(ValueError):
+                    validate.validate(root)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ci/diagnostics/show_columns/validate.py
+++ b/ci/diagnostics/show_columns/validate.py
@@ -1,0 +1,32 @@
+"""Reject missing/dropped query telemetry instead of silently passing the arm."""
+from pathlib import Path
+import sys
+
+
+def validate(directory):
+    if (directory / 'show-columns-error').exists():
+        raise ValueError('Observer failed')
+    rows = (directory / 'show-columns.tsv').read_text().splitlines()[1:]
+    active = set()
+    completed = 0
+    heartbeat = False
+    for line in rows:
+        fields = line.split('\t')
+        if len(fields) != 8:
+            raise ValueError('Incomplete telemetry row')
+        query, stage = fields[2], fields[6]
+        if stage.startswith('heartbeat'):
+            heartbeat = True
+            if stage != 'heartbeat dropped=0':
+                raise ValueError(stage)
+        if stage == 'cursor-enter':
+            active.add(query)
+        elif stage == 'cursor-close' or stage.startswith(('open-error:', 'iteration-error:')):
+            active.discard(query)
+            completed += 1
+    if not heartbeat or completed == 0 or active:
+        raise ValueError(f'Missing heartbeat/completion: completed={completed}, active={active}')
+
+
+if __name__ == '__main__':
+    validate(Path(sys.argv[1]))

--- a/ci/prepare_qwp_ws_jdk.sh
+++ b/ci/prepare_qwp_ws_jdk.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Only the diagnostic job needs the original runtime, not today's hosted JDK.
+set -euo pipefail
+
+[[ "$(uname -s)" == Darwin && "$(uname -m)" == arm64 ]]
+readonly EXPECTED_VERSION='25.0.3+9'
+readonly ARCHIVE='OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.3_9.tar.gz'
+readonly SHA256='7baab4d69a15554e119b86ff78d40e3fdc28819b5b322955c913cebfe3f6a37c'
+
+diagnostic_jdk="${JAVA_HOME:-}"
+if [[ ! -x "$diagnostic_jdk/bin/java" ]] ||
+        [[ "$("$diagnostic_jdk/bin/java" -version 2>&1)" != *"$EXPECTED_VERSION"* ]]; then
+    mkdir -p build
+    install_dir="$(mktemp -d "$PWD/build/qwp-diagnostic-jdk.XXXXXX")"
+    curl --fail --location --retry 3 \
+        "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/$ARCHIVE" \
+        --output "$install_dir/$ARCHIVE"
+    printf '%s  %s\n' "$SHA256" "$install_dir/$ARCHIVE" | shasum -a 256 -c -
+    tar -xzf "$install_dir/$ARCHIVE" -C "$install_dir"
+    diagnostic_jdk="$install_dir/jdk-25.0.3+9/Contents/Home"
+fi
+"$diagnostic_jdk/bin/java" -version
+[[ "$("$diagnostic_jdk/bin/java" -version 2>&1)" == *"$EXPECTED_VERSION"* ]]
+echo "##vso[task.setvariable variable=JAVA_HOME]$diagnostic_jdk"
+echo "##vso[task.prependpath]$diagnostic_jdk/bin"

--- a/ci/prepare_qwp_ws_system_trace.sh
+++ b/ci/prepare_qwp_ws_system_trace.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Fail before compilation if the hosted Mac cannot export useful System Trace.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+preflight_dir="${QWP_WS_DIAGNOSTICS_DIR:?QWP_WS_DIAGNOSTICS_DIR is required}/preflight"
+if [[ -e "$preflight_dir" ]]; then
+    echo "Refusing to reuse preflight artifacts: $preflight_dir" >&2
+    exit 2
+fi
+mkdir -p "$preflight_dir/tmp"
+sudo -n env TMPDIR="$preflight_dir/tmp" "$(command -v python3)" \
+    "$root_dir/system_test/qwp_ws_system_trace.py" preflight --run-dir "$preflight_dir"

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -2,9 +2,8 @@
 
 Status: server progress interruption observed; root cause **not established**.
 This branch is diagnostic only. Keep sender timeouts and correctness assertions
-unchanged. Azure PR 200 allocates only one macOS worker. The next run is
-**preflight-only**: establish recorder startup before resuming
-`TestQwpWsFuzz.test_add_columns`. It will not compile or start QuestDB.
+unchanged. Azure PR 200 allocates only one macOS worker, running only
+`TestQwpWsFuzz.test_add_columns` after validating recorder capability.
 
 Local follow-up, 2026-09-08: a controlled O3 close delay demonstrated global
 `FdCache` lock propagation into both WAL segment work and the serial network
@@ -69,17 +68,30 @@ not. This establishes a mechanism, not the original macOS trigger. See the
   a permissions failure or lack of System Trace support. Compilation and the
   QuestDB test were skipped; only one macOS job ran.
 
-## Current experiment: recorder startup only
+## Recorder startup validation (completed)
 
-Pipeline parameter `qwpWsPreflightOnly` defaults to `true`. In that mode the
+[Build 268361](https://dev.azure.com/questdb/questdb/_build/results?buildId=268361)
+passed the preflight-only run. Recorder readiness took 18.712 seconds: the old
+15-second allowance would have interrupted this successful start. It exported
+1,224 target syscalls with CPU/wait duration fields and 1,084 target thread-state
+intervals; the raw trace was retained. Its template uses a five-second rolling
+window. This establishes recorder capability on that hosted Mac, not the cause
+of the original QuestDB timeout. Kernel wait causes remain to be investigated;
+the exported syscall stacks in this smoke recording contain user-space frames.
+
+Pipeline parameter `qwpWsPreflightOnly` now defaults to `false`. Set it to `true`
+to repeat just the startup check. In that mode the
 expanded job contains checkout, tracing preflight, artifact ownership hand-back,
 and publication only. Dependency installs, client/server builds, the fuzz test,
 and server-log archival are excluded even if the smoke check succeeds. The job
 limit is ten minutes; the preflight step limit is five minutes. Do not turn the
-full experiment back on until the startup artifact has been inspected.
+full experiment on without first inspecting the startup artifact.
 
-Only the preflight receives a 60-second startup budget. The full test's recorder
-startup budget remains 15 seconds within its unchanged 30-second fixture gate.
+Both preflight and full-test recorders now receive a 60-second startup budget.
+Only traced attempts get a 90-second diagnostic setup gate, before the workload
+starts; controls retain their 30-second gate. The shell controller waits up to
+70 seconds for recorder readiness. Workload assertions and sender/SQL timeouts
+are unchanged.
 The smoke process now waits through cold startup and recorder cleanup rather
 than expiring at the old 25-second deadline. It exits without replacing the
 parent's error if the recorder finishes before releasing the smoke workload.
@@ -110,7 +122,7 @@ is an exploratory cold-start allowance, not a claim that slow initialization
 caused build 268344. A successful check still requires actual target syscall
 and scheduler rows; readiness alone is not sufficient.
 
-## Full experiment (disabled by default)
+## Current experiment: bounded full test
 
 The single worker uses server `12a33d651e51e2682e7a448c8db5168fc72dfad3`, Temurin
 25.0.3+9 (official download with pinned SHA-256), fuzz seed
@@ -144,8 +156,8 @@ the outer bound; the test and sender retain all existing timeouts/assertions.
 The recorder starts at the existing server-ready gate and must post its explicit
 Darwin readiness notification before the workload is released. Registration's
 initial notification state is consumed **before** recorder launch, so it cannot
-be mistaken for readiness. Startup is bounded to leave room within the unchanged
-30-second fixture gate.
+be mistaken for readiness. Startup is bounded to leave room within the traced
+attempt's 90-second diagnostic setup gate.
 
 At the first failed ping, heartbeat gap, or workload-error request, the watchdog
 synchronously requests SIGINT of the recorder. The privileged collector polls
@@ -196,7 +208,7 @@ previously its catch-all hid timeouts from the diagnostic callback.
 
 ## Reading the next artifact
 
-Download `qwp-ws-macos-system-trace`. For the current preflight-only run, inspect
+Download `qwp-ws-macos-system-trace`. For a preflight-only run, inspect
 the startup artifacts above and `system-trace-valid.json`/`system-trace-error.json`.
 There should be no `run-*` directories or QuestDB logs. Success establishes
 recorder capability only, not a reproduced ping timeout.

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -7,7 +7,26 @@ unchanged. Azure PR 200 allocates only one macOS worker, running only
 workload mode is enabled. The current default follows the severe filesystem
 episode captured in build 268479.
 
-## Current action: remove file writes from the onset path
+## Current action: decode retained raw samples, no workload
+
+Build 268494 passed three attempts (59 completed SHOW cursors, maximum 52.751
+ms) and retained a 2,140,573-byte raw capture from attempt 3. It decoded into a
+full 151-sample report but without kernel names, so validation correctly failed.
+Exact UUID-plus-offset matching to retained symbolicated builds 268472/268468
+recovers 1,197 frame lines, leaving 5,205 unresolved and no ambiguous keys. This
+is explicitly partial annotation, not nearest-symbol guessing. During samples
+11-15 all three HTTP workers wait at APFS transaction entry while the flusher
+waits in virtual-disk unmap; sample 16 is a barrier. These are short sampled
+intervals, not the previous build's 66-second wait or the original slow query.
+
+The next job defaults qwpWsDecodeOnly=true and downloads only hash-pinned
+retained inputs: 268494/run-3 raw data and 268472/run-4 symbolicated report.
+It tests the installed tool's documented -symbols input when decoding with -i.
+No live-system inspection is requested for historical process identities.
+No dependencies, client/server build, test, filesystem helper or new sampling
+runs. One Mac, bounded download/decoder times, raw data preserved on failure.
+
+## Completed arm: remove file writes from the onset path
 
 Build 268487 reproduced five close-drain timeouts in its first low-rate control.
 The helper completed only two cycles (128 KiB application writes). Its second

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -3,7 +3,39 @@
 Status: server progress interruption observed; root cause **not established**.
 This branch is diagnostic only. Keep sender timeouts and correctness assertions
 unchanged. Azure PR 200 allocates only one macOS worker, running only
-`TestQwpWsFuzz.test_add_columns` after validating recorder capability.
+`TestQwpWsFuzz.test_add_columns` with the focused query-stage probe below.
+
+## Current focus: the original slow SHOW COLUMNS
+
+Build 268363 successfully captured two short ping stalls. All three HTTP workers
+spent most of each failed probe in repeated ftruncate calls, predominantly
+blocked. Those captures do not establish the original 74.7-second SHOW COLUMNS
+delay or the 120-second QWP close-drain failure. HTTP and O3 already use distinct
+shared-network/shared-write pools in the failing revision.
+
+The next arm replaces System Trace with an exact-source, diagnostic-only module
+overlay for ShowColumnsRecordCursorFactory. Neither the server checkout nor its
+JAR is edited. The overlay logs cursor entry, initial circuit-breaker check,
+metadata hydration, metadata read-lock wait/acquisition, reader open, symbol
+size collection, reader close, cursor-ready, iteration, and completion/error.
+Query threads enqueue records in memory; one daemon writes bounded-queue
+telemetry and a heartbeat. Dropped/missing telemetry fails the diagnostic arm.
+
+An active cursor reaching five seconds requests the existing native/JVM stack
+capture. Ping and heartbeat measurements remain enabled but short anomalies no
+longer trigger invasive captures. Workload-error capture remains enabled. Stop
+after the first capture/failure, at most 40 repetitions, no new attempt after
+600 seconds, one macOS worker. Original test/sender/SQL timeouts are unchanged.
+
+The entry marker is inside ShowColumnsRecordCursorFactory.getCursor, after
+QueryProgress's exe log: a gap between exe and cursor-enter is itself evidence
+outside the instrumented cursor stages. The observer can also be delayed by a
+VM/JVM/storage pause; its heartbeat is not independent of the JVM. The existing
+external heartbeat and JVM safepoint logs help distinguish those cases.
+
+See [probe implementation and validation](diagnostics/show_columns/README.md).
+The recorder configuration described below is historical unless explicitly
+selecting the recorder-only preflight parameter.
 
 Local follow-up, 2026-09-08: a controlled O3 close delay demonstrated global
 `FdCache` lock propagation into both WAL segment work and the serial network

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -4,9 +4,34 @@ Status: server progress interruption observed; root cause **not established**.
 This branch is diagnostic only. Keep sender timeouts and correctness assertions
 unchanged. Azure PR 200 allocates only one macOS worker, running only
 `TestQwpWsFuzz.test_add_columns` with the focused query-stage probe below when
-workload mode is enabled. The current default is four paired-memory attempts.
+workload mode is enabled. The current default is a kernel-stack recorder preflight.
 
-## Current action: actual warning-pressure workload
+## Current action: kernel-stack access check, no server build
+
+Build 268458 passed all four natural/warn/warn/natural attempts. Both warning
+gates reached kernel level 2 (after 30.369 and 20.408 seconds of polling), and
+all seven host samples during those two workloads remained level 2. There were
+67 completed query cursors, maximum 98.908 ms, with no slow-query marker. Both
+one-second ping failures occurred in the natural controls. This does not show
+warning pressure alone is sufficient, nor rule out other pressure conditions.
+
+The next job enables recorder-only mode and runs `kernel_wait_preflight.py`.
+It retains the installed spindump help, takes a three-second system sample at
+20 ms intervals, and requires named kernel frames in the report. A single
+helper performs at most 100 truncate/write/fsync cycles (6.25 MiB application
+writes), over at most ten seconds before starting another cycle. This is an
+access check, not a stall reproduction or a storage benchmark. Recorder time,
+free disk space and the job are bounded. No SIP or other security setting is
+changed. All files and recorder temporary storage are in the artifact directory.
+No dependency installation, client/server compilation or fuzz workload runs.
+
+Read-only historical scan: 73 failed scheduled builds since August 25 contained
+34 failed macOS fuzz tasks. Only the original 266336 reported a close-drain
+timeout; other task failures were startup, file-open or row-visibility errors.
+This is not proof that those runs had no slow queries; it found no second
+matching close-drain failure from the task logs.
+
+## Completed arm: actual warning-pressure workload
 
 Build 268431's warning state arrived only after its 20-second setup gate had
 expired. The next arm uses natural/warn/warn/natural, keeps the 72-lookup prefix

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -24,8 +24,33 @@ telemetry and a heartbeat. Dropped/missing telemetry fails the diagnostic arm.
 An active cursor reaching five seconds requests the existing native/JVM stack
 capture. Ping and heartbeat measurements remain enabled but short anomalies no
 longer trigger invasive captures. Workload-error capture remains enabled. Stop
-after the first capture/failure, at most 40 repetitions, no new attempt after
+after the first capture/failure, at most 12 repetitions, no new attempt after
 600 seconds, one macOS worker. Original test/sender/SQL timeouts are unchanged.
+
+Builds 268394 and 268424 passed 40 natural-memory attempts each, with respectively
+504 and 555 completed probe cursors and maxima of 137.21 and 158.25 ms. No
+five-second query or observer-loss marker appeared. The next experiment uses
+three natural/warn/warn/natural cycles on one worker, with the same query probe.
+This is an exploratory resource perturbation, not a claim that original memory
+pressure was established. It tests whether real warning pressure can reproduce
+the prolonged query stage, rather than merely slowing WAL/ping traffic.
+
+`memory_pressure -l warn -s 1` applies real allocation pressure (no `-S`), with
+one-second regulation. Before releasing each paired-plan workload, the harness
+requires `kern.memorystatus_vm_pressure_level` to reach 1 (natural) or 2 (warn)
+within 20 seconds. Unknown/critical levels and an unmet target fail setup; a
+five-second sleep alone is not evidence that pressure was reached. Each attempt
+first requires recovery to normal, so a helper cannot immediately exit because
+the previous attempt left the system at warning pressure. Only this arm's
+pre-workload setup gate is extended to 60 seconds; sender and SQL deadlines are
+unchanged. Per-run gate samples and five-
+second host samples retain the actual levels, compression and swap counters.
+The helper is stopped between attempts. Post-pressure natural runs are recovery
+controls, not independent cold machines: page-cache/compression carryover is a
+known limitation. Stop at the first capture/failure; do not increase workers.
+
+Apple's [memory_pressure manual](https://github.com/apple-oss-distributions/system_cmds/blob/main/memory_pressure/memory_pressure.1)
+and implementation distinguish allocation mode from `-S` notification simulation.
 
 The entry marker is inside ShowColumnsRecordCursorFactory.getCursor, after
 QueryProgress's exe log: a gap between exe and cursor-enter is itself evidence

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -7,7 +7,24 @@ unchanged. Azure PR 200 allocates only one macOS worker, running only
 workload mode is enabled. The current default follows the severe filesystem
 episode captured in build 268479.
 
-## Current action: decode retained raw samples, no workload
+## Current action: repeat without the filesystem helper, query-focused capture
+
+Decoder-only build 268496 successfully regenerated the existing raw report
+using the retained symbolicated report via -symbols. It contains 6,403 kernel
+frame lines, 1,240 named; resolution is partial, not every frame is named.
+The original 151 samples and timestamps are preserved. No new workload ran.
+
+Return to workload mode with up to 24 attempts on ONE Mac and no new attempt
+after 600 seconds. No disk helper and natural guest memory; preserve original
+test inputs, 72-lookup startup prefix, server/JDK and worker shape. Kernel
+capture is query/failure focused: slow SHOW, observer loss or explicit workload
+failure, not short failed pings. Stop at the first capture/failure. Fetch the
+hash-pinned symbol report once before workload gates; onset recording stays
+pipe-based, with no symbol lookup during recording and post-shutdown decoding.
+This removes the external filesystem-helper confound and prioritizes the
+original already-started long query. A passing loop is not proof of root cause.
+
+## Completed arm: decode retained raw samples, no workload
 
 Build 268494 passed three attempts (59 completed SHOW cursors, maximum 52.751
 ms) and retained a 2,140,573-byte raw capture from attempt 3. It decoded into a

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -1,0 +1,85 @@
+# QWP/WebSocket macOS stall investigation
+
+Status: server progress interruption observed; root cause **not established**.
+This branch is diagnostic only. Keep sender timeouts and correctness assertions
+unchanged. Azure PR 200 allocates only two macOS workers for
+`TestQwpWsFuzz.test_add_columns`.
+
+## Evidence and limits
+
+- Original [build 266336](https://dev.azure.com/questdb/questdb/_build/results?buildId=266336):
+  the test begins at 12:17:23 UTC; first reported ALTER timeout at 12:17:38.
+  `SHOW COLUMNS FROM 'weather0'` executes from 12:17:51.377661 to
+  12:19:06.083621, then reports a server-side timeout after 74,706 ms.
+  HTTP, WAL purge and WAL-apply log activity resumes together. A producer's
+  close-drain timeout follows at 12:19:44.
+- The first JVM dump, at 12:20:12, is **after failure and during DROP cleanup**:
+  three HTTP workers in truncate/msync paths, two WAL-apply workers idle.
+  It establishes a late software location, not the original limiting resource.
+- WAL commit/ordinary ACK does not normally await O3 application. Both paths
+  still share OS resources; schema changes also reconcile and roll WAL files.
+  The fuzz case includes type conversions, despite its name.
+- [Build 266405](https://dev.azure.com/questdb/questdb/_build/results?buildId=266405)
+  passed three natural and three artificial warning-pressure attempts. This
+  does **not** rule out memory pressure. Original 3.19 GiB memory accounting
+  includes mappings; a recovery sample has physical RSS about 726 MiB. Original
+  host pressure during the stall is unknown.
+- [Build 268063](https://dev.azure.com/questdb/questdb/_build/results?buildId=268063)
+  passed 40 traced attempts on two hosts. Maximum observed filesystem calls
+  were below one second; some successful drains took 6–8 seconds. Neither a
+  green replay nor a short syscall maximum explains the original failure.
+- That replay changed **both server and JVM**: server `00de5bbb`, Temurin
+  25.0.4.1, macOS 15.7.9. Original JVM dump records Temurin 25.0.3+9 and startup
+  records macOS 15.7.7. The original task log 122 also prints server build hash
+  `12a33d651e51e2682e7a448c8db5168fc72dfad3` (line 404, buffered build information).
+  This pins the source directly, even though the clone step did not print it.
+- Seeds do not pin concurrent scheduling, schema observations, or the exact
+  number of conversions. Two hosts do not provide 40 independent host states.
+
+## Current experiment
+
+Both replicas use server `12a33d651e51e2682e7a448c8db5168fc72dfad3`, Temurin
+25.0.3+9 (official download with pinned SHA-256), fuzz seed
+`0x268579c36b106b74`, build-mode seed `7856154056746654427`, three hosted CPUs,
+and JVM `ActiveProcessorCount=3`. The managed hosted macOS image is still
+moving; record its version, do not call this an exact environment reproduction.
+
+Replica A has lightweight monitoring; replica B additionally runs continuous
+`fs_usage`. Each runs at most 20 attempts and stops at its first capture or test
+failure. No synthetic memory pressure. Store-and-forward, Java temporary data,
+and diagnostics are explicitly on the worker filesystem, not `/tmp`.
+
+The external Python watchdog probes `/ping` once per second with a one-second
+timeout. A separate thread records quarter-second heartbeats in another file.
+The first probe failure, heartbeat gap over one second, or transient workload
+error requests one bounded capture: three SIGQUIT requests 500 ms apart and
+a three-second native `sample` at 10 ms intervals. The JVM writes GC/safepoint
+records to a dedicated rotating log from startup. Capture is allowed to finish
+before DROP cleanup, with a 15-second bound; this does not change workload or
+sender timeout budgets. Failures occurring during teardown do not trigger onset
+capture. Diagnostic helper failures are reported as failures, not green evidence.
+
+`_list_columns()` now lets its existing caller tolerate and report lookup errors;
+previously its catch-all hid timeouts from the diagnostic callback.
+
+## Reading the next artifact
+
+| Evidence during the same interval | Interpretation |
+|---|---|
+| Heartbeat regular; HTTP blocked; repeated native file-operation stacks | Investigate filesystem/page-fault service and worker occupancy. Correlate with syscall durations and host paging. |
+| Heartbeat regular; JVM safepoint spans the delay | Investigate the recorded safepoint/GC cause and time to reach it. |
+| Heartbeat regular; repeated shared lock or queue waits | Trace the owner and dependency. A waiter is not necessarily the cause. |
+| Heartbeat itself has a large gap | Observer scheduling, VM pause, or shared resource delay is possible; not proof of hypervisor descheduling. Check prior log-write duration and host metrics. |
+| HTTP stays responsive; sender drain stalls | Investigate connection-specific ACK/commit/replay progress, not a global server freeze. |
+
+Artifact files: `watchdog.jsonl`, `heartbeat.jsonl`, `capture.jsonl`,
+`native-sample.txt`, `sample-command.log`, `jvm-pauses.log*`, `questdb-server.log`,
+`server.conf`, and on B `fs-usage.log`, plus host manifest/memory/iostat logs.
+SIGQUIT request time is not dump completion time. JVM dumps use the server log;
+native sampling and watchdog output do not depend on that logger. All files
+still share storage. `previous_write_ms` exposes one source of observer delay.
+
+Completed filesystem traces cannot reveal every in-flight operation. Sampling
+and SIGQUIT perturb scheduling after detection; continuous tracing perturbs the
+entire traced arm. Hosted-VM steal time and the original host's pressure timeline
+remain unavailable. Do not optimize production code based only on these stacks.

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -52,9 +52,23 @@ not. This establishes a mechanism, not the original macOS trigger. See the
   12:19:06.083621, then reports a server-side timeout after 74,706 ms.
   HTTP, WAL purge and WAL-apply log activity resumes together. A producer's
   close-drain timeout follows at 12:19:44.
-- The first JVM dump, at 12:20:12, is **after failure and during DROP cleanup**:
+- The first JVM dump, headed 12:20:12, is **after failure and during DROP cleanup**:
   three HTTP workers in truncate/msync paths, two WAL-apply workers idle.
   It establishes a late software location, not the original limiting resource.
+- Timing audit: QueryProgress duration uses `Os.currentTimeNanos()` backed by
+  `clock_gettime(CLOCK_REALTIME)` in the pinned server; the SQL breaker uses
+  `System.currentTimeMillis()`. Agreement between reported duration and log
+  timestamps is not independent monotonic confirmation. Client close-drain
+  deadlines use Rust `Instant`. A wall-clock adjustment alone does not explain
+  the client deadline expiring; the original interval lacks paired clocks.
+- The two original dump headers are 391 seconds apart, but the persistent
+  Reference Handler's monotonic elapsed counters differ by 363.79 seconds.
+  HotSpot samples the header before printing thread elapsed counters; stalled
+  output can separate them. Do not assign all first-dump frames precisely to
+  12:20:12. No original clock-adjustment or dump-output latency record exists.
+- First-dump cumulative CPU: all three HTTP threads total 3941.47 ms; GC workers
+  total 227.60 ms. These constrain CPU-work explanations, not off-CPU waits or
+  time to reach a safepoint. They are not interval-specific measurements.
 - WAL commit/ordinary ACK does not normally await O3 application. Both paths
   still share OS resources; schema changes also reconcile and roll WAL files.
   The fuzz case includes type conversions, despite its name.

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -4,9 +4,42 @@ Status: server progress interruption observed; root cause **not established**.
 This branch is diagnostic only. Keep sender timeouts and correctness assertions
 unchanged. Azure PR 200 allocates only one macOS worker, running only
 `TestQwpWsFuzz.test_add_columns` with the focused query-stage probe below when
-workload mode is enabled. The current default is a kernel-stack recorder preflight.
+workload mode is enabled. The current default is a bounded kernel-wait follow-up.
 
-## Current action: kernel-stack access check, no server build
+## Current action: kernel wait capture with query-stage context
+
+Build 268468 collected a real three-second system spindump with 156 samples.
+The original validator incorrectly expected the kernel marker after the sample
+count, while report v60 prints `*156 function`. Local parsing of the retained
+report finds 4,829 kernel-frame lines and 693 named frames, including APFS and
+AppleVirtIOStorage frames. This access check succeeded; the CI failure was the
+validator, now covered by a regression test. No repeat preflight is needed.
+
+The next arm uses one natural-memory unrecorded control, then at most seven
+attempts with kernel capture on the first failed ping, slow SHOW or explicit
+workload failure. Original test inputs, 72-lookup prefix and query-stage overlay
+remain. There is no extra disk load or memory-pressure helper. Stop after the
+first capture/failure, one Mac, no new attempt after 600 seconds.
+
+`QWP_WS_KERNEL_CAPTURE=ping` explicitly enables this resource follow-up;
+`query` reserves kernel capture for the existing query/failure triggers, and
+`off` leaves the old sampler unchanged. Attempt 1 remains unrecorded in either
+enabled mode. The ping follow-up is not a reproduction of the original long
+query. Its purpose is to distinguish kernel transaction coordination, I/O
+completion and throttling behind the already captured APFS wake-up chain.
+
+The kernel recorder starts only after the triggering anomaly. Sampling lasts
+three seconds at 20 ms intervals; symbol processing is deferred until sampling
+ends. The tool has a 25-second total limit, its privileged controller bounds
+and reaps the actual recorder process, and no SIGQUIT is sent until it finishes.
+Kernel mode replaces the ordinary native sample rather than layering another
+sampler on top. Only post-workload teardown waits longer (50 seconds) to retain
+the report before DROP; workload assertions and sender/SQL deadlines are not
+extended. A missing/unusable report remains an explicit diagnostic failure.
+Reporter overhead can affect subsequent progress; align its time range with
+query stages and workload completion before interpreting any stack.
+
+## Completed arm: kernel-stack access check, no server build
 
 Build 268458 passed all four natural/warn/warn/natural attempts. Both warning
 gates reached kernel level 2 (after 30.369 and 20.408 seconds of polling), and

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -8,6 +8,15 @@ workload mode is enabled. The current default is a paired mapped-file perturbati
 
 ## Current action: mapped-file shrink with slow-query capture
 
+Build 268475 completed all four attempts and 56 query cursors (maximum 130 ms).
+Its helper overlapped the workload, but a source audit found a confound:
+CPython 3.14.7 mmapmodule.c:1855-1859 issues F_FULLFSYNC before mmap on macOS.
+The helper's measured mapping stage therefore included an implicit full flush
+(maximum 293 ms). This run is not a clean test of the intended sequence.
+The follow-up changes only the mapping wrapper to raw libc mmap/munmap and
+retains the same paired plan and budgets. A real-filesystem regression test
+forbids calling Python's mmap constructor and checks the mapped bytes/size.
+
 Build 268472 passed four attempts and captured kernel stacks in run 4. All 47
 SHOW COLUMNS cursors completed; maximum 45.495 ms. The one-second ping failed
 before sampling, but another ping succeeded 143 ms before the first sample.

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -7,7 +7,34 @@ unchanged. Azure PR 200 allocates only one macOS worker, running only
 workload mode is enabled. The current default follows the severe filesystem
 episode captured in build 268479.
 
-## Current action: retain raw kernel samples before symbol processing
+## Current action: remove file writes from the onset path
+
+Build 268487 reproduced five close-drain timeouts in its first low-rate control.
+The helper completed only two cycles (128 KiB application writes). Its second
+grow/ftruncate took 66.224 seconds with 34 us CPU, entirely BEFORE recorder
+launch. The memory-buffered heartbeat covered it with no gap over 400 ms.
+This particular interval was neither a continuous whole-VM scheduling freeze
+nor initiated by the profiler. One SHOW cursor completed in 6.629 ms; this still
+does not reproduce the original already-started long SHOW query.
+
+Capture launched only after the long wait ended: file-writing diagnostics again
+stopped advancing. Raw spindump sampled successfully according to stderr but
+timed out generating its output file; the raw file is empty. Removing symbol
+lookup alone did not solve retention. There are no usable kernel frames here.
+
+Next revision buffers ping/capture events in memory, pre-creates recorder
+directories before watchdog-ready, and uses documented -noFile output through
+two drained pipes (binary stdout, diagnostic stderr). The privileged recorder
+controller opens no output files. After bytes reach the watchdog process they
+are persisted outside the recorder's timeout, then decoded after workload and
+server shutdown. A nonempty binary is still only transport validation; decoded
+named kernel frames are required for a successful diagnostic outcome. The
+64 MiB raw artifact limit is checked after collection, not a streaming memory
+limit. File-based query markers and filesystem persistence can still block;
+this is not a claim of an entirely filesystem-independent observer. Same one
+Mac, four-attempt bounds and unchanged workload/deadlines.
+
+## Completed arm: retain raw kernel samples before symbol processing
 
 Build 268483 failed in teardown on its first low-rate attempt, not in producer
 close-drain. All eight drains completed, maximum 31.496 seconds. All 16 SHOW

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -7,7 +7,33 @@ unchanged. Azure PR 200 allocates only one macOS worker, running only
 workload mode is enabled. The current default follows the severe filesystem
 episode captured in build 268479.
 
-## Current action: earlier kernel capture and memory-buffered heartbeat
+## Current action: retain raw kernel samples before symbol processing
+
+Build 268483 failed in teardown on its first low-rate attempt, not in producer
+close-drain. All eight drains completed, maximum 31.496 seconds. All 16 SHOW
+cursors completed; the longest was 930.846 ms, including 929.753 ms in reader
+open. That query began after the kernel recorder was launched; do not attribute
+its duration to uninstrumented workload behavior. No original long-query
+signature was captured.
+
+The independent helper spent 16.386 seconds in grow/ftruncate with 141 us CPU,
+and another grow took 9.143 seconds. The memory-buffered heartbeat covered both
+intervals without a gap over 403.333 ms. This excludes a continuous multi-second
+whole-VM scheduling freeze for those intervals, not all host scheduling effects.
+Thirty low-rate cycles wrote 1.875 MiB; no high-rate attempt ran.
+
+The recorder announced sampling complete, then timed out during symbol
+processing and left a zero-byte report. The next run uses the installed tool's
+documented -noText -noSymbolicate options to save a binary capture first.
+Nonempty raw output is only transport validation, not proof of useful frames.
+After workload/server shutdown, -i regenerates a symbolic text report with a
+60-second tool limit and 65-second controller bound. A failed decode fails the
+diagnostics but preserves the raw artifact for another decode without rerunning
+the workload. Onset sampling remains three seconds at 20 ms, bounded as before;
+SIGQUIT still follows the recorder, never overlaps sampling. Same four-attempt
+plan, one Mac, stop first capture/failure, unchanged sender and SQL deadlines.
+
+## Completed arm: earlier kernel capture and memory-buffered heartbeat
 
 Build 268479 failed in the first low-rate control attempt: seven producers
 reported close-drain timeout, 24 pings failed, and the server needed forced

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -4,9 +4,54 @@ Status: server progress interruption observed; root cause **not established**.
 This branch is diagnostic only. Keep sender timeouts and correctness assertions
 unchanged. Azure PR 200 allocates only one macOS worker, running only
 `TestQwpWsFuzz.test_add_columns` with the focused query-stage probe below when
-workload mode is enabled. The current default is export-only, described next.
+workload mode is enabled. The current default is four paired-memory attempts.
 
-## Current action: decode retained VM and scheduler evidence
+## Current action: actual warning-pressure workload
+
+Build 268431's warning state arrived only after its 20-second setup gate had
+expired. The next arm uses natural/warn/warn/natural, keeps the 72-lookup prefix
+and query overlay, and disables the separate disk load. Actual kernel pressure
+must reach the selected level before the workload starts. The target gate is
+45 seconds; fixture setup allows 90 seconds for recovery, helper startup and
+verification. These are pre-workload bounds, not sender or SQL timeout changes.
+Stop on first slow query, observer loss or failure; no new attempt after 600 s.
+Warning at the gate is not proof of sustained warning throughout the workload:
+interpret the retained host samples alongside query events.
+
+## New retained evidence: APFS transaction wake-up chain
+
+Build 268456 decoded build 268363/run-4 without a new workload. Mach VM and
+context-switch exports completed. The all-system scheduler export hit its
+45-second limit after writing a 449 MB partial XML; the complete event rows
+cover the interval below and can be parsed locally. Later tables were not
+exported. Do not equate this tooling failure with a QuestDB failure.
+
+Relative to that recording's retained-window origin, the three HTTP threads
+assert wait on the same kernel event `0x787d29237fe859cd` at 575.828, 576.505
+and 576.515 ms, then block inside their already measured ftruncate calls.
+`apfs_transaction_flusher` (TID 0x1dd) emits make-runnable events for all three
+HTTP TIDs at 853.856208, 853.862708 and 853.863291 ms. The independent target
+context-switch table confirms the corresponding Runnable transitions.
+
+Within that interval the flusher asserts a wait at 635.518541 ms; the next
+make-runnable event for it is emitted by `AppleVirtIOQueue` (TID 0xe4) at
+850.838541 ms: 215.320 ms later. The virtual-I/O thread itself had asserted a
+wait and switched out around 635.512 ms, and does not resume until 850.800 ms.
+This is evidence of an APFS transaction wait and a virtual-I/O wake-up chain
+for this captured short stall, not Java FdCache contention. It does not reveal
+the host-side completion delay, physical device latency, or any burst quota.
+
+Event semantics were checked against Apple's published macOS 15-era XNU
+`xnu-11417.140.69`: `MACH_WAIT` (0x10) records the obfuscated event; and
+`MACH_MAKE_RUNNABLE` (0x6) records the target TID in arg1. The waking execution
+context must not automatically be treated as the originator of an I/O request;
+interrupts may run in an unrelated Java thread's context. APFS internals are
+not established from these event names or opaque wait IDs.
+
+This remains a later short-stall capture. It does not identify what blocked
+the original already-started SHOW COLUMNS for 74.7 seconds.
+
+## Completed arm: decode retained VM and scheduler evidence
 
 Build 268446 passed all eight probe/load attempts, with 95 completed probe
 cursors and maximum query duration 104.499 ms. Each load arm completed its
@@ -16,7 +61,7 @@ No original-like query stall was reproduced. This short, bounded workload does
 not establish quota exhaustion or clear storage as a suspect. Ordinary fsync
 also does not reproduce the Apple F_FULLFSYNC calls used by Rust file syncing.
 
-The next job sets `qwpWsDecodeOnly=true`: download the already recorded build
+Build 268456 used `qwpWsDecodeOnly=true`: download the already recorded build
 268363/run-4 System Trace and export context-switch, virtual-memory, system-load,
 Mach VM and scheduler tables. The run's file names and contents are SHA-256
 pinned independently of ZIP packaging. Export selection uses the current

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -29,11 +29,35 @@ after the first capture/failure, at most 12 repetitions, no new attempt after
 
 Builds 268394 and 268424 passed 40 natural-memory attempts each, with respectively
 504 and 555 completed probe cursors and maxima of 137.21 and 158.25 ms. No
-five-second query or observer-loss marker appeared. The next experiment uses
-three natural/warn/warn/natural cycles on one worker, with the same query probe.
-This is an exploratory resource perturbation, not a claim that original memory
-pressure was established. It tests whether real warning pressure can reproduce
-the prolonged query stage, rather than merely slowing WAL/ping traffic.
+five-second query or observer-loss marker appeared.
+
+Build 268431 passed its natural control, then failed pressure setup before the
+second workload started: all sampled kernel pressure levels remained normal
+through the 20-second gate. The allocator substantially increased compression,
+but that is not a valid warning-pressure test and says nothing about the
+original timeout's cause. Pressure is disabled for the next arm.
+
+The original startup prefix is measurably different: 72 failed SHOW COLUMNS
+lookups occurred during the 8.948517 seconds before the first QWP handshake.
+Across all 80 attempts above, only 1..3 lookups preceded that handshake, after
+28..374 ms. All recorded missing-table sequences match the seeded ALTER RNG.
+Thus the same seed did not restore the original ALTER RNG position at ingestion.
+
+The next 12 attempts gate producer connection until the real ALTER thread has
+received 72 actual table-not-found errors. Every query, table-choice draw and
+normal loop sleep still runs. No RNG is skipped or replaced. The gate has a
+30-second bound and rejects unexpected lookup outcomes; it is opt-in via
+`QWP_WS_STARTUP_LOOKUPS=72` and requires fuzz diagnostics. It releases producers
+after lookup 72; further missing lookups may occur while they connect. Artifacts
+must verify the resulting prefix. This restores a recorded scheduling prefix,
+not the unknown cause of the original nine-second startup delay or the later
+exact interleaving. Sender and SQL deadlines and data assertions are unchanged.
+Local Linux calibration passed the full test in 7.787 seconds with three CPUs,
+eight producers and the original server revision. All 72 gated table names
+matched the original recorded prefix exactly. Its JDK 25.0.4 and Linux filesystem
+make this a harness check, not a macOS resource-wait reproduction.
+
+### Optional pressure arm (currently disabled)
 
 `memory_pressure -l warn -s 1` applies real allocation pressure (no `-S`), with
 one-second regulation. Before releasing each paired-plan workload, the harness

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -4,9 +4,42 @@ Status: server progress interruption observed; root cause **not established**.
 This branch is diagnostic only. Keep sender timeouts and correctness assertions
 unchanged. Azure PR 200 allocates only one macOS worker, running only
 `TestQwpWsFuzz.test_add_columns` with the focused query-stage probe below when
-workload mode is enabled. The current default is a paired mapped-file perturbation.
+workload mode is enabled. The current default follows the severe filesystem
+episode captured in build 268479.
 
-## Current action: mapped-file shrink with slow-query capture
+## Current action: earlier kernel capture and memory-buffered heartbeat
+
+Build 268479 failed in the first low-rate control attempt: seven producers
+reported close-drain timeout, 24 pings failed, and the server needed forced
+shutdown. Only 18 helper cycles (1.125 MiB application writes) ran. Its final
+grow/ftruncate interval lasted 88.783 seconds with 79 microseconds process CPU.
+The helper starts no new cycle after 60 seconds; this in-flight call exceeded
+that bound. It is not an intentional 89-second sleep or heavy-write load.
+
+The independent heartbeat's 89.260-second gap included 88.922 seconds inside
+its prior log-write call. The gap alone therefore does not establish a whole-VM
+scheduling pause. All sampled guest pressure levels were normal (1), with no
+swap. Earlier dumps show HTTP workers in truncate, copy and allocation; WAL
+apply workers are also in allocation. No O3-held Java monitor is established.
+Only two observed SHOW COLUMNS cursors ran, both completed (51.153 and 2.398 ms):
+the original already-started long-query signature is still not reproduced.
+
+The first attempt used the ordinary native sampler, which timed out without a
+report. The next bounded four-attempt paired run permits kernel capture on
+EVERY attempt, including the first, after two consecutive one-second ping
+failures (or existing query/observer/workload triggers). This targets sustained
+HTTP loss before the log-writing observer becomes blocked. Single short ping
+failures do not trigger kernel capture. No sampler starts before the anomaly.
+
+The independent heartbeat now stores at most 8192 events in memory and writes
+them on stop, with explicit loss rejection if capacity is exceeded. Its gap
+measurements no longer include per-event file writes; buffered records are
+labelled. No ramdisk file or /tmp path is introduced. Main ping/capture logs
+still write to disk and can be delayed by filesystem stalls; this does not
+pretend to eliminate every observation limit. Test deadlines and helper bounds
+remain unchanged; stop after first capture/failure and use only one Mac.
+
+## Completed arm: mapped-file shrink with slow-query capture
 
 Build 268475 completed all four attempts and 56 query cursors (maximum 130 ms).
 Its helper overlapped the workload, but a source audit found a confound:

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -3,7 +3,31 @@
 Status: server progress interruption observed; root cause **not established**.
 This branch is diagnostic only. Keep sender timeouts and correctness assertions
 unchanged. Azure PR 200 allocates only one macOS worker, running only
-`TestQwpWsFuzz.test_add_columns` with the focused query-stage probe below.
+`TestQwpWsFuzz.test_add_columns` with the focused query-stage probe below when
+workload mode is enabled. The current default is export-only, described next.
+
+## Current action: decode retained VM and scheduler evidence
+
+Build 268446 passed all eight probe/load attempts, with 95 completed probe
+cursors and maximum query duration 104.499 ms. Each load arm completed its
+4096-cycle budget in 1.393, 2.005, 2.053 or 4.240 seconds. The longest independent
+truncate took 274.514 ms, pwrite 136.634 ms, and ordinary fsync 141.423 ms.
+No original-like query stall was reproduced. This short, bounded workload does
+not establish quota exhaustion or clear storage as a suspect. Ordinary fsync
+also does not reproduce the Apple F_FULLFSYNC calls used by Rust file syncing.
+
+The next job sets `qwpWsDecodeOnly=true`: download the already recorded build
+268363/run-4 System Trace and export context-switch, virtual-memory, system-load,
+Mach VM and scheduler tables. The run's file names and contents are SHA-256
+pinned independently of ZIP packaging. Export selection uses the current
+xctrace TOC, not assumed old table positions. No dependency installation, client
+or server build, pressure helper or test workload runs. One Mac is needed only
+because xctrace cannot decode the recording on this Linux host. Download and
+exports are bounded; a 2 GiB free-space guard remains.
+
+This examines an existing short stall, not the original 74.7-second operation.
+The recording did not enable kernel callstack capture, so VM/scheduler events
+may narrow the waits without identifying the kernel lock or device responsible.
 
 ## Current focus: the original slow SHOW COLUMNS
 
@@ -36,6 +60,10 @@ second workload started: all sampled kernel pressure levels remained normal
 through the 20-second gate. The allocator substantially increased compression,
 but that is not a valid warning-pressure test and says nothing about the
 original timeout's cause. Pressure is disabled for the next arm.
+Later audit of the retained host monitor found level 2 in the 16:26:19 sample,
+after the gate had expired around 16:26:08. The allocator did reach warning:
+the 20-second gate was too short, and no workload ran under that verified state.
+Do not rerun that pressure plan unchanged or claim the helper cannot reach warn.
 
 The original startup prefix is measurably different: 72 failed SHOW COLUMNS
 lookups occurred during the 8.948517 seconds before the first QWP handshake.

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -5,6 +5,13 @@ This branch is diagnostic only. Keep sender timeouts and correctness assertions
 unchanged. Azure PR 200 allocates only two macOS workers for
 `TestQwpWsFuzz.test_add_columns`.
 
+Local follow-up, 2026-09-08: a controlled O3 close delay demonstrated global
+`FdCache` lock propagation into both WAL segment work and the serial network
+dispatcher (socket acceptance/closure). Three interleaved inside-lock trials
+delayed unrelated-table ACKs by six seconds; three outside-lock controls did
+not. This establishes a mechanism, not the original macOS trigger. See the
+[experiment, results and rerun instructions](diagnostics/fd_cache_close/README.md).
+
 ## Evidence and limits
 
 - Original [build 266336](https://dev.azure.com/questdb/questdb/_build/results?buildId=266336):

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -4,9 +4,39 @@ Status: server progress interruption observed; root cause **not established**.
 This branch is diagnostic only. Keep sender timeouts and correctness assertions
 unchanged. Azure PR 200 allocates only one macOS worker, running only
 `TestQwpWsFuzz.test_add_columns` with the focused query-stage probe below when
-workload mode is enabled. The current default is a bounded kernel-wait follow-up.
+workload mode is enabled. The current default is a paired mapped-file perturbation.
 
-## Current action: kernel wait capture with query-stage context
+## Current action: mapped-file shrink with slow-query capture
+
+Build 268472 passed four attempts and captured kernel stacks in run 4. All 47
+SHOW COLUMNS cursors completed; maximum 45.495 ms. The one-second ping failed
+before sampling, but another ping succeeded 143 ms before the first sample.
+These are recovery stacks, not an onset capture or original reproduction.
+
+All three HTTP workers sampled buffer-I/O completion waits inside ftruncate,
+including mapped-pageout and clustered-write paths. Each had 5 of 156 samples
+in throttle_lowpri_io, versus 45-59 in buf_biowait. These distinct waits must not
+be conflated with provider quota or measured physical-device service time.
+The APFS flusher also sampled synchronous virtual-disk unmap waits, while HTTP
+workers waited for transaction entry. No evidence ties these later stacks to
+the original already-started 74.7-second SHOW COLUMNS.
+
+The previous load helper used pwrite/fsync and exhausted its byte budget within
+1.4-4.2 seconds. The next paired low-rate/load/load/low-rate arm uses mapped
+writes, unmap, then shrink, following MemoryCMARWImpl.close ordering. Its sparse
+growth does not reproduce physical F_PREALLOCATE. A fresh file stays at most
+1 MiB; each cycle dirties 64 KiB. The 256 MiB application-write cap, 60-second
+helper deadline and workload-finished stop remain; load cycles have 10 ms pacing
+to maintain overlap. Control cycles use the same pattern once per second.
+No explicit fsync/msync drains the dirty mapping before shrink.
+
+Only four attempts on one Mac, original 72-lookup prefix, natural memory. The
+query overlay remains; kernel capture is reserved for slow queries, observer
+loss or workload failure, not short ping failures. Stop on first capture/failure.
+No sender or SQL deadline is changed. This arm asks whether this measured class
+of filesystem work can impede SHOW COLUMNS, not whether a known quota exists.
+
+## Completed arm: kernel wait capture with query-stage context
 
 Build 268468 collected a real three-second system spindump with 156 samples.
 The original validator incorrectly expected the kernel marker after the sample

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -24,7 +24,7 @@ telemetry and a heartbeat. Dropped/missing telemetry fails the diagnostic arm.
 An active cursor reaching five seconds requests the existing native/JVM stack
 capture. Ping and heartbeat measurements remain enabled but short anomalies no
 longer trigger invasive captures. Workload-error capture remains enabled. Stop
-after the first capture/failure, at most 12 repetitions, no new attempt after
+after the first capture/failure, at most 8 repetitions, no new attempt after
 600 seconds, one macOS worker. Original test/sender/SQL timeouts are unchanged.
 
 Builds 268394 and 268424 passed 40 natural-memory attempts each, with respectively
@@ -43,7 +43,7 @@ Across all 80 attempts above, only 1..3 lookups preceded that handshake, after
 28..374 ms. All recorded missing-table sequences match the seeded ALTER RNG.
 Thus the same seed did not restore the original ALTER RNG position at ingestion.
 
-The next 12 attempts gate producer connection until the real ALTER thread has
+Build 268433 gated producer connection until the real ALTER thread had
 received 72 actual table-not-found errors. Every query, table-choice draw and
 normal loop sleep still runs. No RNG is skipped or replaced. The gate has a
 30-second bound and rejects unexpected lookup outcomes; it is opt-in via
@@ -56,6 +56,45 @@ Local Linux calibration passed the full test in 7.787 seconds with three CPUs,
 eight producers and the original server revision. All 72 gated table names
 matched the original recorded prefix exactly. Its JDK 25.0.4 and Linux filesystem
 make this a harness check, not a macOS resource-wait reproduction.
+
+Build 268433 passed all 12 attempts: 165 completed probe cursors, maximum
+185.126 ms, zero failed pings and maximum close-drain 5.446 seconds. Every gated
+72-name sequence matched the original. Ten runs had exactly 72 missing lookups
+before the first handshake; two had 73. No original stall was reproduced.
+
+### Current arm: bounded filesystem work with independent call timing
+
+The failing worker was unusually slow before QuestDB startup. The exact grpc
+1.83.0 bottle took 129.437 seconds to pour versus 1.707 on a sibling Mac in the
+same build; LLVM 22.1.8 took 63.427 versus 7.854 seconds. Adjacent scheduled
+QWP/WS Macs used the same client/server/JVM/macOS image and poured grpc in
+2.306/2.231 seconds. These are log intervals, not physical-disk measurements;
+they support a pre-existing worker problem, not a particular resource cause.
+Original logs: build 266336 task 79 versus 54; neighboring builds 266323 task 57
+and 266352 task 62. Different neighboring fuzz seeds prevent same-workload claims.
+
+The next eight attempts use probe/load/load/probe twice. The 72-lookup gate,
+query overlay and original deadlines remain fixed; memory pressure is off.
+A separate Python process repeatedly truncates its own file to zero, writes
+64 KiB of pre-generated random bytes, and calls fsync. Probe arms sleep one
+second between cycles; load arms do not. It starts only after SHOW COLUMNS
+telemetry exists, so it does not spend its budget on the artificial startup
+prefix. Each process records every call's monotonic elapsed and process CPU time.
+
+Each attempt starts at most 4096 cycles (256 MiB written) and stops starting
+cycles after 60 seconds or workload completion. Four load arms therefore write
+at most 1 GiB combined. The file itself is at most 64 KiB, created exclusively
+inside the attempt directory; it is retained as an artifact. No external files,
+devices, mounts or quotas are modified. Existing free-space and CI time guards
+remain. An in-flight kernel call can exceed the cycle deadline: that delay is
+precisely what must be retained, not hidden by a timeout increase.
+
+This is an exploratory filesystem-load perturbation, not an emulation of a
+known Azure burst quota. fsync does not establish physical-media latency or
+an Apple full-device flush. The control probe also performs I/O, so it is not
+an untouched natural control. Compare actual syscall timing and overlap with
+the query stages, independent heartbeat, CPU/memory and host I/O before drawing
+conclusions. A failed/absent/no-overlap helper invalidates the attempt.
 
 ### Optional pressure arm (currently disabled)
 

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -51,10 +51,38 @@ Both replicas use server `12a33d651e51e2682e7a448c8db5168fc72dfad3`, Temurin
 and JVM `ActiveProcessorCount=3`. The managed hosted macOS image is still
 moving; record its version, do not call this an exact environment reproduction.
 
-Replica A has lightweight monitoring; replica B additionally runs continuous
-`fs_usage`. Each runs at most 20 attempts and stops at its first capture or test
-failure. No synthetic memory pressure. Store-and-forward, Java temporary data,
-and diagnostics are explicitly on the worker filesystem, not `/tmp`.
+Both replicas now use lightweight monitoring and loop the unchanged test up to
+60 times on their respective hosted VM. Do not schedule each attempt as a new
+job: that would replace the VM instead of testing cumulative host load. A fresh
+JVM and fixture are installed for each attempt, with no added cooldown; the
+test's existing internal waits and setup/teardown remain unchanged.
+
+The prior 20-attempt configuration stopped at the first onset capture, including
+a recovered one-second ping timeout. The soak continues after such captures
+when the test passes. It stops immediately on a test/diagnostic failure, refuses
+to start another attempt after 20 minutes, and stops below 2 GiB free space.
+The in-flight test keeps its original timeouts; a 30-minute pipeline step limit
+is the outer safety bound. Artifact publishing remains unconditional.
+
+Continuous `fs_usage` is disabled on both replicas so its large trace output
+does not become the soak's disk workload. Onset thread dumps and native samples,
+JVM pause logs, per-second `iostat`/`vm_stat`, and five-second memory/process
+snapshots remain enabled. No synthetic memory pressure or injected delays.
+Store-and-forward, Java temporary data, and diagnostics are explicitly on the
+worker filesystem, not `/tmp`.
+
+`runs.jsonl` records attempt index, UTC start, elapsed soak/attempt time, unittest
+duration, free space, completed drain maximum, ping errors/maximum, heartbeat
+maximum, capture reason and exit status. Raw per-attempt `test.log` and server
+logs are preserved. Compare successive fixed-seed attempts with the continuous
+host measurements; concurrent scheduling and schema interleavings can still vary.
+The first disk/VM-stat sample includes statistics since boot, not just this test.
+
+This tests cumulative degradation, not a known provider quota. Microsoft's
+[hosted-agent documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops)
+places these macOS machines in GitHub's macOS cloud; an Azure managed-disk burst
+credit policy must not be assumed. A worsening latency curve alone would not
+prove quota exhaustion, and no degradation would not exclude an unknown quota.
 
 The external Python watchdog probes `/ping` once per second with a one-second
 timeout. A separate thread records quarter-second heartbeats in another file.
@@ -81,7 +109,9 @@ previously its catch-all hid timeouts from the diagnostic callback.
 
 Artifact files: `watchdog.jsonl`, `heartbeat.jsonl`, `capture.jsonl`,
 `native-sample.txt`, `sample-command.log`, `jvm-pauses.log*`, `questdb-server.log`,
-`server.conf`, and on B `fs-usage.log`, plus host manifest/memory/iostat logs.
+`server.conf`, per-attempt `test.log`, `runs.jsonl`, plus host
+manifest/memory/iostat logs. `fs-usage.log` is only present when the optional
+continuous tracing setting is explicitly enabled (off in the current soak).
 SIGQUIT request time is not dump completion time. JVM dumps use the server log;
 native sampling and watchdog output do not depend on that logger. All files
 still share storage. `previous_write_ms` exposes one source of observer delay.

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -2,8 +2,9 @@
 
 Status: server progress interruption observed; root cause **not established**.
 This branch is diagnostic only. Keep sender timeouts and correctness assertions
-unchanged. Azure PR 200 now allocates only one macOS worker for
-`TestQwpWsFuzz.test_add_columns`.
+unchanged. Azure PR 200 allocates only one macOS worker. The next run is
+**preflight-only**: establish recorder startup before resuming
+`TestQwpWsFuzz.test_add_columns`. It will not compile or start QuestDB.
 
 Local follow-up, 2026-09-08: a controlled O3 close delay demonstrated global
 `FdCache` lock propagation into both WAL segment work and the serial network
@@ -60,8 +61,56 @@ not. This establishes a mechanism, not the original macOS trigger. See the
   Maximum completed drain was 9.795 seconds; no consistent across-host latency
   deterioration or sampled swap activity was observed. Provider burst-credit
   exhaustion and physical-storage saturation remain unproven.
+- [Build 268344](https://dev.azure.com/questdb/questdb/_build/results?buildId=268344)
+  reached the System Trace preflight on Xcode 16.4. Readiness was absent when
+  the collector's 15-second startup budget expired; the recorder log was empty
+  and no trace was published. The error combined early exit, cancellation, and
+  timeout, and did not record the child PID/exit status. This does not establish
+  a permissions failure or lack of System Trace support. Compilation and the
+  QuestDB test were skipped; only one macOS job ran.
 
-## Current experiment
+## Current experiment: recorder startup only
+
+Pipeline parameter `qwpWsPreflightOnly` defaults to `true`. In that mode the
+expanded job contains checkout, tracing preflight, artifact ownership hand-back,
+and publication only. Dependency installs, client/server builds, the fuzz test,
+and server-log archival are excluded even if the smoke check succeeds. The job
+limit is ten minutes; the preflight step limit is five minutes. Do not turn the
+full experiment back on until the startup artifact has been inspected.
+
+Only the preflight receives a 60-second startup budget. The full test's recorder
+startup budget remains 15 seconds within its unchanged 30-second fixture gate.
+The smoke process now waits through cold startup and recorder cleanup rather
+than expiring at the old 25-second deadline. It exits without replacing the
+parent's error if the recorder finishes before releasing the smoke workload.
+
+New startup artifacts in `preflight/`:
+
+- `system-trace-launch.json`: exact recorder command and startup budget.
+- `system-trace-recorder.json`: actual recorder PID and attach-target PID.
+- `system-trace-startup.jsonl`: elapsed startup/clock readings and exit state
+  every five seconds, plus the failure transition.
+- `system-trace-ready.json`: startup latency when the notification arrives.
+- `system-trace-startup-failure.json`: distinct timeout, spontaneous exit, or
+  interruption, with the return code **before cleanup**.
+- `system-trace-startup-processes.log`: PID/parent, process group, state, CPU,
+  RSS, elapsed time, and command for the collector, recorder, and smoke target.
+- `system-trace-startup-sample.txt`: a one-second native sample of a recorder
+  still alive after startup failure. It is never taken during successful startup
+  or while running the QuestDB test. The process snapshot and sample have
+  five-/ten-second command deadlines; command errors/statuses are retained in
+  `system-trace-startup-diagnostics.json` and its accompanying command logs.
+- `system-trace-cleanup.json` and `system-trace-recorder-exit.json`: state before
+  cleanup and the final child return code. Do not mistake a cleanup-induced
+  SIGINT/SIGKILL exit for a spontaneous recorder failure.
+
+Startup diagnostic failure cannot suppress recorder cleanup or replace the
+original failure reason. Cancellation skips startup sampling. A longer deadline
+is an exploratory cold-start allowance, not a claim that slow initialization
+caused build 268344. A successful check still requires actual target syscall
+and scheduler rows; readiness alone is not sufficient.
+
+## Full experiment (disabled by default)
 
 The single worker uses server `12a33d651e51e2682e7a448c8db5168fc72dfad3`, Temurin
 25.0.3+9 (official download with pinned SHA-256), fuzz seed
@@ -79,7 +128,7 @@ filesystem/sleep smoke workload on the worker. It exports the trace TOC, discove
 syscall and thread-state tables, and requires actual rows associated with the
 smoke PID in both. Merely finding Xcode or creating a `.trace` directory is not
 success. Unsupported schemas or denied tracing stop the job at this preflight,
-which has a three-minute step limit; its logs/artifacts are still published.
+which has a five-minute step limit; its logs/artifacts are still published.
 No SIP or developer-security settings are changed. The root collector owns and
 reaps its recorder child; artifact ownership is returned to the CI uploader.
 
@@ -147,7 +196,12 @@ previously its catch-all hid timeouts from the diagnostic callback.
 
 ## Reading the next artifact
 
-Download `qwp-ws-macos-system-trace`. First check `preflight/`, the final stop
+Download `qwp-ws-macos-system-trace`. For the current preflight-only run, inspect
+the startup artifacts above and `system-trace-valid.json`/`system-trace-error.json`.
+There should be no `run-*` directories or QuestDB logs. Success establishes
+recorder capability only, not a reproduced ping timeout.
+
+When full testing is re-enabled, first check `preflight/`, the final stop
 reason in `test.log`, and each run's `system-trace-valid.json` or error marker.
 A green job with zero onset captures is a negative replay, not a diagnosis.
 

--- a/ci/qwp_ws_investigation.md
+++ b/ci/qwp_ws_investigation.md
@@ -2,7 +2,7 @@
 
 Status: server progress interruption observed; root cause **not established**.
 This branch is diagnostic only. Keep sender timeouts and correctness assertions
-unchanged. Azure PR 200 allocates only two macOS workers for
+unchanged. Azure PR 200 now allocates only one macOS worker for
 `TestQwpWsFuzz.test_add_columns`.
 
 Local follow-up, 2026-09-08: a controlled O3 close delay demonstrated global
@@ -42,43 +42,90 @@ not. This establishes a mechanism, not the original macOS trigger. See the
   This pins the source directly, even though the clone step did not print it.
 - Seeds do not pin concurrent scheduling, schema observations, or the exact
   number of conversions. Two hosts do not provide 40 independent host states.
+- [Build 268075](https://dev.azure.com/questdb/questdb/_build/results?buildId=268075),
+  with the original server/JVM restored, captured a short ping timeout. During
+  its one-second probe, selected file calls occupied approximately 943/950/942 ms
+  on the three HTTP workers. There were 3,462 selected calls, not one long close.
+  Three outlying open/preallocate/truncate calls took 232–251 ms and finished
+  within about 51 microseconds of each other. This is elapsed syscall time,
+  **not a measurement of physical disk service time**.
+- [Build 268312](https://dev.azure.com/questdb/questdb/_build/results?buildId=268312)
+  passed 60 attempts on each of two VMs, with 27 onset captures and 29 failed
+  one-second pings. A/run-36 naturally captured an O3 worker inside native close
+  while holding `FdCache`, with all three HTTP workers waiting for that monitor.
+  A/run-24 captured a WAL-apply worker holding it during native open. These first
+  dumps came after detection: they establish real cross-pool contention but
+  cannot measure its duration during the preceding failed ping.
+- That soak did not reproduce the original 120-second close-drain failure.
+  Maximum completed drain was 9.795 seconds; no consistent across-host latency
+  deterioration or sampled swap activity was observed. Provider burst-credit
+  exhaustion and physical-storage saturation remain unproven.
 
 ## Current experiment
 
-Both replicas use server `12a33d651e51e2682e7a448c8db5168fc72dfad3`, Temurin
+The single worker uses server `12a33d651e51e2682e7a448c8db5168fc72dfad3`, Temurin
 25.0.3+9 (official download with pinned SHA-256), fuzz seed
 `0x268579c36b106b74`, build-mode seed `7856154056746654427`, three hosted CPUs,
 and JVM `ActiveProcessorCount=3`. The managed hosted macOS image is still
 moving; record its version, do not call this an exact environment reproduction.
 
-Both replicas now use lightweight monitoring and loop the unchanged test up to
-60 times on their respective hosted VM. Do not schedule each attempt as a new
-job: that would replace the VM instead of testing cumulative host load. A fresh
-JVM and fixture are installed for each attempt, with no added cooldown; the
-test's existing internal waits and setup/teardown remain unchanged.
+The next measurement is a pre-timeout **System Trace**, not another identical
+soak. The question is whether a long native file call is executing on CPU,
+blocked in a kernel/filesystem wait, or runnable but not scheduled. Kernel
+backtraces and wakeups may identify a wait; an elapsed syscall alone cannot.
 
-The prior 20-attempt configuration stopped at the first onset capture, including
-a recovered one-second ping timeout. The soak continues after such captures
-when the test passes. It stops immediately on a test/diagnostic failure, refuses
-to start another attempt after 20 minutes, and stops below 2 GiB free space.
-The in-flight test keeps its original timeouts; a 30-minute pipeline step limit
-is the outer safety bound. Artifact publishing remains unconditional.
+Before compiling anything, `prepare_qwp_ws_system_trace.sh` records a five-second
+filesystem/sleep smoke workload on the worker. It exports the trace TOC, discovers
+syscall and thread-state tables, and requires actual rows associated with the
+smoke PID in both. Merely finding Xcode or creating a `.trace` directory is not
+success. Unsupported schemas or denied tracing stop the job at this preflight,
+which has a three-minute step limit; its logs/artifacts are still published.
+No SIP or developer-security settings are changed. The root collector owns and
+reaps its recorder child; artifact ownership is returned to the CI uploader.
 
-Continuous `fs_usage` is disabled on both replicas so its large trace output
-does not become the soak's disk workload. Onset thread dumps and native samples,
-JVM pause logs, per-second `iostat`/`vm_stat`, and five-second memory/process
-snapshots remain enabled. No synthetic memory pressure or injected delays.
-Store-and-forward, Java temporary data, and diagnostics are explicitly on the
-worker filesystem, not `/tmp`.
+Run at most 13 attempts on that same VM: attempts **1, 6, 11 are untraced
+controls**, the other ten use System Trace. Stop after two event-bearing traced
+onset captures, or immediately on a test/diagnostic failure. Refuse to start
+another attempt after ten minutes or below 2 GiB free space. The recording itself
+has a 30-second hard limit, finalization a 30-second wait, and export/validation
+a 60-second budget. Recording expiry before onset/completion is a diagnostic
+failure, not evidence of a healthy run. The 30-minute test-step limit remains
+the outer bound; the test and sender retain all existing timeouts/assertions.
+
+The recorder starts at the existing server-ready gate and must post its explicit
+Darwin readiness notification before the workload is released. Registration's
+initial notification state is consumed **before** recorder launch, so it cannot
+be mistaken for readiness. Startup is bounded to leave room within the unchanged
+30-second fixture gate.
+
+At the first failed ping, heartbeat gap, or workload-error request, the watchdog
+synchronously requests SIGINT of the recorder. The privileged collector polls
+that request every 20 ms; the watchdog waits up to three seconds for the
+stop-sent acknowledgment before permitting teardown. Normal workload completion
+uses the same stop/acknowledgment handshake. Traced attempts do **not** launch
+SIGQUIT or native `sample`. Untraced controls retain the previous onset captures.
+Any nonzero recorder exit, missing target events, or stop lag over two seconds
+fails the diagnostic run. Raw `.trace`, TOC, exported rows, and tool stderr are
+kept even when validation fails.
+
+System Trace can use a rolling window; stopping quickly is important, but does
+not itself prove that the whole failed probe was retained. Inspect actual event
+coverage before interpreting a capture. This policy counts event-bearing onset
+captures to bound CI spending, not to declare the investigation solved.
+
+Continuous `fs_usage` is disabled. JVM pause logs, per-second `iostat`/`vm_stat`,
+and five-second memory/process snapshots remain enabled. No synthetic memory
+pressure or injected delays. Store-and-forward, Java/tool temporary data, and
+diagnostics are explicitly directed to the worker filesystem, not `/tmp`.
 
 `runs.jsonl` records attempt index, UTC start, elapsed soak/attempt time, unittest
 duration, free space, completed drain maximum, ping errors/maximum, heartbeat
-maximum, capture reason and exit status. Raw per-attempt `test.log` and server
+maximum, capture reason, trace/validation flags and exit status. Raw per-attempt `test.log` and server
 logs are preserved. Compare successive fixed-seed attempts with the continuous
 host measurements; concurrent scheduling and schema interleavings can still vary.
 The first disk/VM-stat sample includes statistics since boot, not just this test.
 
-This tests cumulative degradation, not a known provider quota. Microsoft's
+Neither this experiment nor the preceding soak tests a known provider quota. Microsoft's
 [hosted-agent documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops)
 places these macOS machines in GitHub's macOS cloud; an Azure managed-disk burst
 credit policy must not be assumed. A worsening latency curve alone would not
@@ -87,8 +134,9 @@ prove quota exhaustion, and no degradation would not exclude an unknown quota.
 The external Python watchdog probes `/ping` once per second with a one-second
 timeout. A separate thread records quarter-second heartbeats in another file.
 The first probe failure, heartbeat gap over one second, or transient workload
-error requests one bounded capture: three SIGQUIT requests 500 ms apart and
-a three-second native `sample` at 10 ms intervals. The JVM writes GC/safepoint
+error requests one bounded capture. In untraced controls, that means three
+SIGQUIT requests 500 ms apart and a three-second native `sample` at 10 ms
+intervals. The JVM writes GC/safepoint
 records to a dedicated rotating log from startup. Capture is allowed to finish
 before DROP cleanup, with a 15-second bound; this does not change workload or
 sender timeout budgets. Failures occurring during teardown do not trigger onset
@@ -99,6 +147,36 @@ previously its catch-all hid timeouts from the diagnostic callback.
 
 ## Reading the next artifact
 
+Download `qwp-ws-macos-system-trace`. First check `preflight/`, the final stop
+reason in `test.log`, and each run's `system-trace-valid.json` or error marker.
+A green job with zero onset captures is a negative replay, not a diagnosis.
+
+For each traced onset:
+
+1. Locate the failed probe's `started_wall_ns` and completion `wall_ns` in
+   `watchdog.jsonl`, and the request/stop markers. Their UTC, monotonic, and Mach
+   clock readings include a clock-read uncertainty bracket. Use the TOC's run
+   start metadata when aligning exported relative timestamps; do not assume the
+   ready notification is the recording origin.
+2. Open `system.trace` in Instruments and verify the failed interval is covered
+   by syscall and scheduler events for the server PID. Check for lost/truncated
+   events. Inspect native thread identities/names in that interval, particularly
+   `shared-network_*`, `shared-write_*`, and `wal-apply_*`.
+3. For long file calls, split elapsed time into running, runnable, and blocked
+   intervals using the thread-state timeline. Inspect available kernel stacks
+   and wakeups for the blocking dependency. Do not label a generic blocked state
+   as disk I/O without supporting stack/event evidence.
+4. Correlate with JVM pause logs, heartbeat, and host paging/CPU/I/O observations.
+   The nominal one-second host counters can drift; they are not exact per-probe
+   service-time measurements. Compare untraced controls for gross observer effects;
+   this small interleaved sample cannot quantify tracing overhead precisely.
+
+If syscall/scheduling tables are unavailable, the preflight stops before build.
+If events are present but their kernel stacks cannot identify the wait, report
+that boundary explicitly; do not spend more identical CI runs assuming the trace
+can expose it. Guest traces cannot prove a provider's storage quota or measure
+unavailable hypervisor steal time.
+
 | Evidence during the same interval | Interpretation |
 |---|---|
 | Heartbeat regular; HTTP blocked; repeated native file-operation stacks | Investigate filesystem/page-fault service and worker occupancy. Correlate with syscall durations and host paging. |
@@ -108,10 +186,10 @@ previously its catch-all hid timeouts from the diagnostic callback.
 | HTTP stays responsive; sender drain stalls | Investigate connection-specific ACK/commit/replay progress, not a global server freeze. |
 
 Artifact files: `watchdog.jsonl`, `heartbeat.jsonl`, `capture.jsonl`,
-`native-sample.txt`, `sample-command.log`, `jvm-pauses.log*`, `questdb-server.log`,
+`native-sample.txt` (controls), `sample-command.log`, `jvm-pauses.log*`, `questdb-server.log`,
 `server.conf`, per-attempt `test.log`, `runs.jsonl`, plus host
 manifest/memory/iostat logs. `fs-usage.log` is only present when the optional
-continuous tracing setting is explicitly enabled (off in the current soak).
+continuous tracing setting is explicitly enabled (off in this experiment).
 SIGQUIT request time is not dump completion time. JVM dumps use the server log;
 native sampling and watchdog output do not depend on that logger. All files
 still share storage. `previous_write_ms` exposes one source of observer delay.
@@ -120,3 +198,14 @@ Completed filesystem traces cannot reveal every in-flight operation. Sampling
 and SIGQUIT perturb scheduling after detection; continuous tracing perturbs the
 entire traced arm. Hosted-VM steal time and the original host's pressure timeline
 remain unavailable. Do not optimize production code based only on these stacks.
+
+Tool references: Apple's [System Trace walkthrough](https://developer.apple.com/videos/play/wwdc2016/411/)
+describes scheduling, syscall, and windowed tracing; the current hosted Xcode is
+verified by the smoke test, not assumed to match that older demonstration.
+The [notify API documentation](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/notify_register_check.3.html)
+documents notification polling. CLI usage is described in the
+[xctrace manual](https://keith.github.io/xcode-man-pages/xctrace.1.html).
+
+Local validation uses mocked recorder/notification calls and synthetic exported
+XML on Linux; it cannot establish hosted macOS permissions or actual schema
+support. Keep all local unit-test temporary files under the repository as well.

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -13,6 +13,7 @@ readonly DIAG_DIR="${QWP_WS_DIAGNOSTICS_DIR:?QWP_WS_DIAGNOSTICS_DIR is required}
 readonly PRESSURE_MODE="${QWP_WS_MEMORY_PRESSURE:-natural}"
 readonly RUN_COUNT="${QWP_WS_DIAGNOSTIC_RUNS:-3}"
 readonly FUZZ_SEED="0x268579c36b106b74"
+readonly BUILD_MODE_SEED="7856154056746654427"
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "This diagnostic harness must run on macOS." >&2
@@ -109,6 +110,7 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     mkdir -p "$run_dir"
 
     echo "=== run=$run_number pressure=$PRESSURE_MODE seed=$FUZZ_SEED "\
+         "build_mode_seed=$BUILD_MODE_SEED "\
          "started=$(date -u '+%Y-%m-%dT%H:%M:%SZ') ===" \
         | tee -a "$DIAG_DIR/test.log"
 
@@ -143,6 +145,7 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     controller_pid=$!
 
     QWP_WS_FUZZ_SEED="$FUZZ_SEED" \
+    QDB_BUILD_MODE_SEED="$BUILD_MODE_SEED" \
     QWP_WS_FUZZ_DIAGNOSTICS=1 \
     QWP_WS_FUZZ_READY_FILE="$ready_file" \
     QWP_WS_FUZZ_GO_FILE="$go_file" \

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+
+# Reproduce TestQwpWsFuzz.test_add_columns on the hosted macOS arm64 image
+# while preserving enough host evidence to distinguish VM pressure from a
+# filesystem stall. This is intentionally a diagnostic harness, not a general
+# test runner.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly ROOT_DIR
+readonly DIAG_DIR="${QWP_WS_DIAGNOSTICS_DIR:?QWP_WS_DIAGNOSTICS_DIR is required}"
+readonly PRESSURE_MODE="${QWP_WS_MEMORY_PRESSURE:-natural}"
+readonly RUN_COUNT="${QWP_WS_DIAGNOSTIC_RUNS:-3}"
+readonly FUZZ_SEED="0x268579c36b106b74"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "This diagnostic harness must run on macOS." >&2
+    exit 2
+fi
+
+if [[ "$PRESSURE_MODE" != "natural" && "$PRESSURE_MODE" != "warn" ]]; then
+    echo "Unsupported QWP_WS_MEMORY_PRESSURE=$PRESSURE_MODE" >&2
+    exit 2
+fi
+
+cd "$ROOT_DIR" || exit 2
+mkdir -p "$DIAG_DIR"
+
+snapshot_host() {
+    local label="$1"
+    {
+        echo "=== $label $(date -u '+%Y-%m-%dT%H:%M:%SZ') ==="
+        sw_vers
+        uname -a
+        sysctl hw.memsize || true
+        sysctl hw.physicalcpu || true
+        sysctl hw.logicalcpu || true
+        sysctl vm.swapusage || true
+        memory_pressure || true
+        diskutil info / || true
+        df -h /
+        ulimit -a
+        java -version
+        git rev-parse HEAD
+        git -C questdb rev-parse HEAD
+        find questdb/core/target -maxdepth 1 -type f \
+            -name 'questdb*-SNAPSHOT.jar' \
+            -exec shasum -a 256 {} \;
+    } >>"$DIAG_DIR/manifest.log" 2>&1
+}
+
+monitor_pids=()
+pressure_pid_file=""
+controller_pid=""
+
+# shellcheck disable=SC2329  # Invoked through the EXIT trap below.
+stop_monitors() {
+    local pid
+    if [[ -n "$pressure_pid_file" && -f "$pressure_pid_file" ]]; then
+        pid="$(sed -n '1p' "$pressure_pid_file")"
+        if [[ -n "$pid" ]]; then
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+    fi
+    if [[ -n "$controller_pid" ]]; then
+        kill "$controller_pid" 2>/dev/null || true
+        wait "$controller_pid" 2>/dev/null || true
+    fi
+    for pid in "${monitor_pids[@]}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    for pid in "${monitor_pids[@]}"; do
+        wait "$pid" 2>/dev/null || true
+    done
+    monitor_pids=()
+}
+
+trap stop_monitors EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+snapshot_host before
+
+vm_stat 1 >"$DIAG_DIR/vm-stat.log" 2>&1 &
+monitor_pids+=("$!")
+
+iostat -w 1 >"$DIAG_DIR/iostat.log" 2>&1 &
+monitor_pids+=("$!")
+
+(
+    while true; do
+        echo "=== $(date -u '+%Y-%m-%dT%H:%M:%SZ') ==="
+        memory_pressure || true
+        sysctl vm.swapusage || true
+        ps -axo pid,ppid,rss,vsz,%cpu,state,etime,command || true
+        sleep 5
+    done
+) >"$DIAG_DIR/memory-and-processes.log" 2>&1 &
+monitor_pids+=("$!")
+
+overall_rc=0
+for run_number in $(seq 1 "$RUN_COUNT"); do
+    run_dir="$DIAG_DIR/run-$run_number"
+    ready_file="$run_dir/server-ready"
+    go_file="$run_dir/start-test"
+    pressure_pid_file="$run_dir/memory-pressure.pid"
+    mkdir -p "$run_dir"
+
+    echo "=== run=$run_number pressure=$PRESSURE_MODE seed=$FUZZ_SEED "\
+         "started=$(date -u '+%Y-%m-%dT%H:%M:%SZ') ===" \
+        | tee -a "$DIAG_DIR/test.log"
+
+    # The test process creates ready_file after QuestDB is accepting requests
+    # but before it starts the selected unittest. In the pressure arm, hold it
+    # at that barrier until the macOS pressure helper has had five seconds to
+    # reach the warning state.
+    (
+        while [[ ! -f "$ready_file" ]]; do
+            sleep 0.1
+        done
+        if [[ "$PRESSURE_MODE" == "warn" ]]; then
+            memory_pressure -l warn -s 300 \
+                >"$run_dir/memory-pressure.log" 2>&1 &
+            pressure_pid=$!
+            echo "$pressure_pid" >"$pressure_pid_file"
+            sleep 5
+            if ! kill -0 "$pressure_pid" 2>/dev/null; then
+                touch "$run_dir/memory-pressure-helper-exited"
+            fi
+        else
+            echo "natural-memory control" >"$run_dir/memory-pressure.log"
+        fi
+        {
+            date -u '+%Y-%m-%dT%H:%M:%SZ'
+            memory_pressure || true
+            sysctl vm.swapusage || true
+            vm_stat || true
+        } >"$run_dir/pressure-at-gate.log" 2>&1
+        touch "$go_file"
+    ) &
+    controller_pid=$!
+
+    QWP_WS_FUZZ_SEED="$FUZZ_SEED" \
+    QWP_WS_FUZZ_DIAGNOSTICS=1 \
+    QWP_WS_FUZZ_READY_FILE="$ready_file" \
+    QWP_WS_FUZZ_GO_FILE="$go_file" \
+        python3 system_test/test.py run --repo ./questdb \
+            TestQwpWsFuzz.test_add_columns -v \
+            2>&1 | tee -a "$DIAG_DIR/test.log"
+    test_rc=${PIPESTATUS[0]}
+    if [[ "$test_rc" -eq 0 && \
+          -f "$run_dir/memory-pressure-helper-exited" ]]; then
+        echo "memory_pressure exited before the diagnostic gate" \
+            | tee -a "$DIAG_DIR/test.log"
+        test_rc=2
+    fi
+
+    {
+        date -u '+%Y-%m-%dT%H:%M:%SZ'
+        memory_pressure || true
+        sysctl vm.swapusage || true
+        vm_stat || true
+    } >"$run_dir/pressure-after-test.log" 2>&1
+
+    if [[ ! -f "$go_file" ]]; then
+        kill "$controller_pid" 2>/dev/null || true
+    fi
+    wait "$controller_pid" 2>/dev/null || true
+    controller_pid=""
+    if [[ -f "$pressure_pid_file" ]]; then
+        pressure_pid="$(sed -n '1p' "$pressure_pid_file")"
+        kill "$pressure_pid" 2>/dev/null || true
+        wait "$pressure_pid" 2>/dev/null || true
+    fi
+    pressure_pid_file=""
+
+    server_log="build/questdb/repo/data/log/log.txt"
+    if [[ -f "$server_log" ]]; then
+        cp "$server_log" "$run_dir/questdb-server.log"
+    fi
+
+    echo "=== run=$run_number rc=$test_rc "\
+         "finished=$(date -u '+%Y-%m-%dT%H:%M:%SZ') ===" \
+        | tee -a "$DIAG_DIR/test.log"
+
+    if [[ "$test_rc" -ne 0 ]]; then
+        overall_rc="$test_rc"
+        break
+    fi
+done
+
+snapshot_host after
+exit "$overall_rc"

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -20,6 +20,7 @@ readonly STOP_ON_CAPTURE="${QWP_WS_STOP_ON_CAPTURE:-1}"
 readonly MAX_SECONDS="${QWP_WS_MAX_SECONDS:-1200}"
 readonly MIN_FREE_KB="${QWP_WS_MIN_FREE_KB:-2097152}"
 readonly SYSTEM_TRACE="${QWP_WS_SYSTEM_TRACE:-0}"
+readonly QUERY_OVERLAY="${QWP_WS_SHOW_COLUMNS_OVERLAY:-}"
 
 if [[ ! "$RUN_COUNT" =~ ^[1-9][0-9]*$ ||
       ! "$MAX_SECONDS" =~ ^[1-9][0-9]*$ ||
@@ -46,6 +47,10 @@ if [[ "$FS_TRACE" != "0" && "$FS_TRACE" != "1" ]]; then
 fi
 
 cd "$ROOT_DIR" || exit 2
+if [[ -n "$QUERY_OVERLAY" && ( ! -s "$QUERY_OVERLAY" || "$SYSTEM_TRACE" != "0" ) ]]; then
+    echo "SHOW COLUMNS requires a compiled overlay and no System Trace" >&2
+    exit 2
+fi
 mkdir -p "$DIAG_DIR"
 if [[ "$SYSTEM_TRACE" == "1" &&
       ( ! -s "$DIAG_DIR/preflight/system-trace-valid.json" ||
@@ -364,6 +369,12 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
         echo "memory_pressure exited before the diagnostic gate" \
             | tee -a "$DIAG_DIR/test.log"
         test_rc=2
+    fi
+    if [[ -n "$QUERY_OVERLAY" ]]; then
+        if ! python3 ci/diagnostics/show_columns/validate.py "$run_dir"; then
+            echo "Invalid SHOW COLUMNS telemetry" | tee -a "$DIAG_DIR/test.log"
+            [[ "$test_rc" -ne 0 ]] || test_rc=2
+        fi
     fi
     if [[ "$test_rc" -eq 0 && \
           -f "$run_dir/fs-usage-helper-exited" ]]; then

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -120,7 +120,7 @@ snapshot_host() {
         echo "disk_pattern=$DISK_PATTERN mapped_max_file_bytes=1048576 mapped_load_pacing_seconds=0.01"
         echo "min_free_kb=$MIN_FREE_KB"
         echo "system_trace=$SYSTEM_TRACE trace_capture_limit=2 controls=1,6,11"
-        echo "kernel_capture=$KERNEL_CAPTURE kernel_unrecorded_control=1"
+        echo "kernel_capture=$KERNEL_CAPTURE ping_trigger_consecutive_failures=2 memory_heartbeat=1"
         find questdb/core/target -maxdepth 1 -type f \
             -name 'questdb*-SNAPSHOT.jar' \
             -exec shasum -a 256 {} \;
@@ -263,8 +263,9 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
         break
     fi
     mkdir -p "$run_dir/tmp"
+    touch "$run_dir/memory-heartbeat-enabled"
     [[ "$traced" == "0" ]] || touch "$run_dir/system-trace-enabled"
-    if [[ "$KERNEL_CAPTURE" != "off" && "$run_number" != "1" ]]; then
+    if [[ "$KERNEL_CAPTURE" != "off" ]]; then
         touch "$run_dir/kernel-stacks-enabled"
         [[ "$KERNEL_CAPTURE" != "ping" ]] || touch "$run_dir/kernel-ping-capture-enabled"
     fi

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -516,6 +516,21 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     fi
     cp build/questdb/repo/data/conf/server.conf "$run_dir/server.conf" || true
 
+    # Decode only after the test and server shutdown. Keep the raw capture
+    # even when symbol processing times out; do not rerun the workload for it.
+    if [[ -s "$run_dir/kernel-stacks/spindump.raw" ]]; then
+        # The watchdog creates this directory as the runner; log ownership
+        # deliberately stays with the runner, not the privileged decoder.
+        # shellcheck disable=SC2024
+        if ! sudo -n env TMPDIR="$run_dir/kernel-stacks/tmp" \
+                python3 ci/diagnostics/kernel_wait_preflight.py \
+                "$run_dir/kernel-stacks" --decode \
+                >"$run_dir/kernel-stacks/decode.log" 2>&1; then
+            echo "Kernel decode failed; raw capture retained" | tee -a "$DIAG_DIR/test.log"
+            [[ "$test_rc" -ne 0 ]] || test_rc=2
+        fi
+    fi
+
     echo "=== run=$run_number rc=$test_rc "\
          "finished=$(date -u '+%Y-%m-%dT%H:%M:%SZ') ===" \
         | tee -a "$DIAG_DIR/test.log"

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -94,6 +94,7 @@ snapshot_host() {
         echo "fs_trace=$FS_TRACE server_revision=$SERVER_REVISION"
         echo "runs=$RUN_COUNT max_seconds=$MAX_SECONDS stop_on_capture=$STOP_ON_CAPTURE"
         echo "pressure_plan=$PRESSURE_PLAN"
+        echo "startup_missing_lookups=${QWP_WS_STARTUP_LOOKUPS:-0}"
         echo "min_free_kb=$MIN_FREE_KB"
         echo "system_trace=$SYSTEM_TRACE trace_capture_limit=2 controls=1,6,11"
         find questdb/core/target -maxdepth 1 -type f \

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -266,7 +266,9 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
                 --pid "$server_pid" >"$run_dir/system-trace-helper.log" 2>&1 &
             system_trace_pid=$!
             echo "$system_trace_pid" >"$system_trace_pid_file"
-            for _ in $(seq 1 200); do
+            # Recorder startup allows 60s; the traced fixture setup gate allows
+            # 90s. Leave time for watchdog startup and the host snapshot.
+            for _ in $(seq 1 700); do
                 [[ -f "$run_dir/system-trace-ready.json" ]] && break
                 kill -0 "$system_trace_pid" 2>/dev/null || break
                 [[ ! -f "$run_dir/system-trace-error.json" ]] || break

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -16,6 +16,17 @@ readonly FUZZ_SEED="0x268579c36b106b74"
 readonly BUILD_MODE_SEED="7856154056746654427"
 readonly SERVER_REVISION="12a33d651e51e2682e7a448c8db5168fc72dfad3"
 readonly FS_TRACE="${QWP_WS_FS_TRACE:-0}"
+readonly STOP_ON_CAPTURE="${QWP_WS_STOP_ON_CAPTURE:-1}"
+readonly MAX_SECONDS="${QWP_WS_MAX_SECONDS:-1200}"
+readonly MIN_FREE_KB="${QWP_WS_MIN_FREE_KB:-2097152}"
+
+if [[ ! "$RUN_COUNT" =~ ^[1-9][0-9]*$ ||
+      ! "$MAX_SECONDS" =~ ^[1-9][0-9]*$ ||
+      ! "$MIN_FREE_KB" =~ ^[1-9][0-9]*$ ||
+      ( "$STOP_ON_CAPTURE" != "0" && "$STOP_ON_CAPTURE" != "1" ) ]]; then
+    echo "Invalid repetition, time, disk-space or capture-stop setting" >&2
+    exit 2
+fi
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "This diagnostic harness must run on macOS." >&2
@@ -66,6 +77,8 @@ snapshot_host() {
         git rev-parse HEAD
         git -C questdb rev-parse HEAD
         echo "fs_trace=$FS_TRACE server_revision=$SERVER_REVISION"
+        echo "runs=$RUN_COUNT max_seconds=$MAX_SECONDS stop_on_capture=$STOP_ON_CAPTURE"
+        echo "min_free_kb=$MIN_FREE_KB"
         find questdb/core/target -maxdepth 1 -type f \
             -name 'questdb*-SNAPSHOT.jar' \
             -exec shasum -a 256 {} \;
@@ -131,10 +144,16 @@ trap 'exit 143' TERM
 
 snapshot_host before
 
-vm_stat 1 >"$DIAG_DIR/vm-stat.log" 2>&1 &
+{
+    date -u '+monitor_start=%Y-%m-%dT%H:%M:%SZ interval_seconds=1'
+    exec vm_stat 1
+} >"$DIAG_DIR/vm-stat.log" 2>&1 &
 monitor_pids+=("$!")
 
-iostat -w 1 >"$DIAG_DIR/iostat.log" 2>&1 &
+{
+    date -u '+monitor_start=%Y-%m-%dT%H:%M:%SZ interval_seconds=1'
+    exec iostat -w 1
+} >"$DIAG_DIR/iostat.log" 2>&1 &
 monitor_pids+=("$!")
 
 (
@@ -149,7 +168,34 @@ monitor_pids+=("$!")
 monitor_pids+=("$!")
 
 overall_rc=0
+soak_started=$SECONDS
+stop_reason="run_limit"
 for run_number in $(seq 1 "$RUN_COUNT"); do
+    # Stay on this hosted VM for the whole loop. JVM/fixture restarts do not
+    # allocate a new worker. Let an in-flight test retain its original timeout.
+    if (( SECONDS - soak_started >= MAX_SECONDS )); then
+        stop_reason="time_budget"
+        break
+    fi
+    for pid in "${monitor_pids[@]}"; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            echo "Host monitor exited; refusing an unobserved soak" | tee -a "$DIAG_DIR/test.log"
+            overall_rc=2
+            stop_reason="host_monitor_failure"
+            break
+        fi
+    done
+    [[ "$overall_rc" -eq 0 ]] || break
+    free_kb="$(df -Pk "$DIAG_DIR" | awk 'NR == 2 { print $4 }')"
+    if [[ ! "$free_kb" =~ ^[0-9]+$ ]] || (( free_kb < MIN_FREE_KB )); then
+        echo "Disk-space safety stop: available_kb=$free_kb required_kb=$MIN_FREE_KB" \
+            | tee -a "$DIAG_DIR/test.log"
+        overall_rc=2
+        stop_reason="disk_space_guard"
+        break
+    fi
+    run_started=$SECONDS
+    run_epoch="$(date -u '+%s')"
     run_dir="$DIAG_DIR/run-$run_number"
     ready_file="$run_dir/server-ready"
     go_file="$run_dir/start-test"
@@ -159,6 +205,12 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     watchdog_pid_file="$run_dir/watchdog.pid"
     # Keep Python store-and-forward buffers and JVM temporary files on the
     # worker's real filesystem. Never inherit a possibly memory-backed /tmp.
+    if [[ -e "$run_dir" ]]; then
+        echo "Refusing to reuse existing diagnostic artifacts: $run_dir" >&2
+        overall_rc=2
+        stop_reason="existing_artifacts"
+        break
+    fi
     mkdir -p "$run_dir/tmp"
 
     echo "=== run=$run_number pressure=$PRESSURE_MODE seed=$FUZZ_SEED "\
@@ -231,8 +283,12 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     TMPDIR="$run_dir/tmp" \
         python3 system_test/test.py run --repo ./questdb \
             TestQwpWsFuzz.test_add_columns -v \
-            2>&1 | tee -a "$DIAG_DIR/test.log"
-    test_rc=${PIPESTATUS[0]}
+            2>&1 | tee -a "$DIAG_DIR/test.log" "$run_dir/test.log"
+    test_status=("${PIPESTATUS[@]}")
+    test_rc=${test_status[0]}
+    if [[ "${test_status[1]}" -ne 0 && "$test_rc" -eq 0 ]]; then
+        test_rc=2
+    fi
     if [[ ! -f "$run_dir/workload-finished" ||
           -f "$run_dir/watchdog-helper-failed" ||
           ! -s "$run_dir/heartbeat.jsonl" ||
@@ -297,16 +353,33 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
          "finished=$(date -u '+%Y-%m-%dT%H:%M:%SZ') ===" \
         | tee -a "$DIAG_DIR/test.log"
 
+    python3 ci/summarize_qwp_ws_run.py "$run_dir" \
+        --run "$run_number" --started "$run_epoch" \
+        --duration "$((SECONDS - run_started))" \
+        --soak-elapsed "$((SECONDS - soak_started))" \
+        --free-kb "$free_kb" --returncode "$test_rc" \
+        | tee -a "$DIAG_DIR/runs.jsonl"
+    summary_status=("${PIPESTATUS[@]}")
+    if [[ ( "${summary_status[0]}" -ne 0 || "${summary_status[1]}" -ne 0 ) && "$test_rc" -eq 0 ]]; then
+        test_rc=2
+    fi
+
     if [[ "$test_rc" -ne 0 ]]; then
         overall_rc="$test_rc"
+        stop_reason="test_or_diagnostic_failure"
         break
     fi
     if [[ -f "$run_dir/capture-started" ]]; then
-        echo "Onset captured; ending this replica to inspect evidence" \
+        echo "Onset captured; test passed; stop_on_capture=$STOP_ON_CAPTURE" \
             | tee -a "$DIAG_DIR/test.log"
-        break
+        if [[ "$STOP_ON_CAPTURE" == "1" ]]; then
+            stop_reason="onset_capture"
+            break
+        fi
     fi
 done
 
+echo "=== soak stop=$stop_reason elapsed_seconds=$((SECONDS - soak_started)) rc=$overall_rc ===" \
+    | tee -a "$DIAG_DIR/test.log"
 snapshot_host after
 exit "$overall_rc"

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -94,6 +94,12 @@ if [[ "$(sysctl -n hw.logicalcpu)" != "3" ||
     exit 2
 fi
 
+if [[ "$KERNEL_CAPTURE" != "off" ]]; then
+    # Fetch once before workload/monitor gates, never during onset capture.
+    python3 ci/diagnostics/decode_kernel_capture.py \
+        "$DIAG_DIR/kernel-symbols" --symbols-only || exit 2
+fi
+
 snapshot_host() {
     local label="$1"
     {
@@ -525,6 +531,7 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
         if ! sudo -n env TMPDIR="$run_dir/kernel-stacks/tmp" \
                 python3 ci/diagnostics/kernel_wait_preflight.py \
                 "$run_dir/kernel-stacks" --decode \
+                --symbols "$DIAG_DIR/kernel-symbols/symbols.spindump" \
                 >"$run_dir/kernel-stacks/decode.log" 2>&1; then
             echo "Kernel decode failed; raw capture retained" | tee -a "$DIAG_DIR/test.log"
             [[ "$test_rc" -ne 0 ]] || test_rc=2

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -255,8 +255,7 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
 
     # The test process creates ready_file after QuestDB is accepting requests
     # but before it starts the selected unittest. In the pressure arm, hold it
-    # at that barrier until the macOS pressure helper has had five seconds to
-    # reach the warning state.
+    # at that barrier until the paired arm verifies the actual kernel state.
     (
         system_trace_pid=""
         disk_load_pid=""
@@ -350,7 +349,7 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
             echo "natural-memory control" >"$run_dir/memory-pressure.log"
         fi
         if [[ "$PRESSURE_PLAN" == "paired" ]]; then
-            pressure_gate_args=(gate "$PRESSURE_MODE")
+            pressure_gate_args=(gate "$PRESSURE_MODE" --timeout 45)
             if [[ "$PRESSURE_MODE" == "warn" ]]; then
                 pressure_gate_args+=(--pid "$pressure_pid")
             fi
@@ -358,7 +357,7 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
                     >"$run_dir/pressure-gate.jsonl" 2>"$run_dir/pressure-gate-error.log"; then
                 touch "$run_dir/pressure-target-not-reached"
                 # Do not release a workload under a falsely labelled condition.
-                # Paired pressure setup has a separate 60-second gate budget.
+                # Paired pressure setup has a separate 90-second gate budget.
                 exit 2
             fi
         fi

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -53,11 +53,25 @@ snapshot_host() {
 
 monitor_pids=()
 pressure_pid_file=""
+trace_pid_file=""
 controller_pid=""
+
+stop_trace() {
+    local pid
+    if [[ -n "$trace_pid_file" && -f "$trace_pid_file" ]]; then
+        pid="$(sed -n '1p' "$trace_pid_file")"
+        if [[ -n "$pid" ]]; then
+            sudo -n kill "$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+    fi
+    trace_pid_file=""
+}
 
 # shellcheck disable=SC2329  # Invoked through the EXIT trap below.
 stop_monitors() {
     local pid
+    stop_trace
     if [[ -n "$pressure_pid_file" && -f "$pressure_pid_file" ]]; then
         pid="$(sed -n '1p' "$pressure_pid_file")"
         if [[ -n "$pid" ]]; then
@@ -106,7 +120,9 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     run_dir="$DIAG_DIR/run-$run_number"
     ready_file="$run_dir/server-ready"
     go_file="$run_dir/start-test"
+    server_pid_file="$run_dir/questdb.pid"
     pressure_pid_file="$run_dir/memory-pressure.pid"
+    trace_pid_file="$run_dir/fs-usage.pid"
     mkdir -p "$run_dir"
 
     echo "=== run=$run_number pressure=$PRESSURE_MODE seed=$FUZZ_SEED "\
@@ -122,6 +138,18 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
         while [[ ! -f "$ready_file" ]]; do
             sleep 0.1
         done
+        server_pid="$(sed -n '1p' "$server_pid_file")"
+        # The diagnostic directory belongs to the build user; only fs_usage
+        # itself needs elevation, not this output redirection.
+        # shellcheck disable=SC2024
+        sudo -n fs_usage -w -f filesys "$server_pid" \
+            >"$run_dir/fs-usage.log" 2>&1 &
+        fs_usage_pid=$!
+        echo "$fs_usage_pid" >"$trace_pid_file"
+        sleep 1
+        if ! sudo -n kill -0 "$fs_usage_pid" 2>/dev/null; then
+            touch "$run_dir/fs-usage-helper-exited"
+        fi
         if [[ "$PRESSURE_MODE" == "warn" ]]; then
             memory_pressure -l warn -s 300 \
                 >"$run_dir/memory-pressure.log" 2>&1 &
@@ -149,6 +177,7 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     QWP_WS_FUZZ_DIAGNOSTICS=1 \
     QWP_WS_FUZZ_READY_FILE="$ready_file" \
     QWP_WS_FUZZ_GO_FILE="$go_file" \
+    QWP_WS_FUZZ_PID_FILE="$server_pid_file" \
         python3 system_test/test.py run --repo ./questdb \
             TestQwpWsFuzz.test_add_columns -v \
             2>&1 | tee -a "$DIAG_DIR/test.log"
@@ -156,6 +185,12 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     if [[ "$test_rc" -eq 0 && \
           -f "$run_dir/memory-pressure-helper-exited" ]]; then
         echo "memory_pressure exited before the diagnostic gate" \
+            | tee -a "$DIAG_DIR/test.log"
+        test_rc=2
+    fi
+    if [[ "$test_rc" -eq 0 && \
+          -f "$run_dir/fs-usage-helper-exited" ]]; then
+        echo "fs_usage exited before the diagnostic gate" \
             | tee -a "$DIAG_DIR/test.log"
         test_rc=2
     fi
@@ -172,6 +207,7 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     fi
     wait "$controller_pid" 2>/dev/null || true
     controller_pid=""
+    stop_trace
     if [[ -f "$pressure_pid_file" ]]; then
         pressure_pid="$(sed -n '1p' "$pressure_pid_file")"
         kill "$pressure_pid" 2>/dev/null || true

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -19,10 +19,12 @@ readonly FS_TRACE="${QWP_WS_FS_TRACE:-0}"
 readonly STOP_ON_CAPTURE="${QWP_WS_STOP_ON_CAPTURE:-1}"
 readonly MAX_SECONDS="${QWP_WS_MAX_SECONDS:-1200}"
 readonly MIN_FREE_KB="${QWP_WS_MIN_FREE_KB:-2097152}"
+readonly SYSTEM_TRACE="${QWP_WS_SYSTEM_TRACE:-0}"
 
 if [[ ! "$RUN_COUNT" =~ ^[1-9][0-9]*$ ||
       ! "$MAX_SECONDS" =~ ^[1-9][0-9]*$ ||
       ! "$MIN_FREE_KB" =~ ^[1-9][0-9]*$ ||
+      ( "$SYSTEM_TRACE" != "0" && "$SYSTEM_TRACE" != "1" ) ||
       ( "$STOP_ON_CAPTURE" != "0" && "$STOP_ON_CAPTURE" != "1" ) ]]; then
     echo "Invalid repetition, time, disk-space or capture-stop setting" >&2
     exit 2
@@ -45,6 +47,13 @@ fi
 
 cd "$ROOT_DIR" || exit 2
 mkdir -p "$DIAG_DIR"
+if [[ "$SYSTEM_TRACE" == "1" &&
+      ( ! -s "$DIAG_DIR/preflight/system-trace-valid.json" ||
+        -e "$DIAG_DIR/preflight/system-trace-error.json" ||
+        "$FS_TRACE" != "0" || "$PRESSURE_MODE" != "natural" ) ]]; then
+    echo "System Trace requires a successful preflight, no fs_usage and natural memory" >&2
+    exit 2
+fi
 if [[ "$(git -C questdb rev-parse HEAD)" != "$SERVER_REVISION" ]]; then
     echo "Diagnostic server revision must be $SERVER_REVISION" >&2
     exit 2
@@ -79,6 +88,7 @@ snapshot_host() {
         echo "fs_trace=$FS_TRACE server_revision=$SERVER_REVISION"
         echo "runs=$RUN_COUNT max_seconds=$MAX_SECONDS stop_on_capture=$STOP_ON_CAPTURE"
         echo "min_free_kb=$MIN_FREE_KB"
+        echo "system_trace=$SYSTEM_TRACE trace_capture_limit=2 controls=1,6,11"
         find questdb/core/target -maxdepth 1 -type f \
             -name 'questdb*-SNAPSHOT.jar' \
             -exec shasum -a 256 {} \;
@@ -170,6 +180,7 @@ monitor_pids+=("$!")
 overall_rc=0
 soak_started=$SECONDS
 stop_reason="run_limit"
+trace_captures=0
 for run_number in $(seq 1 "$RUN_COUNT"); do
     # Stay on this hosted VM for the whole loop. JVM/fixture restarts do not
     # allocate a new worker. Let an in-flight test retain its original timeout.
@@ -203,6 +214,12 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     pressure_pid_file="$run_dir/memory-pressure.pid"
     trace_pid_file="$run_dir/fs-usage.pid"
     watchdog_pid_file="$run_dir/watchdog.pid"
+    system_trace_pid_file="$run_dir/system-trace-helper.pid"
+    traced=0
+    if [[ "$SYSTEM_TRACE" == "1" && "$run_number" != "1" &&
+          "$run_number" != "6" && "$run_number" != "11" ]]; then
+        traced=1
+    fi
     # Keep Python store-and-forward buffers and JVM temporary files on the
     # worker's real filesystem. Never inherit a possibly memory-backed /tmp.
     if [[ -e "$run_dir" ]]; then
@@ -212,10 +229,11 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
         break
     fi
     mkdir -p "$run_dir/tmp"
+    [[ "$traced" == "0" ]] || touch "$run_dir/system-trace-enabled"
 
     echo "=== run=$run_number pressure=$PRESSURE_MODE seed=$FUZZ_SEED "\
          "build_mode_seed=$BUILD_MODE_SEED "\
-         "started=$(date -u '+%Y-%m-%dT%H:%M:%SZ') ===" \
+         "system_trace=$traced started=$(date -u '+%Y-%m-%dT%H:%M:%SZ') ===" \
         | tee -a "$DIAG_DIR/test.log"
 
     # The test process creates ready_file after QuestDB is accepting requests
@@ -223,10 +241,45 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     # at that barrier until the macOS pressure helper has had five seconds to
     # reach the warning state.
     (
+        system_trace_pid=""
+        # This shell is the parent of sudo/collector. On setup failure or
+        # cancellation, signal that exact child and wait for it to reap xctrace.
+        # shellcheck disable=SC2329
+        stop_controller_trace() {
+            if [[ -n "$system_trace_pid" ]]; then
+                sudo -n kill -TERM "$system_trace_pid" 2>/dev/null || true
+                wait "$system_trace_pid" 2>/dev/null || true
+            fi
+        }
+        trap stop_controller_trace EXIT
+        trap 'exit 130' INT
+        trap 'exit 143' TERM
         while [[ ! -f "$ready_file" ]]; do
             sleep 0.1
         done
         server_pid="$(sed -n '1p' "$server_pid_file")"
+        if [[ "$traced" == "1" ]]; then
+            # Redirection deliberately belongs to the unprivileged uploader.
+            # shellcheck disable=SC2024
+            sudo -n env TMPDIR="$run_dir/tmp" "$(command -v python3)" \
+                system_test/qwp_ws_system_trace.py collect --run-dir "$run_dir" \
+                --pid "$server_pid" >"$run_dir/system-trace-helper.log" 2>&1 &
+            system_trace_pid=$!
+            echo "$system_trace_pid" >"$system_trace_pid_file"
+            for _ in $(seq 1 200); do
+                [[ -f "$run_dir/system-trace-ready.json" ]] && break
+                kill -0 "$system_trace_pid" 2>/dev/null || break
+                [[ ! -f "$run_dir/system-trace-error.json" ]] || break
+                sleep 0.1
+            done
+            if [[ ! -f "$run_dir/system-trace-ready.json" ||
+                  -f "$run_dir/system-trace-error.json" ]]; then
+                touch "$run_dir/watchdog-helper-failed"
+                # Never release an unobserved workload; test setup will report
+                # its existing gate timeout, and artifacts explain the cause.
+                exit 2
+            fi
+        fi
         if [[ "$FS_TRACE" == "1" ]]; then
             # Only the tracing replica pays continuous syscall-tracing cost.
             # shellcheck disable=SC2024
@@ -270,6 +323,12 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
             vm_stat || true
         } >"$run_dir/pressure-at-gate.log" 2>&1
         touch "$go_file"
+        if [[ "$traced" == "1" ]]; then
+            wait "$system_trace_pid"
+            trace_rc=$?
+            system_trace_pid=""
+            exit "$trace_rc"
+        fi
     ) &
     controller_pid=$!
 
@@ -321,8 +380,17 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     if [[ ! -f "$go_file" ]]; then
         kill "$controller_pid" 2>/dev/null || true
     fi
-    wait "$controller_pid" 2>/dev/null || true
+    if ! wait "$controller_pid"; then
+        echo "Diagnostic controller failed; inspect run=$run_number" | tee -a "$DIAG_DIR/test.log"
+        [[ "$test_rc" -ne 0 ]] || test_rc=2
+    fi
     controller_pid=""
+    if [[ "$traced" == "1" &&
+          ( ! -s "$run_dir/system-trace-valid.json" ||
+            -f "$run_dir/system-trace-error.json" ) ]]; then
+        echo "Missing or invalid System Trace; refusing a green result" | tee -a "$DIAG_DIR/test.log"
+        [[ "$test_rc" -ne 0 ]] || test_rc=2
+    fi
     # The watchdog normally exits after the workload-finished marker. Allow
     # its in-flight probe to return, then detect an unexpected helper death.
     for _ in $(seq 1 20); do
@@ -370,6 +438,13 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
         break
     fi
     if [[ -f "$run_dir/capture-started" ]]; then
+        if [[ "$traced" == "1" ]]; then
+            trace_captures=$((trace_captures + 1))
+            if (( trace_captures >= 2 )); then
+                stop_reason="two_system_trace_captures"
+                break
+            fi
+        fi
         echo "Onset captured; test passed; stop_on_capture=$STOP_ON_CAPTURE" \
             | tee -a "$DIAG_DIR/test.log"
         if [[ "$STOP_ON_CAPTURE" == "1" ]]; then
@@ -379,7 +454,8 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     fi
 done
 
-echo "=== soak stop=$stop_reason elapsed_seconds=$((SECONDS - soak_started)) rc=$overall_rc ===" \
+echo "=== soak stop=$stop_reason elapsed_seconds=$((SECONDS - soak_started)) "\
+     "system_trace_captures=$trace_captures rc=$overall_rc ===" \
     | tee -a "$DIAG_DIR/test.log"
 snapshot_host after
 exit "$overall_rc"

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -24,11 +24,15 @@ readonly QUERY_OVERLAY="${QWP_WS_SHOW_COLUMNS_OVERLAY:-}"
 readonly DISK_LOAD="${QWP_WS_DISK_LOAD:-0}"
 readonly DISK_PATTERN="${QWP_WS_DISK_PATTERN:-pwrite}"
 readonly KERNEL_CAPTURE="${QWP_WS_KERNEL_CAPTURE:-off}"
+readonly QUERY_READER="${QWP_WS_QUERY_READER:-0}"
+readonly DISK_MODE="${QWP_WS_DISK_MODE:-paired}"
 
 if [[ ! "$RUN_COUNT" =~ ^[1-9][0-9]*$ ||
       ! "$MAX_SECONDS" =~ ^[1-9][0-9]*$ ||
       ! "$MIN_FREE_KB" =~ ^[1-9][0-9]*$ ||
       ( "$DISK_LOAD" != "0" && "$DISK_LOAD" != "1" ) ||
+      ( "$QUERY_READER" != "0" && "$QUERY_READER" != "1" ) ||
+      ( "$DISK_MODE" != "paired" && "$DISK_MODE" != "probe" ) ||
       ( "$SYSTEM_TRACE" != "0" && "$SYSTEM_TRACE" != "1" ) ||
       ( "$STOP_ON_CAPTURE" != "0" && "$STOP_ON_CAPTURE" != "1" ) ]]; then
     echo "Invalid repetition, time, disk-space or capture-stop setting" >&2
@@ -64,6 +68,10 @@ if [[ "$DISK_PATTERN" != "pwrite" && "$DISK_PATTERN" != "mapped" ]]; then
 fi
 
 cd "$ROOT_DIR" || exit 2
+if [[ "$QUERY_READER" == "1" && -z "$QUERY_OVERLAY" ]]; then
+    echo "Query reader requires query-stage telemetry" >&2
+    exit 2
+fi
 if [[ "$DISK_LOAD" == "1" && ( -z "$QUERY_OVERLAY" || "$PRESSURE_PLAN" != "natural" ) ]]; then
     echo "Disk experiment requires query overlay and natural memory" >&2
     exit 2
@@ -270,6 +278,7 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     fi
     mkdir -p "$run_dir/tmp"
     touch "$run_dir/memory-heartbeat-enabled"
+    [[ "$QUERY_READER" != "1" ]] || touch "$run_dir/query-reader-enabled"
     [[ "$traced" == "0" ]] || touch "$run_dir/system-trace-enabled"
     if [[ "$KERNEL_CAPTURE" != "off" ]]; then
         touch "$run_dir/kernel-stacks-enabled"
@@ -398,7 +407,7 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
         } >"$run_dir/pressure-at-gate.log" 2>&1
         if [[ "$DISK_LOAD" == "1" ]]; then
             TMPDIR="$run_dir/tmp" python3 system_test/qwp_ws_disk_load.py \
-                "$run_dir" --run "$run_number" --pattern "$DISK_PATTERN" >"$run_dir/disk-load-process.log" 2>&1 &
+                "$run_dir" --run "$run_number" --pattern "$DISK_PATTERN" --mode "$DISK_MODE" >"$run_dir/disk-load-process.log" 2>&1 &
             disk_load_pid=$!
             for _ in $(seq 1 50); do
                 [[ -f "$run_dir/disk-load-ready" ]] && break
@@ -508,6 +517,12 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
         [[ "$test_rc" -ne 0 ]] || test_rc=2
     fi
     stop_watchdog
+    if [[ "$QUERY_READER" == "1" ]] &&
+            { ! grep -q '"event": "query_start"' "$run_dir/query-reader.jsonl" ||
+              ! grep -q '"event": "stopped"' "$run_dir/query-reader.jsonl"; }; then
+        echo "Query reader had no overlap or incomplete telemetry" | tee -a "$DIAG_DIR/test.log"
+        [[ "$test_rc" -ne 0 ]] || test_rc=2
+    fi
     stop_trace
     if [[ -f "$pressure_pid_file" ]]; then
         pressure_pid="$(sed -n '1p' "$pressure_pid_file")"

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -22,6 +22,7 @@ readonly MIN_FREE_KB="${QWP_WS_MIN_FREE_KB:-2097152}"
 readonly SYSTEM_TRACE="${QWP_WS_SYSTEM_TRACE:-0}"
 readonly QUERY_OVERLAY="${QWP_WS_SHOW_COLUMNS_OVERLAY:-}"
 readonly DISK_LOAD="${QWP_WS_DISK_LOAD:-0}"
+readonly DISK_PATTERN="${QWP_WS_DISK_PATTERN:-pwrite}"
 readonly KERNEL_CAPTURE="${QWP_WS_KERNEL_CAPTURE:-off}"
 
 if [[ ! "$RUN_COUNT" =~ ^[1-9][0-9]*$ ||
@@ -55,6 +56,10 @@ if [[ "$KERNEL_CAPTURE" != "off" && "$KERNEL_CAPTURE" != "query" && "$KERNEL_CAP
 fi
 if [[ "$KERNEL_CAPTURE" != "off" && -z "$QUERY_OVERLAY" ]]; then
     echo "Kernel follow-up requires query-stage telemetry" >&2
+    exit 2
+fi
+if [[ "$DISK_PATTERN" != "pwrite" && "$DISK_PATTERN" != "mapped" ]]; then
+    echo "Unsupported QWP_WS_DISK_PATTERN=$DISK_PATTERN" >&2
     exit 2
 fi
 
@@ -112,6 +117,7 @@ snapshot_host() {
         echo "pressure_plan=$PRESSURE_PLAN"
         echo "startup_missing_lookups=${QWP_WS_STARTUP_LOOKUPS:-0}"
         echo "disk_load=$DISK_LOAD paired_order=probe,load,load,probe max_write_bytes_per_attempt=268435456"
+        echo "disk_pattern=$DISK_PATTERN mapped_max_file_bytes=1048576 mapped_load_pacing_seconds=0.01"
         echo "min_free_kb=$MIN_FREE_KB"
         echo "system_trace=$SYSTEM_TRACE trace_capture_limit=2 controls=1,6,11"
         echo "kernel_capture=$KERNEL_CAPTURE kernel_unrecorded_control=1"
@@ -385,7 +391,7 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
         } >"$run_dir/pressure-at-gate.log" 2>&1
         if [[ "$DISK_LOAD" == "1" ]]; then
             TMPDIR="$run_dir/tmp" python3 system_test/qwp_ws_disk_load.py \
-                "$run_dir" --run "$run_number" >"$run_dir/disk-load-process.log" 2>&1 &
+                "$run_dir" --run "$run_number" --pattern "$DISK_PATTERN" >"$run_dir/disk-load-process.log" 2>&1 &
             disk_load_pid=$!
             for _ in $(seq 1 50); do
                 [[ -f "$run_dir/disk-load-ready" ]] && break

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -21,10 +21,12 @@ readonly MAX_SECONDS="${QWP_WS_MAX_SECONDS:-1200}"
 readonly MIN_FREE_KB="${QWP_WS_MIN_FREE_KB:-2097152}"
 readonly SYSTEM_TRACE="${QWP_WS_SYSTEM_TRACE:-0}"
 readonly QUERY_OVERLAY="${QWP_WS_SHOW_COLUMNS_OVERLAY:-}"
+readonly DISK_LOAD="${QWP_WS_DISK_LOAD:-0}"
 
 if [[ ! "$RUN_COUNT" =~ ^[1-9][0-9]*$ ||
       ! "$MAX_SECONDS" =~ ^[1-9][0-9]*$ ||
       ! "$MIN_FREE_KB" =~ ^[1-9][0-9]*$ ||
+      ( "$DISK_LOAD" != "0" && "$DISK_LOAD" != "1" ) ||
       ( "$SYSTEM_TRACE" != "0" && "$SYSTEM_TRACE" != "1" ) ||
       ( "$STOP_ON_CAPTURE" != "0" && "$STOP_ON_CAPTURE" != "1" ) ]]; then
     echo "Invalid repetition, time, disk-space or capture-stop setting" >&2
@@ -47,6 +49,10 @@ if [[ "$FS_TRACE" != "0" && "$FS_TRACE" != "1" ]]; then
 fi
 
 cd "$ROOT_DIR" || exit 2
+if [[ "$DISK_LOAD" == "1" && ( -z "$QUERY_OVERLAY" || "$PRESSURE_PLAN" != "natural" ) ]]; then
+    echo "Disk experiment requires query overlay and natural memory" >&2
+    exit 2
+fi
 if [[ -n "$QUERY_OVERLAY" && ( ! -s "$QUERY_OVERLAY" || "$SYSTEM_TRACE" != "0" ) ]]; then
     echo "SHOW COLUMNS requires a compiled overlay and no System Trace" >&2
     exit 2
@@ -95,6 +101,7 @@ snapshot_host() {
         echo "runs=$RUN_COUNT max_seconds=$MAX_SECONDS stop_on_capture=$STOP_ON_CAPTURE"
         echo "pressure_plan=$PRESSURE_PLAN"
         echo "startup_missing_lookups=${QWP_WS_STARTUP_LOOKUPS:-0}"
+        echo "disk_load=$DISK_LOAD paired_order=probe,load,load,probe max_write_bytes_per_attempt=268435456"
         echo "min_free_kb=$MIN_FREE_KB"
         echo "system_trace=$SYSTEM_TRACE trace_capture_limit=2 controls=1,6,11"
         find questdb/core/target -maxdepth 1 -type f \
@@ -252,10 +259,15 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     # reach the warning state.
     (
         system_trace_pid=""
+        disk_load_pid=""
         # This shell is the parent of sudo/collector. On setup failure or
         # cancellation, signal that exact child and wait for it to reap xctrace.
         # shellcheck disable=SC2329
         stop_controller_trace() {
+            if [[ -n "$disk_load_pid" ]]; then
+                kill -TERM "$disk_load_pid" 2>/dev/null || true
+                wait "$disk_load_pid" 2>/dev/null || true
+            fi
             if [[ -n "$system_trace_pid" ]]; then
                 sudo -n kill -TERM "$system_trace_pid" 2>/dev/null || true
                 wait "$system_trace_pid" 2>/dev/null || true
@@ -357,7 +369,26 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
             sysctl kern.memorystatus_vm_pressure_level || true
             vm_stat || true
         } >"$run_dir/pressure-at-gate.log" 2>&1
+        if [[ "$DISK_LOAD" == "1" ]]; then
+            TMPDIR="$run_dir/tmp" python3 system_test/qwp_ws_disk_load.py \
+                "$run_dir" --run "$run_number" >"$run_dir/disk-load-process.log" 2>&1 &
+            disk_load_pid=$!
+            for _ in $(seq 1 50); do
+                [[ -f "$run_dir/disk-load-ready" ]] && break
+                kill -0 "$disk_load_pid" 2>/dev/null || break
+                sleep 0.1
+            done
+            if [[ ! -f "$run_dir/disk-load-ready" || -f "$run_dir/disk-load-error" ]]; then
+                exit 2
+            fi
+        fi
         touch "$go_file"
+        if [[ -n "$disk_load_pid" ]]; then
+            wait "$disk_load_pid"
+            disk_rc=$?
+            disk_load_pid=""
+            [[ "$disk_rc" -eq 0 ]] || exit "$disk_rc"
+        fi
         if [[ "$traced" == "1" ]]; then
             wait "$system_trace_pid"
             trace_rc=$?
@@ -427,6 +458,11 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
         [[ "$test_rc" -ne 0 ]] || test_rc=2
     fi
     controller_pid=""
+    if [[ "$DISK_LOAD" == "1" &&
+          ( ! -f "$run_dir/disk-load-finished" || -f "$run_dir/disk-load-error" ) ]]; then
+        echo "Missing or failed filesystem load telemetry" | tee -a "$DIAG_DIR/test.log"
+        [[ "$test_rc" -ne 0 ]] || test_rc=2
+    fi
     if [[ "$traced" == "1" &&
           ( ! -s "$run_dir/system-trace-valid.json" ||
             -f "$run_dir/system-trace-error.json" ) ]]; then

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -22,6 +22,7 @@ readonly MIN_FREE_KB="${QWP_WS_MIN_FREE_KB:-2097152}"
 readonly SYSTEM_TRACE="${QWP_WS_SYSTEM_TRACE:-0}"
 readonly QUERY_OVERLAY="${QWP_WS_SHOW_COLUMNS_OVERLAY:-}"
 readonly DISK_LOAD="${QWP_WS_DISK_LOAD:-0}"
+readonly KERNEL_CAPTURE="${QWP_WS_KERNEL_CAPTURE:-off}"
 
 if [[ ! "$RUN_COUNT" =~ ^[1-9][0-9]*$ ||
       ! "$MAX_SECONDS" =~ ^[1-9][0-9]*$ ||
@@ -45,6 +46,15 @@ fi
 
 if [[ "$FS_TRACE" != "0" && "$FS_TRACE" != "1" ]]; then
     echo "Unsupported QWP_WS_FS_TRACE=$FS_TRACE" >&2
+    exit 2
+fi
+
+if [[ "$KERNEL_CAPTURE" != "off" && "$KERNEL_CAPTURE" != "query" && "$KERNEL_CAPTURE" != "ping" ]]; then
+    echo "Unsupported QWP_WS_KERNEL_CAPTURE=$KERNEL_CAPTURE" >&2
+    exit 2
+fi
+if [[ "$KERNEL_CAPTURE" != "off" && -z "$QUERY_OVERLAY" ]]; then
+    echo "Kernel follow-up requires query-stage telemetry" >&2
     exit 2
 fi
 
@@ -104,6 +114,7 @@ snapshot_host() {
         echo "disk_load=$DISK_LOAD paired_order=probe,load,load,probe max_write_bytes_per_attempt=268435456"
         echo "min_free_kb=$MIN_FREE_KB"
         echo "system_trace=$SYSTEM_TRACE trace_capture_limit=2 controls=1,6,11"
+        echo "kernel_capture=$KERNEL_CAPTURE kernel_unrecorded_control=1"
         find questdb/core/target -maxdepth 1 -type f \
             -name 'questdb*-SNAPSHOT.jar' \
             -exec shasum -a 256 {} \;
@@ -247,6 +258,10 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     fi
     mkdir -p "$run_dir/tmp"
     [[ "$traced" == "0" ]] || touch "$run_dir/system-trace-enabled"
+    if [[ "$KERNEL_CAPTURE" != "off" && "$run_number" != "1" ]]; then
+        touch "$run_dir/kernel-stacks-enabled"
+        [[ "$KERNEL_CAPTURE" != "ping" ]] || touch "$run_dir/kernel-ping-capture-enabled"
+    fi
 
     echo "=== run=$run_number pressure=$PRESSURE_MODE seed=$FUZZ_SEED "\
          "build_mode_seed=$BUILD_MODE_SEED "\

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -14,6 +14,8 @@ readonly PRESSURE_MODE="${QWP_WS_MEMORY_PRESSURE:-natural}"
 readonly RUN_COUNT="${QWP_WS_DIAGNOSTIC_RUNS:-3}"
 readonly FUZZ_SEED="0x268579c36b106b74"
 readonly BUILD_MODE_SEED="7856154056746654427"
+readonly SERVER_REVISION="12a33d651e51e2682e7a448c8db5168fc72dfad3"
+readonly FS_TRACE="${QWP_WS_FS_TRACE:-0}"
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "This diagnostic harness must run on macOS." >&2
@@ -25,8 +27,26 @@ if [[ "$PRESSURE_MODE" != "natural" && "$PRESSURE_MODE" != "warn" ]]; then
     exit 2
 fi
 
+if [[ "$FS_TRACE" != "0" && "$FS_TRACE" != "1" ]]; then
+    echo "Unsupported QWP_WS_FS_TRACE=$FS_TRACE" >&2
+    exit 2
+fi
+
 cd "$ROOT_DIR" || exit 2
 mkdir -p "$DIAG_DIR"
+if [[ "$(git -C questdb rev-parse HEAD)" != "$SERVER_REVISION" ]]; then
+    echo "Diagnostic server revision must be $SERVER_REVISION" >&2
+    exit 2
+fi
+# Keep the original worker sizing and runtime. Do not quietly replay on a
+# different hosted-machine shape or a newer JDK after an image update.
+if [[ "$(sysctl -n hw.logicalcpu)" != "3" ||
+      "$(java -version 2>&1)" != *"25.0.3+9"* ]]; then
+    echo "Expected three CPUs and JDK 25.0.3+9; inspect the hosted image" >&2
+    sysctl hw.logicalcpu
+    java -version
+    exit 2
+fi
 
 snapshot_host() {
     local label="$1"
@@ -45,6 +65,7 @@ snapshot_host() {
         java -version
         git rev-parse HEAD
         git -C questdb rev-parse HEAD
+        echo "fs_trace=$FS_TRACE server_revision=$SERVER_REVISION"
         find questdb/core/target -maxdepth 1 -type f \
             -name 'questdb*-SNAPSHOT.jar' \
             -exec shasum -a 256 {} \;
@@ -55,6 +76,17 @@ monitor_pids=()
 pressure_pid_file=""
 trace_pid_file=""
 controller_pid=""
+watchdog_pid_file=""
+
+stop_watchdog() {
+    local pid
+    if [[ -n "$watchdog_pid_file" && -f "$watchdog_pid_file" ]]; then
+        pid="$(sed -n '1p' "$watchdog_pid_file")"
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    fi
+    watchdog_pid_file=""
+}
 
 stop_trace() {
     local pid
@@ -71,6 +103,7 @@ stop_trace() {
 # shellcheck disable=SC2329  # Invoked through the EXIT trap below.
 stop_monitors() {
     local pid
+    stop_watchdog
     stop_trace
     if [[ -n "$pressure_pid_file" && -f "$pressure_pid_file" ]]; then
         pid="$(sed -n '1p' "$pressure_pid_file")"
@@ -123,7 +156,10 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     server_pid_file="$run_dir/questdb.pid"
     pressure_pid_file="$run_dir/memory-pressure.pid"
     trace_pid_file="$run_dir/fs-usage.pid"
-    mkdir -p "$run_dir"
+    watchdog_pid_file="$run_dir/watchdog.pid"
+    # Keep Python store-and-forward buffers and JVM temporary files on the
+    # worker's real filesystem. Never inherit a possibly memory-backed /tmp.
+    mkdir -p "$run_dir/tmp"
 
     echo "=== run=$run_number pressure=$PRESSURE_MODE seed=$FUZZ_SEED "\
          "build_mode_seed=$BUILD_MODE_SEED "\
@@ -139,16 +175,29 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
             sleep 0.1
         done
         server_pid="$(sed -n '1p' "$server_pid_file")"
-        # The diagnostic directory belongs to the build user; only fs_usage
-        # itself needs elevation, not this output redirection.
-        # shellcheck disable=SC2024
-        sudo -n fs_usage -w -f filesys "$server_pid" \
-            >"$run_dir/fs-usage.log" 2>&1 &
-        fs_usage_pid=$!
-        echo "$fs_usage_pid" >"$trace_pid_file"
-        sleep 1
-        if ! sudo -n kill -0 "$fs_usage_pid" 2>/dev/null; then
-            touch "$run_dir/fs-usage-helper-exited"
+        if [[ "$FS_TRACE" == "1" ]]; then
+            # Only the tracing replica pays continuous syscall-tracing cost.
+            # shellcheck disable=SC2024
+            sudo -n fs_usage -w -f filesys "$server_pid" \
+                >"$run_dir/fs-usage.log" 2>&1 &
+            fs_usage_pid=$!
+            echo "$fs_usage_pid" >"$trace_pid_file"
+            sleep 1
+            if ! sudo -n kill -0 "$fs_usage_pid" 2>/dev/null; then
+                touch "$run_dir/fs-usage-helper-exited"
+            fi
+        fi
+        python3 system_test/qwp_ws_watchdog.py --run-dir "$run_dir" \
+            >"$run_dir/watchdog-process.log" 2>&1 &
+        watchdog_pid=$!
+        echo "$watchdog_pid" >"$watchdog_pid_file"
+        for _ in $(seq 1 50); do
+            [[ -f "$run_dir/watchdog-ready" ]] && break
+            kill -0 "$watchdog_pid" 2>/dev/null || break
+            sleep 0.1
+        done
+        if [[ ! -f "$run_dir/watchdog-ready" ]]; then
+            touch "$run_dir/watchdog-helper-failed"
         fi
         if [[ "$PRESSURE_MODE" == "warn" ]]; then
             memory_pressure -l warn -s 300 \
@@ -178,10 +227,21 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     QWP_WS_FUZZ_READY_FILE="$ready_file" \
     QWP_WS_FUZZ_GO_FILE="$go_file" \
     QWP_WS_FUZZ_PID_FILE="$server_pid_file" \
+    QWP_WS_FUZZ_WATCHDOG_DIR="$run_dir" \
+    TMPDIR="$run_dir/tmp" \
         python3 system_test/test.py run --repo ./questdb \
             TestQwpWsFuzz.test_add_columns -v \
             2>&1 | tee -a "$DIAG_DIR/test.log"
     test_rc=${PIPESTATUS[0]}
+    if [[ ! -f "$run_dir/workload-finished" ||
+          -f "$run_dir/watchdog-helper-failed" ||
+          ! -s "$run_dir/heartbeat.jsonl" ||
+          ! -s "$run_dir/jvm-pauses.log" ||
+          -f "$run_dir/capture-error" ]]; then
+        echo "Incomplete onset diagnostics; inspect run=$run_number artifacts" \
+            | tee -a "$DIAG_DIR/test.log"
+        [[ "$test_rc" -ne 0 ]] || test_rc=2
+    fi
     if [[ "$test_rc" -eq 0 && \
           -f "$run_dir/memory-pressure-helper-exited" ]]; then
         echo "memory_pressure exited before the diagnostic gate" \
@@ -207,6 +267,18 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     fi
     wait "$controller_pid" 2>/dev/null || true
     controller_pid=""
+    # The watchdog normally exits after the workload-finished marker. Allow
+    # its in-flight probe to return, then detect an unexpected helper death.
+    for _ in $(seq 1 20); do
+        [[ -f "$run_dir/watchdog-stopped" ]] && break
+        sleep 0.1
+    done
+    if [[ ! -f "$run_dir/watchdog-stopped" ]] ||
+            ! grep -q '"event": "workload_finished"' "$run_dir/watchdog.jsonl"; then
+        echo "Watchdog did not observe workload completion" | tee -a "$DIAG_DIR/test.log"
+        [[ "$test_rc" -ne 0 ]] || test_rc=2
+    fi
+    stop_watchdog
     stop_trace
     if [[ -f "$pressure_pid_file" ]]; then
         pressure_pid="$(sed -n '1p' "$pressure_pid_file")"
@@ -219,6 +291,7 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
     if [[ -f "$server_log" ]]; then
         cp "$server_log" "$run_dir/questdb-server.log"
     fi
+    cp build/questdb/repo/data/conf/server.conf "$run_dir/server.conf" || true
 
     echo "=== run=$run_number rc=$test_rc "\
          "finished=$(date -u '+%Y-%m-%dT%H:%M:%SZ') ===" \
@@ -226,6 +299,11 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
 
     if [[ "$test_rc" -ne 0 ]]; then
         overall_rc="$test_rc"
+        break
+    fi
+    if [[ -f "$run_dir/capture-started" ]]; then
+        echo "Onset captured; ending this replica to inspect evidence" \
+            | tee -a "$DIAG_DIR/test.log"
         break
     fi
 done

--- a/ci/run_macos_qwp_ws_diagnostics.sh
+++ b/ci/run_macos_qwp_ws_diagnostics.sh
@@ -10,7 +10,7 @@ set -uo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly ROOT_DIR
 readonly DIAG_DIR="${QWP_WS_DIAGNOSTICS_DIR:?QWP_WS_DIAGNOSTICS_DIR is required}"
-readonly PRESSURE_MODE="${QWP_WS_MEMORY_PRESSURE:-natural}"
+readonly PRESSURE_PLAN="${QWP_WS_MEMORY_PRESSURE:-natural}"
 readonly RUN_COUNT="${QWP_WS_DIAGNOSTIC_RUNS:-3}"
 readonly FUZZ_SEED="0x268579c36b106b74"
 readonly BUILD_MODE_SEED="7856154056746654427"
@@ -36,8 +36,8 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
     exit 2
 fi
 
-if [[ "$PRESSURE_MODE" != "natural" && "$PRESSURE_MODE" != "warn" ]]; then
-    echo "Unsupported QWP_WS_MEMORY_PRESSURE=$PRESSURE_MODE" >&2
+if [[ "$PRESSURE_PLAN" != "natural" && "$PRESSURE_PLAN" != "warn" && "$PRESSURE_PLAN" != "paired" ]]; then
+    echo "Unsupported QWP_WS_MEMORY_PRESSURE=$PRESSURE_PLAN" >&2
     exit 2
 fi
 
@@ -55,7 +55,7 @@ mkdir -p "$DIAG_DIR"
 if [[ "$SYSTEM_TRACE" == "1" &&
       ( ! -s "$DIAG_DIR/preflight/system-trace-valid.json" ||
         -e "$DIAG_DIR/preflight/system-trace-error.json" ||
-        "$FS_TRACE" != "0" || "$PRESSURE_MODE" != "natural" ) ]]; then
+        "$FS_TRACE" != "0" || "$PRESSURE_PLAN" != "natural" ) ]]; then
     echo "System Trace requires a successful preflight, no fs_usage and natural memory" >&2
     exit 2
 fi
@@ -83,6 +83,7 @@ snapshot_host() {
         sysctl hw.physicalcpu || true
         sysctl hw.logicalcpu || true
         sysctl vm.swapusage || true
+        sysctl kern.memorystatus_vm_pressure_level || true
         memory_pressure || true
         diskutil info / || true
         df -h /
@@ -92,6 +93,7 @@ snapshot_host() {
         git -C questdb rev-parse HEAD
         echo "fs_trace=$FS_TRACE server_revision=$SERVER_REVISION"
         echo "runs=$RUN_COUNT max_seconds=$MAX_SECONDS stop_on_capture=$STOP_ON_CAPTURE"
+        echo "pressure_plan=$PRESSURE_PLAN"
         echo "min_free_kb=$MIN_FREE_KB"
         echo "system_trace=$SYSTEM_TRACE trace_capture_limit=2 controls=1,6,11"
         find questdb/core/target -maxdepth 1 -type f \
@@ -176,6 +178,7 @@ monitor_pids+=("$!")
         echo "=== $(date -u '+%Y-%m-%dT%H:%M:%SZ') ==="
         memory_pressure || true
         sysctl vm.swapusage || true
+        sysctl kern.memorystatus_vm_pressure_level || true
         ps -axo pid,ppid,rss,vsz,%cpu,state,etime,command || true
         sleep 5
     done
@@ -187,6 +190,7 @@ soak_started=$SECONDS
 stop_reason="run_limit"
 trace_captures=0
 for run_number in $(seq 1 "$RUN_COUNT"); do
+    PRESSURE_MODE="$(python3 system_test/qwp_ws_pressure.py mode "$PRESSURE_PLAN" "$run_number")" || exit 2
     # Stay on this hosted VM for the whole loop. JVM/fixture restarts do not
     # allocate a new worker. Let an in-flight test retain its original timeout.
     if (( SECONDS - soak_started >= MAX_SECONDS )); then
@@ -311,8 +315,17 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
         if [[ ! -f "$run_dir/watchdog-ready" ]]; then
             touch "$run_dir/watchdog-helper-failed"
         fi
+        if [[ "$PRESSURE_PLAN" == "paired" ]]; then
+            # The previous allocator has been stopped. Require recovery before
+            # creating the next one; memory_pressure exits if already at warn.
+            if ! python3 system_test/qwp_ws_pressure.py gate natural \
+                    >"$run_dir/pressure-recovery.jsonl" 2>"$run_dir/pressure-recovery-error.log"; then
+                touch "$run_dir/pressure-target-not-reached"
+                exit 2
+            fi
+        fi
         if [[ "$PRESSURE_MODE" == "warn" ]]; then
-            memory_pressure -l warn -s 300 \
+            memory_pressure -l warn -s 1 \
                 >"$run_dir/memory-pressure.log" 2>&1 &
             pressure_pid=$!
             echo "$pressure_pid" >"$pressure_pid_file"
@@ -323,10 +336,24 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
         else
             echo "natural-memory control" >"$run_dir/memory-pressure.log"
         fi
+        if [[ "$PRESSURE_PLAN" == "paired" ]]; then
+            pressure_gate_args=(gate "$PRESSURE_MODE")
+            if [[ "$PRESSURE_MODE" == "warn" ]]; then
+                pressure_gate_args+=(--pid "$pressure_pid")
+            fi
+            if ! python3 system_test/qwp_ws_pressure.py "${pressure_gate_args[@]}" \
+                    >"$run_dir/pressure-gate.jsonl" 2>"$run_dir/pressure-gate-error.log"; then
+                touch "$run_dir/pressure-target-not-reached"
+                # Do not release a workload under a falsely labelled condition.
+                # Paired pressure setup has a separate 60-second gate budget.
+                exit 2
+            fi
+        fi
         {
             date -u '+%Y-%m-%dT%H:%M:%SZ'
             memory_pressure || true
             sysctl vm.swapusage || true
+            sysctl kern.memorystatus_vm_pressure_level || true
             vm_stat || true
         } >"$run_dir/pressure-at-gate.log" 2>&1
         touch "$go_file"
@@ -387,6 +414,7 @@ for run_number in $(seq 1 "$RUN_COUNT"); do
         date -u '+%Y-%m-%dT%H:%M:%SZ'
         memory_pressure || true
         sysctl vm.swapusage || true
+        sysctl kern.memorystatus_vm_pressure_level || true
         vm_stat || true
     } >"$run_dir/pressure-after-test.log" 2>&1
 

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -7,7 +7,7 @@ variables:
   Darwin-ARM: armosx
   Linux-ARM: armlinux
   Linux-X64: linux
-  QWP_WS_DIAGNOSTIC_BRANCH: refs/heads/investigate/qwp-ws-macos-pressure
+  QWP_WS_DIAGNOSTIC_REF: refs/pull/200/merge
 
 stages:
   - stage: BuildAndTest
@@ -15,7 +15,7 @@ stages:
     jobs:
       - job: RunOn
         displayName: "on"
-        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
+        condition: ne(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         strategy:
           matrix:
             linux:
@@ -84,7 +84,7 @@ stages:
       # image tests the one macOS architecture the client ships against.
       - job: RustTests
         displayName: "cargo tests (mac/windows)"
-        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
+        condition: ne(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         strategy:
           matrix:
             mac:
@@ -105,7 +105,7 @@ stages:
             displayName: "cargo tests"
       - job: NativeTests
         displayName: "build + C++ + integration (mac/windows)"
-        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
+        condition: ne(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         strategy:
           matrix:
             mac:
@@ -164,7 +164,7 @@ stages:
               artifactName: qdb-log-native-$(imageName)
       - job: VersionMatrix
         displayName: "arrow/polars version-range tests (linux)"
-        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
+        condition: ne(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         pool:
           vmImage: "ubuntu-latest"
         timeoutInMinutes: 90
@@ -177,7 +177,7 @@ stages:
             displayName: "questdb-rs: pinned arrow/polars versions"
       - job: RustMsrvAndDocs
         displayName: "Rust MSRV and release documentation"
-        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
+        condition: ne(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         pool:
           vmImage: "ubuntu-latest"
         timeoutInMinutes: 45
@@ -205,7 +205,7 @@ stages:
             displayName: "Check release documentation"
       - job: FormatAndLinting
         displayName: "cargo fmt and clippy"
-        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
+        condition: ne(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         pool:
           vmImage: "ubuntu-latest"
         timeoutInMinutes: 10
@@ -268,7 +268,7 @@ stages:
             displayName: "failover_clients: clippy"
       - job: SanitizeCppTests
         displayName: "C/C++ tests under ASan + UBSan"
-        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
+        condition: ne(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         pool:
           vmImage: "ubuntu-latest"
         timeoutInMinutes: 60
@@ -301,7 +301,7 @@ stages:
       # Python dependencies, including pyarrow/polars, for non-macOS builds.
       - job: TestVsQuestDBMaster
         displayName: "Vs QuestDB master"
-        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
+        condition: ne(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         pool:
           name: hetzner-incus
         timeoutInMinutes: 90
@@ -399,7 +399,7 @@ stages:
               artifactName: qdb-log-vs-master-$(Agent.OS)
       - job: TestQwpWsFuzz
         displayName: "QWP/WS add-columns diagnostics (macOS hosted)"
-        condition: eq(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
+        condition: eq(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         strategy:
           matrix:
             natural-memory:
@@ -475,7 +475,7 @@ stages:
       # are available on the self-hosted image.
       - job: TestQwpWsFuzzLinux
         displayName: "QWP/WS fuzz suite (linux/hetzner-incus)"
-        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
+        condition: ne(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         pool:
           name: hetzner-incus
         timeoutInMinutes: 90
@@ -574,7 +574,7 @@ stages:
       # run_fuzz_pipeline.yaml varies the seed per build.
       - job: TestQwpEgressLiveServerFuzz
         displayName: "QWP egress live-server suite"
-        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
+        condition: ne(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         pool:
           vmImage: "ubuntu-latest"
         timeoutInMinutes: 60
@@ -665,7 +665,7 @@ stages:
         # tokens) are not exposed to fork builds, so the REST POST
         # would 401. Skipping rather than failing keeps fork-PR CI
         # clean.
-        condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH']))
+        condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF']))
         variables:
           # Hardcoded because the Enterprise pipeline lives in its own
           # ADO project, not the one this pipeline runs in.

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -389,13 +389,15 @@ stages:
               pathToPublish: $(Build.ArtifactStagingDirectory)/qdb-log-vs-master-$(Agent.OS).zip
               artifactName: qdb-log-vs-master-$(Agent.OS)
       - job: TestQwpWsFuzz
-        displayName: "QWP/WS fuzz suite (mac/windows hosted)"
+        displayName: "QWP/WS add-columns diagnostics (macOS hosted)"
         strategy:
           matrix:
-            mac:
+            natural-memory:
               imageName: "macOS-15-arm64"
-            windows-2022:
-              imageName: "windows-2022"
+              qwpMemoryPressure: "natural"
+            warning-memory-pressure:
+              imageName: "macOS-15-arm64"
+              qwpMemoryPressure: "warn"
         pool:
           vmImage: $(imageName)
         timeoutInMinutes: 90
@@ -416,12 +418,21 @@ stages:
               javaHomeOption: "Path"
               jdkDirectory: "$(JAVA_HOME)"
               options: "-s $(MAVEN_SETTINGS_FILE) -DskipTests -Pbuild-web-console$(CLIENT_PROFILE) $(MAVEN_RUN_OPTS)"
-          - script: |
-              python3 system_test/test.py run --repo ./questdb TestQwpWsFuzz -v
-            displayName: "TestQwpWsFuzz"
-          - script: |
-              python3 system_test/test.py run --repo ./questdb TestArrowEgressFuzz TestArrowEgressPerKind TestArrowEgressEmpty TestArrowIngressFuzz TestArrowIngressPerKind TestArrowIngressDesignatedTs TestArrowIngressErrors TestArrowIngressMultiBatch TestArrowIngressExtraTypes TestArrowIngressUnsupportedTypes TestArrowIngressSfa TestArrowRoundTripFuzz TestArrowRoundTripPerKind TestArrowAlignment TestArrowPolarsFuzz TestArrowPolarsRoundTripPerKind TestArrowPolarsPerDtype -v
-            displayName: "TestArrowWsFuzz"
+          - bash: ci/run_macos_qwp_ws_diagnostics.sh
+            displayName: "Reproduce QWP/WS add-columns stall"
+            env:
+              QWP_WS_DIAGNOSTIC_RUNS: "3"
+              QWP_WS_DIAGNOSTICS_DIR: >-
+                $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
+              QWP_WS_MEMORY_PRESSURE: $(qwpMemoryPressure)
+          - task: PublishBuildArtifacts@1
+            displayName: "Publish macOS host diagnostics"
+            condition: always()
+            continueOnError: true
+            inputs:
+              pathToPublish: >-
+                $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
+              artifactName: qwp-ws-macos-$(qwpMemoryPressure)
           # Mirrors ci/run_fuzz_pipeline.yaml: on failure, archive and
           # publish the QuestDB server log so PR reviewers don't have to
           # repro locally. Path comes from system_test/fixture.py:_log_path.
@@ -433,15 +444,17 @@ stages:
               rootFolderOrFile: $(Build.SourcesDirectory)/build/questdb/repo/data/log
               includeRootFolder: false
               archiveType: zip
-              archiveFile: $(Build.ArtifactStagingDirectory)/qdb-log-$(Agent.OS).zip
+              archiveFile: >-
+                $(Build.ArtifactStagingDirectory)/qdb-log-$(Agent.OS)-$(qwpMemoryPressure).zip
               quiet: true
           - task: PublishBuildArtifacts@1
             displayName: "Publish QuestDB server log on failure"
             condition: failed()
             continueOnError: true
             inputs:
-              pathToPublish: $(Build.ArtifactStagingDirectory)/qdb-log-$(Agent.OS).zip
-              artifactName: qdb-log-$(Agent.OS)
+              pathToPublish: >-
+                $(Build.ArtifactStagingDirectory)/qdb-log-$(Agent.OS)-$(qwpMemoryPressure).zip
+              artifactName: qdb-log-$(Agent.OS)-$(qwpMemoryPressure)
 
       # Linux leg on self-hosted hetzner-incus — mirrors the equivalent
       # job in ci/run_fuzz_pipeline.yaml. Pool image is built from

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -7,6 +7,7 @@ variables:
   Darwin-ARM: armosx
   Linux-ARM: armlinux
   Linux-X64: linux
+  QWP_WS_DIAGNOSTIC_BRANCH: refs/heads/investigate/qwp-ws-macos-pressure
 
 stages:
   - stage: BuildAndTest
@@ -14,6 +15,7 @@ stages:
     jobs:
       - job: RunOn
         displayName: "on"
+        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
         strategy:
           matrix:
             linux:
@@ -82,6 +84,7 @@ stages:
       # image tests the one macOS architecture the client ships against.
       - job: RustTests
         displayName: "cargo tests (mac/windows)"
+        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
         strategy:
           matrix:
             mac:
@@ -102,6 +105,7 @@ stages:
             displayName: "cargo tests"
       - job: NativeTests
         displayName: "build + C++ + integration (mac/windows)"
+        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
         strategy:
           matrix:
             mac:
@@ -160,6 +164,7 @@ stages:
               artifactName: qdb-log-native-$(imageName)
       - job: VersionMatrix
         displayName: "arrow/polars version-range tests (linux)"
+        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
         pool:
           vmImage: "ubuntu-latest"
         timeoutInMinutes: 90
@@ -172,6 +177,7 @@ stages:
             displayName: "questdb-rs: pinned arrow/polars versions"
       - job: RustMsrvAndDocs
         displayName: "Rust MSRV and release documentation"
+        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
         pool:
           vmImage: "ubuntu-latest"
         timeoutInMinutes: 45
@@ -199,6 +205,7 @@ stages:
             displayName: "Check release documentation"
       - job: FormatAndLinting
         displayName: "cargo fmt and clippy"
+        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
         pool:
           vmImage: "ubuntu-latest"
         timeoutInMinutes: 10
@@ -261,6 +268,7 @@ stages:
             displayName: "failover_clients: clippy"
       - job: SanitizeCppTests
         displayName: "C/C++ tests under ASan + UBSan"
+        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
         pool:
           vmImage: "ubuntu-latest"
         timeoutInMinutes: 60
@@ -293,6 +301,7 @@ stages:
       # Python dependencies, including pyarrow/polars, for non-macOS builds.
       - job: TestVsQuestDBMaster
         displayName: "Vs QuestDB master"
+        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
         pool:
           name: hetzner-incus
         timeoutInMinutes: 90
@@ -390,6 +399,7 @@ stages:
               artifactName: qdb-log-vs-master-$(Agent.OS)
       - job: TestQwpWsFuzz
         displayName: "QWP/WS add-columns diagnostics (macOS hosted)"
+        condition: eq(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
         strategy:
           matrix:
             natural-memory:
@@ -418,7 +428,7 @@ stages:
               javaHomeOption: "Path"
               jdkDirectory: "$(JAVA_HOME)"
               options: "-s $(MAVEN_SETTINGS_FILE) -DskipTests -Pbuild-web-console$(CLIENT_PROFILE) $(MAVEN_RUN_OPTS)"
-          - bash: ci/run_macos_qwp_ws_diagnostics.sh
+          - bash: bash ci/run_macos_qwp_ws_diagnostics.sh
             displayName: "Reproduce QWP/WS add-columns stall"
             env:
               QWP_WS_DIAGNOSTIC_RUNS: "3"
@@ -465,6 +475,7 @@ stages:
       # are available on the self-hosted image.
       - job: TestQwpWsFuzzLinux
         displayName: "QWP/WS fuzz suite (linux/hetzner-incus)"
+        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
         pool:
           name: hetzner-incus
         timeoutInMinutes: 90
@@ -563,6 +574,7 @@ stages:
       # run_fuzz_pipeline.yaml varies the seed per build.
       - job: TestQwpEgressLiveServerFuzz
         displayName: "QWP egress live-server suite"
+        condition: ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH'])
         pool:
           vmImage: "ubuntu-latest"
         timeoutInMinutes: 60
@@ -653,7 +665,7 @@ stages:
         # tokens) are not exposed to fork builds, so the REST POST
         # would 401. Skipping rather than failing keeps fork-PR CI
         # clean.
-        condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
+        condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['System.PullRequest.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_BRANCH']))
         variables:
           # Hardcoded because the Enterprise pipeline lives in its own
           # ADO project, not the one this pipeline runs in.

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -480,14 +480,15 @@ stages:
                 # Restore the original 72 missing-table ALTER lookups before
                 # producer connection. This is a scheduling perturbation, not
                 # a recreation of the unknown original startup delay.
-                # Kernel-resource follow-up: one unrecorded control, then up to
-                # seven attempts that capture the first failed ping or slow
-                # query. Preserve query stages; short pings are not the original
-                # long-query failure. No pressure or separate disk load.
+                # Paired mapped-file perturbation: low-rate/load/load/low-rate.
+                # Unlike the earlier pwrite/fsync helper, dirty a mapping,
+                # unmap and shrink; pace the finite byte budget across the test.
+                # Capture only slow query/observer/workload failure, not pings.
                 # No new attempt after ten minutes; stop at first capture.
-                QWP_WS_DIAGNOSTIC_RUNS: "8"
-                QWP_WS_KERNEL_CAPTURE: ping
-                QWP_WS_DISK_LOAD: "0"
+                QWP_WS_DIAGNOSTIC_RUNS: "4"
+                QWP_WS_KERNEL_CAPTURE: query
+                QWP_WS_DISK_LOAD: "1"
+                QWP_WS_DISK_PATTERN: mapped
                 QWP_WS_STARTUP_LOOKUPS: "72"
                 QWP_WS_MAX_SECONDS: "600"
                 QWP_WS_STOP_ON_CAPTURE: "1"

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -4,7 +4,7 @@ parameters:
   - name: qwpWsPreflightOnly
     displayName: "QWP diagnostics: verify recorder startup only (no builds/tests)"
     type: boolean
-    default: true
+    default: false
 
 variables:
   OS_MAPPING: none

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -398,7 +398,7 @@ stages:
               pathToPublish: $(Build.ArtifactStagingDirectory)/qdb-log-vs-master-$(Agent.OS).zip
               artifactName: qdb-log-vs-master-$(Agent.OS)
       - job: TestQwpWsFuzz
-        displayName: "QWP/WS add-columns onset diagnostics (macOS hosted)"
+        displayName: "QWP/WS add-columns repeated-load diagnostics (macOS hosted)"
         condition: eq(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         strategy:
           matrix:
@@ -409,7 +409,7 @@ stages:
             replica-b:
               imageName: "macOS-15-arm64"
               diagnosticReplica: "b"
-              diagnosticFsTrace: "1"
+              diagnosticFsTrace: "0"
         pool:
           vmImage: $(imageName)
         timeoutInMinutes: 90
@@ -436,9 +436,13 @@ stages:
               jdkDirectory: "$(JAVA_HOME)"
               options: "-s $(MAVEN_SETTINGS_FILE) -DskipTests -Pbuild-web-console$(CLIENT_PROFILE) $(MAVEN_RUN_OPTS)"
           - bash: bash ci/run_macos_qwp_ws_diagnostics.sh
-            displayName: "Reproduce QWP/WS add-columns stall"
+            displayName: "Loop unchanged QWP/WS test on the same worker"
+            timeoutInMinutes: 30
             env:
-              QWP_WS_DIAGNOSTIC_RUNS: "20"
+              QWP_WS_DIAGNOSTIC_RUNS: "60"
+              QWP_WS_MAX_SECONDS: "1200"
+              QWP_WS_STOP_ON_CAPTURE: "0"
+              QWP_WS_MIN_FREE_KB: "2097152"
               QWP_WS_DIAGNOSTICS_DIR: >-
                 $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
               QWP_WS_MEMORY_PRESSURE: natural

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -398,27 +398,27 @@ stages:
               pathToPublish: $(Build.ArtifactStagingDirectory)/qdb-log-vs-master-$(Agent.OS).zip
               artifactName: qdb-log-vs-master-$(Agent.OS)
       - job: TestQwpWsFuzz
-        displayName: "QWP/WS add-columns repeated-load diagnostics (macOS hosted)"
+        displayName: "QWP/WS syscall and scheduler diagnostics (one macOS worker)"
         condition: eq(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
-        strategy:
-          matrix:
-            replica-a:
-              imageName: "macOS-15-arm64"
-              diagnosticReplica: "a"
-              diagnosticFsTrace: "0"
-            replica-b:
-              imageName: "macOS-15-arm64"
-              diagnosticReplica: "b"
-              diagnosticFsTrace: "0"
+        variables:
+          diagnosticReplica: system-trace
         pool:
-          vmImage: $(imageName)
+          vmImage: macOS-15-arm64
         timeoutInMinutes: 90
         steps:
           - checkout: self
             fetchDepth: 1
             lfs: false
             submodules: false
+          - bash: bash ci/prepare_qwp_ws_system_trace.sh
+            displayName: "Verify syscall and scheduler tracing before compilation"
+            timeoutInMinutes: 3
+            env:
+              QWP_WS_DIAGNOSTICS_DIR: >-
+                $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
           - template: templates/compile.yaml
+            parameters:
+              prerequisiteCondition: succeeded()
           - template: templates/resolve_jdk25.yaml
           - template: templates/clone_questdb.yaml
             parameters:
@@ -436,21 +436,33 @@ stages:
               jdkDirectory: "$(JAVA_HOME)"
               options: "-s $(MAVEN_SETTINGS_FILE) -DskipTests -Pbuild-web-console$(CLIENT_PROFILE) $(MAVEN_RUN_OPTS)"
           - bash: bash ci/run_macos_qwp_ws_diagnostics.sh
-            displayName: "Loop unchanged QWP/WS test on the same worker"
+            displayName: "Capture two onset events with interleaved tracing controls"
             timeoutInMinutes: 30
             env:
-              QWP_WS_DIAGNOSTIC_RUNS: "60"
-              QWP_WS_MAX_SECONDS: "1200"
+              # Attempts 1, 6, 11 are controls; at most ten traced attempts.
+              QWP_WS_DIAGNOSTIC_RUNS: "13"
+              QWP_WS_MAX_SECONDS: "600"
               QWP_WS_STOP_ON_CAPTURE: "0"
+              QWP_WS_SYSTEM_TRACE: "1"
               QWP_WS_MIN_FREE_KB: "2097152"
               QWP_WS_DIAGNOSTICS_DIR: >-
                 $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
               QWP_WS_MEMORY_PRESSURE: natural
-              QWP_WS_FS_TRACE: $(diagnosticFsTrace)
+              QWP_WS_FS_TRACE: "0"
+          - bash: |
+              # xctrace may create private root-owned files despite umask.
+              # Return only this job's diagnostic artifacts to the uploader.
+              if [[ -d "$QWP_WS_DIAGNOSTICS_DIR" ]]; then
+                sudo -n chown -R "$(id -u):$(id -g)" "$QWP_WS_DIAGNOSTICS_DIR"
+              fi
+            displayName: "Make privileged trace artifacts readable by uploader"
+            condition: always()
+            env:
+              QWP_WS_DIAGNOSTICS_DIR: >-
+                $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
           - task: PublishBuildArtifacts@1
             displayName: "Publish macOS host diagnostics"
             condition: always()
-            continueOnError: true
             inputs:
               pathToPublish: >-
                 $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -8,7 +8,7 @@ parameters:
   - name: qwpWsPreflightOnly
     displayName: "QWP diagnostics: verify recorder startup only (no builds/tests)"
     type: boolean
-    default: false
+    default: true
 
 variables:
   OS_MAPPING: none
@@ -413,6 +413,8 @@ stages:
         variables:
           ${{ if parameters.qwpWsDecodeOnly }}:
             diagnosticReplica: trace-decode
+          ${{ elseif parameters.qwpWsPreflightOnly }}:
+            diagnosticReplica: kernel-preflight
           ${{ else }}:
             diagnosticReplica: show-columns
         pool:
@@ -437,8 +439,8 @@ stages:
                 QWP_WS_DIAGNOSTICS_DIR: >-
                   $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
           - ${{ if and(parameters.qwpWsPreflightOnly, not(parameters.qwpWsDecodeOnly)) }}:
-            - bash: bash ci/prepare_qwp_ws_system_trace.sh
-              displayName: "Verify recorder startup and exported syscall/scheduler events"
+            - bash: python3 ci/diagnostics/kernel_wait_preflight.py "$QWP_WS_DIAGNOSTICS_DIR/kernel-preflight"
+              displayName: "Verify kernel wait stacks with a bounded filesystem smoke test"
               timeoutInMinutes: 5
               env:
                 QWP_WS_DIAGNOSTICS_DIR: >-

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -461,8 +461,12 @@ stages:
                 # Restore the original 72 missing-table ALTER lookups before
                 # producer connection. This is a scheduling perturbation, not
                 # a recreation of the unknown original startup delay.
+                # Two probe/load/load/probe cycles; filesystem load only starts
+                # once SHOW COLUMNS telemetry exists. Maximum 1 GiB load writes
+                # across the four load attempts, on one hosted worker.
                 # No new attempt after ten minutes; stop at first capture.
-                QWP_WS_DIAGNOSTIC_RUNS: "12"
+                QWP_WS_DIAGNOSTIC_RUNS: "8"
+                QWP_WS_DISK_LOAD: "1"
                 QWP_WS_STARTUP_LOOKUPS: "72"
                 QWP_WS_MAX_SECONDS: "600"
                 QWP_WS_STOP_ON_CAPTURE: "1"

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -4,7 +4,7 @@ parameters:
   - name: qwpWsDecodeOnly
     displayName: "QWP diagnostics: decode existing trace only (no builds/tests)"
     type: boolean
-    default: false
+    default: true
   - name: qwpWsPreflightOnly
     displayName: "QWP diagnostics: verify recorder startup only (no builds/tests)"
     type: boolean
@@ -432,8 +432,8 @@ stages:
             - bash: |
                 mkdir -p "$QWP_WS_DIAGNOSTICS_DIR/tmp"
                 export TMPDIR="$QWP_WS_DIAGNOSTICS_DIR/tmp"
-                python3 ci/diagnostics/decode_system_trace.py "$QWP_WS_DIAGNOSTICS_DIR/decoded"
-              displayName: "Decode retained VM and scheduler events (no workload)"
+                python3 ci/diagnostics/decode_kernel_capture.py "$QWP_WS_DIAGNOSTICS_DIR/decoded"
+              displayName: "Decode retained kernel capture with retained symbols (no workload)"
               timeoutInMinutes: 7
               env:
                 QWP_WS_DIAGNOSTICS_DIR: >-

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -398,16 +398,18 @@ stages:
               pathToPublish: $(Build.ArtifactStagingDirectory)/qdb-log-vs-master-$(Agent.OS).zip
               artifactName: qdb-log-vs-master-$(Agent.OS)
       - job: TestQwpWsFuzz
-        displayName: "QWP/WS add-columns filesystem diagnostics (macOS hosted)"
+        displayName: "QWP/WS add-columns onset diagnostics (macOS hosted)"
         condition: eq(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         strategy:
           matrix:
             replica-a:
               imageName: "macOS-15-arm64"
               diagnosticReplica: "a"
+              diagnosticFsTrace: "0"
             replica-b:
               imageName: "macOS-15-arm64"
               diagnosticReplica: "b"
+              diagnosticFsTrace: "1"
         pool:
           vmImage: $(imageName)
         timeoutInMinutes: 90
@@ -419,6 +421,11 @@ stages:
           - template: templates/compile.yaml
           - template: templates/resolve_jdk25.yaml
           - template: templates/clone_questdb.yaml
+            parameters:
+              # Original build 266336 task log 122 prints this build hash.
+              revision: 12a33d651e51e2682e7a448c8db5168fc72dfad3
+          - bash: bash ci/prepare_qwp_ws_jdk.sh
+            displayName: "Pin original Temurin 25.0.3+9"
           - template: templates/maven_settings.yaml
           - task: Maven@3
             displayName: "Compile QuestDB"
@@ -435,6 +442,7 @@ stages:
               QWP_WS_DIAGNOSTICS_DIR: >-
                 $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
               QWP_WS_MEMORY_PRESSURE: natural
+              QWP_WS_FS_TRACE: $(diagnosticFsTrace)
           - task: PublishBuildArtifacts@1
             displayName: "Publish macOS host diagnostics"
             condition: always()

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -8,7 +8,7 @@ parameters:
   - name: qwpWsPreflightOnly
     displayName: "QWP diagnostics: verify recorder startup only (no builds/tests)"
     type: boolean
-    default: true
+    default: false
 
 variables:
   OS_MAPPING: none
@@ -480,10 +480,13 @@ stages:
                 # Restore the original 72 missing-table ALTER lookups before
                 # producer connection. This is a scheduling perturbation, not
                 # a recreation of the unknown original startup delay.
-                # One natural/warn/warn/natural cycle. Verify actual kernel
-                # pressure before releasing each workload; no disk-load helper.
+                # Kernel-resource follow-up: one unrecorded control, then up to
+                # seven attempts that capture the first failed ping or slow
+                # query. Preserve query stages; short pings are not the original
+                # long-query failure. No pressure or separate disk load.
                 # No new attempt after ten minutes; stop at first capture.
-                QWP_WS_DIAGNOSTIC_RUNS: "4"
+                QWP_WS_DIAGNOSTIC_RUNS: "8"
+                QWP_WS_KERNEL_CAPTURE: ping
                 QWP_WS_DISK_LOAD: "0"
                 QWP_WS_STARTUP_LOOKUPS: "72"
                 QWP_WS_MAX_SECONDS: "600"
@@ -494,7 +497,7 @@ stages:
                 QWP_WS_MIN_FREE_KB: "2097152"
                 QWP_WS_DIAGNOSTICS_DIR: >-
                   $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
-                QWP_WS_MEMORY_PRESSURE: paired
+                QWP_WS_MEMORY_PRESSURE: natural
                 QWP_WS_FS_TRACE: "0"
           - bash: |
               # xctrace may create private root-owned files despite umask.

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -458,9 +458,12 @@ stages:
               displayName: "Repeat only add-columns until slow query or failure"
               timeoutInMinutes: 30
               env:
-                # Three natural/warn/warn/natural cycles, one host, same test.
+                # Restore the original 72 missing-table ALTER lookups before
+                # producer connection. This is a scheduling perturbation, not
+                # a recreation of the unknown original startup delay.
                 # No new attempt after ten minutes; stop at first capture.
                 QWP_WS_DIAGNOSTIC_RUNS: "12"
+                QWP_WS_STARTUP_LOOKUPS: "72"
                 QWP_WS_MAX_SECONDS: "600"
                 QWP_WS_STOP_ON_CAPTURE: "1"
                 QWP_WS_SYSTEM_TRACE: "0"
@@ -469,7 +472,7 @@ stages:
                 QWP_WS_MIN_FREE_KB: "2097152"
                 QWP_WS_DIAGNOSTICS_DIR: >-
                   $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
-                QWP_WS_MEMORY_PRESSURE: paired
+                QWP_WS_MEMORY_PRESSURE: natural
                 QWP_WS_FS_TRACE: "0"
           - bash: |
               # xctrace may create private root-owned files despite umask.

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -480,14 +480,17 @@ stages:
                 # Restore the original 72 missing-table ALTER lookups before
                 # producer connection. This is a scheduling perturbation, not
                 # a recreation of the unknown original startup delay.
-                # Return to the original query failure without the external
-                # filesystem helper. More repetitions amortize this one build.
+                # Stress reproduction: one serial 5 Hz SHOW COLUMNS reader
+                # stops on its first error. Only a 1 Hz tiny mapped-file probe;
+                # no high-rate filesystem load. This changes query traffic.
                 # Capture slow queries, observer loss or actual workload failure;
                 # short ping failures are telemetry only. Stop first capture.
                 # No new attempt after ten minutes, regardless of run count.
-                QWP_WS_DIAGNOSTIC_RUNS: "24"
+                QWP_WS_DIAGNOSTIC_RUNS: "4"
                 QWP_WS_KERNEL_CAPTURE: query
-                QWP_WS_DISK_LOAD: "0"
+                QWP_WS_QUERY_READER: "1"
+                QWP_WS_DISK_LOAD: "1"
+                QWP_WS_DISK_MODE: probe
                 QWP_WS_DISK_PATTERN: mapped
                 QWP_WS_STARTUP_LOOKUPS: "72"
                 QWP_WS_MAX_SECONDS: "600"

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -398,16 +398,16 @@ stages:
               pathToPublish: $(Build.ArtifactStagingDirectory)/qdb-log-vs-master-$(Agent.OS).zip
               artifactName: qdb-log-vs-master-$(Agent.OS)
       - job: TestQwpWsFuzz
-        displayName: "QWP/WS add-columns diagnostics (macOS hosted)"
+        displayName: "QWP/WS add-columns filesystem diagnostics (macOS hosted)"
         condition: eq(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         strategy:
           matrix:
-            natural-memory:
+            replica-a:
               imageName: "macOS-15-arm64"
-              qwpMemoryPressure: "natural"
-            warning-memory-pressure:
+              diagnosticReplica: "a"
+            replica-b:
               imageName: "macOS-15-arm64"
-              qwpMemoryPressure: "warn"
+              diagnosticReplica: "b"
         pool:
           vmImage: $(imageName)
         timeoutInMinutes: 90
@@ -431,10 +431,10 @@ stages:
           - bash: bash ci/run_macos_qwp_ws_diagnostics.sh
             displayName: "Reproduce QWP/WS add-columns stall"
             env:
-              QWP_WS_DIAGNOSTIC_RUNS: "3"
+              QWP_WS_DIAGNOSTIC_RUNS: "20"
               QWP_WS_DIAGNOSTICS_DIR: >-
                 $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
-              QWP_WS_MEMORY_PRESSURE: $(qwpMemoryPressure)
+              QWP_WS_MEMORY_PRESSURE: natural
           - task: PublishBuildArtifacts@1
             displayName: "Publish macOS host diagnostics"
             condition: always()
@@ -442,7 +442,7 @@ stages:
             inputs:
               pathToPublish: >-
                 $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
-              artifactName: qwp-ws-macos-$(qwpMemoryPressure)
+              artifactName: qwp-ws-macos-$(diagnosticReplica)
           # Mirrors ci/run_fuzz_pipeline.yaml: on failure, archive and
           # publish the QuestDB server log so PR reviewers don't have to
           # repro locally. Path comes from system_test/fixture.py:_log_path.
@@ -455,7 +455,7 @@ stages:
               includeRootFolder: false
               archiveType: zip
               archiveFile: >-
-                $(Build.ArtifactStagingDirectory)/qdb-log-$(Agent.OS)-$(qwpMemoryPressure).zip
+                $(Build.ArtifactStagingDirectory)/qdb-log-$(Agent.OS)-$(diagnosticReplica).zip
               quiet: true
           - task: PublishBuildArtifacts@1
             displayName: "Publish QuestDB server log on failure"
@@ -463,8 +463,8 @@ stages:
             continueOnError: true
             inputs:
               pathToPublish: >-
-                $(Build.ArtifactStagingDirectory)/qdb-log-$(Agent.OS)-$(qwpMemoryPressure).zip
-              artifactName: qdb-log-$(Agent.OS)-$(qwpMemoryPressure)
+                $(Build.ArtifactStagingDirectory)/qdb-log-$(Agent.OS)-$(diagnosticReplica).zip
+              artifactName: qdb-log-$(Agent.OS)-$(diagnosticReplica)
 
       # Linux leg on self-hosted hetzner-incus — mirrors the equivalent
       # job in ci/run_fuzz_pipeline.yaml. Pool image is built from

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -4,7 +4,7 @@ parameters:
   - name: qwpWsDecodeOnly
     displayName: "QWP diagnostics: decode existing trace only (no builds/tests)"
     type: boolean
-    default: true
+    default: false
   - name: qwpWsPreflightOnly
     displayName: "QWP diagnostics: verify recorder startup only (no builds/tests)"
     type: boolean
@@ -478,12 +478,11 @@ stages:
                 # Restore the original 72 missing-table ALTER lookups before
                 # producer connection. This is a scheduling perturbation, not
                 # a recreation of the unknown original startup delay.
-                # Two probe/load/load/probe cycles; filesystem load only starts
-                # once SHOW COLUMNS telemetry exists. Maximum 1 GiB load writes
-                # across the four load attempts, on one hosted worker.
+                # One natural/warn/warn/natural cycle. Verify actual kernel
+                # pressure before releasing each workload; no disk-load helper.
                 # No new attempt after ten minutes; stop at first capture.
-                QWP_WS_DIAGNOSTIC_RUNS: "8"
-                QWP_WS_DISK_LOAD: "1"
+                QWP_WS_DIAGNOSTIC_RUNS: "4"
+                QWP_WS_DISK_LOAD: "0"
                 QWP_WS_STARTUP_LOOKUPS: "72"
                 QWP_WS_MAX_SECONDS: "600"
                 QWP_WS_STOP_ON_CAPTURE: "1"
@@ -493,7 +492,7 @@ stages:
                 QWP_WS_MIN_FREE_KB: "2097152"
                 QWP_WS_DIAGNOSTICS_DIR: >-
                   $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
-                QWP_WS_MEMORY_PRESSURE: natural
+                QWP_WS_MEMORY_PRESSURE: paired
                 QWP_WS_FS_TRACE: "0"
           - bash: |
               # xctrace may create private root-owned files despite umask.

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -404,10 +404,10 @@ stages:
               pathToPublish: $(Build.ArtifactStagingDirectory)/qdb-log-vs-master-$(Agent.OS).zip
               artifactName: qdb-log-vs-master-$(Agent.OS)
       - job: TestQwpWsFuzz
-        displayName: "QWP/WS recorder diagnostics (one macOS worker)"
+        displayName: "QWP/WS slow SHOW COLUMNS diagnostics (one macOS worker)"
         condition: eq(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         variables:
-          diagnosticReplica: system-trace
+          diagnosticReplica: show-columns
         pool:
           vmImage: macOS-15-arm64
         ${{ if parameters.qwpWsPreflightOnly }}:
@@ -419,14 +419,15 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: false
-          - bash: bash ci/prepare_qwp_ws_system_trace.sh
-            displayName: "Verify recorder startup and exported syscall/scheduler events"
-            timeoutInMinutes: 5
-            env:
-              QWP_WS_DIAGNOSTICS_DIR: >-
-                $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
-          # Compile-time exclusion: a successful smoke check must not silently
-          # turn this startup investigation into another expensive test run.
+          - ${{ if parameters.qwpWsPreflightOnly }}:
+            - bash: bash ci/prepare_qwp_ws_system_trace.sh
+              displayName: "Verify recorder startup and exported syscall/scheduler events"
+              timeoutInMinutes: 5
+              env:
+                QWP_WS_DIAGNOSTICS_DIR: >-
+                  $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
+          # The optional recorder-only mode still excludes all builds/tests.
+          # The normal query-stage arm does not start System Trace.
           - ${{ if not(parameters.qwpWsPreflightOnly) }}:
             - template: templates/compile.yaml
               parameters:
@@ -447,15 +448,23 @@ stages:
                 javaHomeOption: "Path"
                 jdkDirectory: "$(JAVA_HOME)"
                 options: "-s $(MAVEN_SETTINGS_FILE) -DskipTests -Pbuild-web-console$(CLIENT_PROFILE) $(MAVEN_RUN_OPTS)"
+            - bash: |
+                python3 ci/diagnostics/show_columns/prepare.py \
+                  --repo questdb \
+                  --jar questdb/core/target/questdb-10.0.2-SNAPSHOT.jar \
+                  --output "$(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics/query-probe"
+              displayName: "Compile exact-revision SHOW COLUMNS diagnostic overlay"
             - bash: bash ci/run_macos_qwp_ws_diagnostics.sh
-              displayName: "Capture two onset events with interleaved tracing controls"
+              displayName: "Repeat only add-columns until slow query or failure"
               timeoutInMinutes: 30
               env:
-                # Attempts 1, 6, 11 are controls; at most ten traced attempts.
-                QWP_WS_DIAGNOSTIC_RUNS: "13"
+                # One host, unchanged test; no new attempt after ten minutes.
+                QWP_WS_DIAGNOSTIC_RUNS: "40"
                 QWP_WS_MAX_SECONDS: "600"
-                QWP_WS_STOP_ON_CAPTURE: "0"
-                QWP_WS_SYSTEM_TRACE: "1"
+                QWP_WS_STOP_ON_CAPTURE: "1"
+                QWP_WS_SYSTEM_TRACE: "0"
+                QWP_WS_SHOW_COLUMNS_OVERLAY: >-
+                  $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics/query-probe/show-columns-probe.jar
                 QWP_WS_MIN_FREE_KB: "2097152"
                 QWP_WS_DIAGNOSTICS_DIR: >-
                   $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -1,6 +1,10 @@
 trigger: none
 
 parameters:
+  - name: qwpWsDecodeOnly
+    displayName: "QWP diagnostics: decode existing trace only (no builds/tests)"
+    type: boolean
+    default: true
   - name: qwpWsPreflightOnly
     displayName: "QWP diagnostics: verify recorder startup only (no builds/tests)"
     type: boolean
@@ -407,10 +411,13 @@ stages:
         displayName: "QWP/WS slow SHOW COLUMNS diagnostics (one macOS worker)"
         condition: eq(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         variables:
-          diagnosticReplica: show-columns
+          ${{ if parameters.qwpWsDecodeOnly }}:
+            diagnosticReplica: trace-decode
+          ${{ else }}:
+            diagnosticReplica: show-columns
         pool:
           vmImage: macOS-15-arm64
-        ${{ if parameters.qwpWsPreflightOnly }}:
+        ${{ if or(parameters.qwpWsPreflightOnly, parameters.qwpWsDecodeOnly) }}:
           timeoutInMinutes: 10
         ${{ else }}:
           timeoutInMinutes: 90
@@ -419,7 +426,17 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: false
-          - ${{ if parameters.qwpWsPreflightOnly }}:
+          - ${{ if parameters.qwpWsDecodeOnly }}:
+            - bash: |
+                mkdir -p "$QWP_WS_DIAGNOSTICS_DIR/tmp"
+                export TMPDIR="$QWP_WS_DIAGNOSTICS_DIR/tmp"
+                python3 ci/diagnostics/decode_system_trace.py "$QWP_WS_DIAGNOSTICS_DIR/decoded"
+              displayName: "Decode retained VM and scheduler events (no workload)"
+              timeoutInMinutes: 7
+              env:
+                QWP_WS_DIAGNOSTICS_DIR: >-
+                  $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
+          - ${{ if and(parameters.qwpWsPreflightOnly, not(parameters.qwpWsDecodeOnly)) }}:
             - bash: bash ci/prepare_qwp_ws_system_trace.sh
               displayName: "Verify recorder startup and exported syscall/scheduler events"
               timeoutInMinutes: 5
@@ -428,7 +445,7 @@ stages:
                   $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
           # The optional recorder-only mode still excludes all builds/tests.
           # The normal query-stage arm does not start System Trace.
-          - ${{ if not(parameters.qwpWsPreflightOnly) }}:
+          - ${{ if and(not(parameters.qwpWsPreflightOnly), not(parameters.qwpWsDecodeOnly)) }}:
             - template: templates/compile.yaml
               parameters:
                 prerequisiteCondition: succeeded()
@@ -499,7 +516,7 @@ stages:
           # Mirrors ci/run_fuzz_pipeline.yaml: on failure, archive and
           # publish the QuestDB server log so PR reviewers don't have to
           # repro locally. Path comes from system_test/fixture.py:_log_path.
-          - ${{ if not(parameters.qwpWsPreflightOnly) }}:
+          - ${{ if and(not(parameters.qwpWsPreflightOnly), not(parameters.qwpWsDecodeOnly)) }}:
             - task: ArchiveFiles@2
               displayName: "Compress QuestDB server log on failure"
               condition: failed()

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -4,7 +4,7 @@ parameters:
   - name: qwpWsDecodeOnly
     displayName: "QWP diagnostics: decode existing trace only (no builds/tests)"
     type: boolean
-    default: true
+    default: false
   - name: qwpWsPreflightOnly
     displayName: "QWP diagnostics: verify recorder startup only (no builds/tests)"
     type: boolean
@@ -480,14 +480,14 @@ stages:
                 # Restore the original 72 missing-table ALTER lookups before
                 # producer connection. This is a scheduling perturbation, not
                 # a recreation of the unknown original startup delay.
-                # Follow the severe low-rate-control failure in 268479.
-                # Keep paired raw-mapping workload, capture two consecutive
-                # failed pings before diagnostic output can stall the observer.
-                # Every attempt permits kernel capture; heartbeat buffers in RAM.
-                # No new attempt after ten minutes; stop at first capture.
-                QWP_WS_DIAGNOSTIC_RUNS: "4"
-                QWP_WS_KERNEL_CAPTURE: ping
-                QWP_WS_DISK_LOAD: "1"
+                # Return to the original query failure without the external
+                # filesystem helper. More repetitions amortize this one build.
+                # Capture slow queries, observer loss or actual workload failure;
+                # short ping failures are telemetry only. Stop first capture.
+                # No new attempt after ten minutes, regardless of run count.
+                QWP_WS_DIAGNOSTIC_RUNS: "24"
+                QWP_WS_KERNEL_CAPTURE: query
+                QWP_WS_DISK_LOAD: "0"
                 QWP_WS_DISK_PATTERN: mapped
                 QWP_WS_STARTUP_LOOKUPS: "72"
                 QWP_WS_MAX_SECONDS: "600"

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -1,5 +1,11 @@
 trigger: none
 
+parameters:
+  - name: qwpWsPreflightOnly
+    displayName: "QWP diagnostics: verify recorder startup only (no builds/tests)"
+    type: boolean
+    default: true
+
 variables:
   OS_MAPPING: none
   Windows_NT-X86: windows
@@ -398,57 +404,63 @@ stages:
               pathToPublish: $(Build.ArtifactStagingDirectory)/qdb-log-vs-master-$(Agent.OS).zip
               artifactName: qdb-log-vs-master-$(Agent.OS)
       - job: TestQwpWsFuzz
-        displayName: "QWP/WS syscall and scheduler diagnostics (one macOS worker)"
+        displayName: "QWP/WS recorder diagnostics (one macOS worker)"
         condition: eq(variables['Build.SourceBranch'], variables['QWP_WS_DIAGNOSTIC_REF'])
         variables:
           diagnosticReplica: system-trace
         pool:
           vmImage: macOS-15-arm64
-        timeoutInMinutes: 90
+        ${{ if parameters.qwpWsPreflightOnly }}:
+          timeoutInMinutes: 10
+        ${{ else }}:
+          timeoutInMinutes: 90
         steps:
           - checkout: self
             fetchDepth: 1
             lfs: false
             submodules: false
           - bash: bash ci/prepare_qwp_ws_system_trace.sh
-            displayName: "Verify syscall and scheduler tracing before compilation"
-            timeoutInMinutes: 3
+            displayName: "Verify recorder startup and exported syscall/scheduler events"
+            timeoutInMinutes: 5
             env:
               QWP_WS_DIAGNOSTICS_DIR: >-
                 $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
-          - template: templates/compile.yaml
-            parameters:
-              prerequisiteCondition: succeeded()
-          - template: templates/resolve_jdk25.yaml
-          - template: templates/clone_questdb.yaml
-            parameters:
-              # Original build 266336 task log 122 prints this build hash.
-              revision: 12a33d651e51e2682e7a448c8db5168fc72dfad3
-          - bash: bash ci/prepare_qwp_ws_jdk.sh
-            displayName: "Pin original Temurin 25.0.3+9"
-          - template: templates/maven_settings.yaml
-          - task: Maven@3
-            displayName: "Compile QuestDB"
-            retryCountOnTaskFailure: 2
-            inputs:
-              mavenPOMFile: "questdb/pom.xml"
-              javaHomeOption: "Path"
-              jdkDirectory: "$(JAVA_HOME)"
-              options: "-s $(MAVEN_SETTINGS_FILE) -DskipTests -Pbuild-web-console$(CLIENT_PROFILE) $(MAVEN_RUN_OPTS)"
-          - bash: bash ci/run_macos_qwp_ws_diagnostics.sh
-            displayName: "Capture two onset events with interleaved tracing controls"
-            timeoutInMinutes: 30
-            env:
-              # Attempts 1, 6, 11 are controls; at most ten traced attempts.
-              QWP_WS_DIAGNOSTIC_RUNS: "13"
-              QWP_WS_MAX_SECONDS: "600"
-              QWP_WS_STOP_ON_CAPTURE: "0"
-              QWP_WS_SYSTEM_TRACE: "1"
-              QWP_WS_MIN_FREE_KB: "2097152"
-              QWP_WS_DIAGNOSTICS_DIR: >-
-                $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
-              QWP_WS_MEMORY_PRESSURE: natural
-              QWP_WS_FS_TRACE: "0"
+          # Compile-time exclusion: a successful smoke check must not silently
+          # turn this startup investigation into another expensive test run.
+          - ${{ if not(parameters.qwpWsPreflightOnly) }}:
+            - template: templates/compile.yaml
+              parameters:
+                prerequisiteCondition: succeeded()
+            - template: templates/resolve_jdk25.yaml
+            - template: templates/clone_questdb.yaml
+              parameters:
+                # Original build 266336 task log 122 prints this build hash.
+                revision: 12a33d651e51e2682e7a448c8db5168fc72dfad3
+            - bash: bash ci/prepare_qwp_ws_jdk.sh
+              displayName: "Pin original Temurin 25.0.3+9"
+            - template: templates/maven_settings.yaml
+            - task: Maven@3
+              displayName: "Compile QuestDB"
+              retryCountOnTaskFailure: 2
+              inputs:
+                mavenPOMFile: "questdb/pom.xml"
+                javaHomeOption: "Path"
+                jdkDirectory: "$(JAVA_HOME)"
+                options: "-s $(MAVEN_SETTINGS_FILE) -DskipTests -Pbuild-web-console$(CLIENT_PROFILE) $(MAVEN_RUN_OPTS)"
+            - bash: bash ci/run_macos_qwp_ws_diagnostics.sh
+              displayName: "Capture two onset events with interleaved tracing controls"
+              timeoutInMinutes: 30
+              env:
+                # Attempts 1, 6, 11 are controls; at most ten traced attempts.
+                QWP_WS_DIAGNOSTIC_RUNS: "13"
+                QWP_WS_MAX_SECONDS: "600"
+                QWP_WS_STOP_ON_CAPTURE: "0"
+                QWP_WS_SYSTEM_TRACE: "1"
+                QWP_WS_MIN_FREE_KB: "2097152"
+                QWP_WS_DIAGNOSTICS_DIR: >-
+                  $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
+                QWP_WS_MEMORY_PRESSURE: natural
+                QWP_WS_FS_TRACE: "0"
           - bash: |
               # xctrace may create private root-owned files despite umask.
               # Return only this job's diagnostic artifacts to the uploader.
@@ -470,25 +482,26 @@ stages:
           # Mirrors ci/run_fuzz_pipeline.yaml: on failure, archive and
           # publish the QuestDB server log so PR reviewers don't have to
           # repro locally. Path comes from system_test/fixture.py:_log_path.
-          - task: ArchiveFiles@2
-            displayName: "Compress QuestDB server log on failure"
-            condition: failed()
-            continueOnError: true
-            inputs:
-              rootFolderOrFile: $(Build.SourcesDirectory)/build/questdb/repo/data/log
-              includeRootFolder: false
-              archiveType: zip
-              archiveFile: >-
-                $(Build.ArtifactStagingDirectory)/qdb-log-$(Agent.OS)-$(diagnosticReplica).zip
-              quiet: true
-          - task: PublishBuildArtifacts@1
-            displayName: "Publish QuestDB server log on failure"
-            condition: failed()
-            continueOnError: true
-            inputs:
-              pathToPublish: >-
-                $(Build.ArtifactStagingDirectory)/qdb-log-$(Agent.OS)-$(diagnosticReplica).zip
-              artifactName: qdb-log-$(Agent.OS)-$(diagnosticReplica)
+          - ${{ if not(parameters.qwpWsPreflightOnly) }}:
+            - task: ArchiveFiles@2
+              displayName: "Compress QuestDB server log on failure"
+              condition: failed()
+              continueOnError: true
+              inputs:
+                rootFolderOrFile: $(Build.SourcesDirectory)/build/questdb/repo/data/log
+                includeRootFolder: false
+                archiveType: zip
+                archiveFile: >-
+                  $(Build.ArtifactStagingDirectory)/qdb-log-$(Agent.OS)-$(diagnosticReplica).zip
+                quiet: true
+            - task: PublishBuildArtifacts@1
+              displayName: "Publish QuestDB server log on failure"
+              condition: failed()
+              continueOnError: true
+              inputs:
+                pathToPublish: >-
+                  $(Build.ArtifactStagingDirectory)/qdb-log-$(Agent.OS)-$(diagnosticReplica).zip
+                artifactName: qdb-log-$(Agent.OS)-$(diagnosticReplica)
 
       # Linux leg on self-hosted hetzner-incus — mirrors the equivalent
       # job in ci/run_fuzz_pipeline.yaml. Pool image is built from

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -458,8 +458,9 @@ stages:
               displayName: "Repeat only add-columns until slow query or failure"
               timeoutInMinutes: 30
               env:
-                # One host, unchanged test; no new attempt after ten minutes.
-                QWP_WS_DIAGNOSTIC_RUNS: "40"
+                # Three natural/warn/warn/natural cycles, one host, same test.
+                # No new attempt after ten minutes; stop at first capture.
+                QWP_WS_DIAGNOSTIC_RUNS: "12"
                 QWP_WS_MAX_SECONDS: "600"
                 QWP_WS_STOP_ON_CAPTURE: "1"
                 QWP_WS_SYSTEM_TRACE: "0"
@@ -468,7 +469,7 @@ stages:
                 QWP_WS_MIN_FREE_KB: "2097152"
                 QWP_WS_DIAGNOSTICS_DIR: >-
                   $(Build.ArtifactStagingDirectory)/qwp-ws-macos-diagnostics
-                QWP_WS_MEMORY_PRESSURE: natural
+                QWP_WS_MEMORY_PRESSURE: paired
                 QWP_WS_FS_TRACE: "0"
           - bash: |
               # xctrace may create private root-owned files despite umask.

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -480,13 +480,13 @@ stages:
                 # Restore the original 72 missing-table ALTER lookups before
                 # producer connection. This is a scheduling perturbation, not
                 # a recreation of the unknown original startup delay.
-                # Paired mapped-file perturbation: low-rate/load/load/low-rate.
-                # Unlike the earlier pwrite/fsync helper, dirty a mapping,
-                # unmap and shrink; pace the finite byte budget across the test.
-                # Capture only slow query/observer/workload failure, not pings.
+                # Follow the severe low-rate-control failure in 268479.
+                # Keep paired raw-mapping workload, capture two consecutive
+                # failed pings before diagnostic output can stall the observer.
+                # Every attempt permits kernel capture; heartbeat buffers in RAM.
                 # No new attempt after ten minutes; stop at first capture.
                 QWP_WS_DIAGNOSTIC_RUNS: "4"
-                QWP_WS_KERNEL_CAPTURE: query
+                QWP_WS_KERNEL_CAPTURE: ping
                 QWP_WS_DISK_LOAD: "1"
                 QWP_WS_DISK_PATTERN: mapped
                 QWP_WS_STARTUP_LOOKUPS: "72"

--- a/ci/summarize_qwp_ws_run.py
+++ b/ci/summarize_qwp_ws_run.py
@@ -34,6 +34,9 @@ def summarize(directory):
         max_drain_seconds=max(drains, default=None),
         capture_reason=(directory / 'capture-started').read_text().strip()
         if (directory / 'capture-started').exists() else None,
+        system_trace=(directory / 'system-trace-enabled').exists(),
+        system_trace_valid=(directory / 'system-trace-valid.json').exists()
+        and not (directory / 'system-trace-error.json').exists(),
     )
 
 

--- a/ci/summarize_qwp_ws_run.py
+++ b/ci/summarize_qwp_ws_run.py
@@ -1,0 +1,54 @@
+"""One row per unchanged fuzz attempt, to expose degradation across a soak."""
+import argparse
+import json
+from pathlib import Path
+import re
+
+
+def summarize(directory):
+    # Treat malformed/truncated telemetry as an error rather than a healthy run.
+    missing = []
+
+    def read_events(name):
+        path = directory / name
+        if not path.exists():
+            missing.append(name)
+            return []
+        return [json.loads(line) for line in path.read_text().splitlines()]
+
+    probes = read_events('watchdog.jsonl')
+    heartbeats = read_events('heartbeat.jsonl')
+    pings = [event for event in probes if event['event'] == 'ping']
+    log = (directory / 'test.log').read_text()
+    drains = [float(value) for value in re.findall(
+        r'event=drain-complete[^\n]*elapsed=([0-9.]+)s', log)]
+    unittest_time = re.findall(r'^Ran 1 test in ([0-9.]+)s$', log, re.M)
+    return dict(
+        directory=directory.name,
+        missing_telemetry=missing,
+        unittest_seconds=float(unittest_time[-1]) if unittest_time else None,
+        ping_count=len(pings),
+        ping_errors=sum(event.get('error') is not None for event in pings),
+        max_ping_ms=max((event['elapsed_ms'] for event in pings), default=None),
+        max_heartbeat_gap_ms=max((event['gap_ms'] for event in heartbeats), default=None),
+        max_drain_seconds=max(drains, default=None),
+        capture_reason=(directory / 'capture-started').read_text().strip()
+        if (directory / 'capture-started').exists() else None,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('directory', type=Path)
+    for name in ['run', 'started', 'duration', 'soak-elapsed', 'free-kb', 'returncode']:
+        parser.add_argument('--' + name, type=int, required=True)
+    args = parser.parse_args()
+    row = summarize(args.directory)
+    row.update(run=args.run, started_epoch_seconds=args.started,
+               attempt_seconds=args.duration, soak_elapsed_seconds=args.soak_elapsed,
+               free_kb_before=args.free_kb, returncode=args.returncode)
+    print(json.dumps(row))
+
+
+if __name__ == '__main__':
+    main()

--- a/ci/templates/clone_questdb.yaml
+++ b/ci/templates/clone_questdb.yaml
@@ -16,10 +16,24 @@
 # release CLIENT_PROFILE is cleared, leaving the Maven options untouched.
 # Reading the version (rather than hard-coding the profile) keeps every
 # questdb-building job working whichever way questdb master flips next.
+parameters:
+  - name: revision
+    type: string
+    default: ''
+
 steps:
   - script: |
       git clone --depth 1 https://github.com/questdb/questdb.git
     displayName: git clone questdb
+  - ${{ if ne(parameters.revision, '') }}:
+    - bash: |
+        set -eu
+        git -C questdb fetch --depth 1 origin "$QUESTDB_REVISION"
+        git -C questdb checkout --detach FETCH_HEAD
+        test "$(git -C questdb rev-parse HEAD)" = "$QUESTDB_REVISION"
+      displayName: "Pin QuestDB diagnostic revision"
+      env:
+        QUESTDB_REVISION: ${{ parameters.revision }}
   - bash: |
       # No `pipefail`: the version extraction is `sed ... | head -1`, and
       # core/pom.xml carries the property on more than one line, so head can

--- a/ci/templates/compile.yaml
+++ b/ci/templates/compile.yaml
@@ -2,6 +2,11 @@ parameters:
   - name: cxx20Variants
     type: boolean
     default: false
+  # Explicit OS conditions otherwise bypass Azure's implicit succeeded().
+  # Diagnostic callers can require a preflight; preserve other jobs' behavior.
+  - name: prerequisiteCondition
+    type: string
+    default: 'true'
 
 steps:
   - bash: |
@@ -10,16 +15,16 @@ steps:
                   /opt/hostedtoolcache/CodeQL /usr/local/share/boost || true
       sudo docker image prune --all --force >/dev/null 2>&1 || true
       df -h /
-    condition: eq(variables['imageName'], 'ubuntu-latest')
+    condition: and(${{ parameters.prerequisiteCondition }}, eq(variables['imageName'], 'ubuntu-latest'))
     displayName: "Free disk space (Microsoft-hosted ubuntu)"
   - bash: |
       echo "##vso[task.setvariable variable=CARGO_INCREMENTAL]0"
-    condition: eq(variables['imageName'], 'ubuntu-latest')
+    condition: and(${{ parameters.prerequisiteCondition }}, eq(variables['imageName'], 'ubuntu-latest'))
     displayName: "Disable cargo incremental on Linux (saves ~30-50% target/ size)"
   - script: |
       rustup update $(toolchain)
       rustup default $(toolchain)
-    condition: ne(variables['toolchain'], '')
+    condition: and(${{ parameters.prerequisiteCondition }}, ne(variables['toolchain'], ''))
     displayName: "Update and set Rust toolchain"
   # Keyed on the agent OS, not the image label: the macOS legs run on
   # macOS-15-arm64, the Linux legs run on both hosted and self-hosted images,
@@ -28,12 +33,12 @@ steps:
       brew install numpy apache-arrow
       python3 -m pip install --break-system-packages pyarrow polars
       echo "##vso[task.setvariable variable=CMAKE_PREFIX_PATH]$(brew --prefix)"
-    condition: eq(variables['Agent.OS'], 'Darwin')
+    condition: and(${{ parameters.prerequisiteCondition }}, eq(variables['Agent.OS'], 'Darwin'))
     displayName: "Install numpy + pyarrow + polars + apache-arrow on macOS"
   - script: |
       python -m pip install --upgrade pip
       pip install numpy pyarrow polars tzdata
-    condition: ne(variables['Agent.OS'], 'Darwin')
+    condition: and(${{ parameters.prerequisiteCondition }}, ne(variables['Agent.OS'], 'Darwin'))
     env:
       PIP_BREAK_SYSTEM_PACKAGES: "1"
     displayName: "Install Python Dependencies"

--- a/system_test/fixture.py
+++ b/system_test/fixture.py
@@ -762,6 +762,12 @@ class QuestDbFixture(QuestDbFixtureBase):
             return pathlib.Path(directory).resolve()
         return None
 
+    def fuzz_diagnostic_gate_timeout(self):
+        directory = self._watchdog_dir()
+        if directory is not None and (directory / 'system-trace-enabled').exists():
+            return 90  # recorder initialization only, before workload starts
+        return 30
+
     def finish_fuzz_diagnostics(self):
         directory = self._watchdog_dir()
         if directory is None:

--- a/system_test/fixture.py
+++ b/system_test/fixture.py
@@ -593,6 +593,13 @@ class QuestDbFixture(QuestDbFixtureBase):
                 '-Xlog:gc*,safepoint=debug:file='
                 f'{watchdog_dir / "jvm-pauses.log"}'
                 ':utctime,uptimemillis,level,tags:filecount=2,filesize=16M']
+            query_probe = os.environ.get('QWP_WS_SHOW_COLUMNS_OVERLAY')
+            if query_probe:
+                overlay = pathlib.Path(query_probe).resolve(strict=True)
+                launch_args[1:1] = [
+                    '--patch-module', f'io.questdb={overlay}',
+                    f'-Dqwp.show.columns.dir={watchdog_dir}']
+                (watchdog_dir / 'show-columns-enabled').touch()
         sys.stderr.write(
             f'Starting QuestDB: {launch_args!r} '
             f'(auth: {self.auth}, http_auth: {self.http_auth}, '

--- a/system_test/fixture.py
+++ b/system_test/fixture.py
@@ -774,7 +774,7 @@ class QuestDbFixture(QuestDbFixtureBase):
         if directory is not None and (directory / 'system-trace-enabled').exists():
             return 90  # recorder initialization only, before workload starts
         if directory is not None and os.environ.get('QWP_WS_MEMORY_PRESSURE') == 'paired':
-            return 60  # recovery and pressure setup only; workload budgets unchanged
+            return 90  # recovery and pressure setup only; workload budgets unchanged
         return 30
 
     def finish_fuzz_diagnostics(self):

--- a/system_test/fixture.py
+++ b/system_test/fixture.py
@@ -773,6 +773,8 @@ class QuestDbFixture(QuestDbFixtureBase):
         directory = self._watchdog_dir()
         if directory is not None and (directory / 'system-trace-enabled').exists():
             return 90  # recorder initialization only, before workload starts
+        if directory is not None and os.environ.get('QWP_WS_MEMORY_PRESSURE') == 'paired':
+            return 60  # recovery and pressure setup only; workload budgets unchanged
         return 30
 
     def finish_fuzz_diagnostics(self):

--- a/system_test/fixture.py
+++ b/system_test/fixture.py
@@ -786,7 +786,10 @@ class QuestDbFixture(QuestDbFixtureBase):
         # between its capture-started marker and this teardown thread.
         # This is after workload assertions, outside sender timeout budgets.
         (directory / 'workload-finished').touch()
-        deadline = time.monotonic() + 15
+        # Kernel report processing is after onset, outside workload assertions
+        # and sender/SQL deadlines. Do not start DROP while it is still reading.
+        wait_seconds = 50 if (directory / 'kernel-stacks-enabled').exists() else 15
+        deadline = time.monotonic() + wait_seconds
         while not (directory / 'watchdog-stopped').exists():
             if time.monotonic() >= deadline:
                 (directory / 'capture-error').write_text(

--- a/system_test/fixture.py
+++ b/system_test/fixture.py
@@ -584,6 +584,15 @@ class QuestDbFixture(QuestDbFixtureBase):
             '-p', str(self._root_dir / 'bin' / 'questdb.jar'),
             '-m', 'io.questdb/io.questdb.ServerMain',
             '-d', str(self._data_dir)]
+        watchdog_dir = self._watchdog_dir()
+        if watchdog_dir is not None:
+            watchdog_dir.mkdir(parents=True, exist_ok=True)
+            launch_args[1:1] = [
+                '-XX:ActiveProcessorCount=3',
+                f'-Djava.io.tmpdir={os.environ["TMPDIR"]}',
+                '-Xlog:gc*,safepoint=debug:file='
+                f'{watchdog_dir / "jvm-pauses.log"}'
+                ':utctime,uptimemillis,level,tags:filecount=2,filesize=16M']
         sys.stderr.write(
             f'Starting QuestDB: {launch_args!r} '
             f'(auth: {self.auth}, http_auth: {self.http_auth}, '
@@ -614,6 +623,9 @@ class QuestDbFixture(QuestDbFixtureBase):
                 stdout=self._log,
                 stderr=subprocess.STDOUT,
                 creationflags=creationflags)
+            if watchdog_dir is not None:
+                (watchdog_dir / 'watchdog-endpoint.json').write_text(json.dumps(
+                    dict(pid=self._proc.pid, port=self.http_server_port)))
 
             def check_http_up():
                 if self._proc.poll() is not None:
@@ -710,6 +722,12 @@ class QuestDbFixture(QuestDbFixtureBase):
         return False
 
     def capture_timeout_diagnostics(self, test_name):
+        watchdog_dir = self._watchdog_dir()
+        if watchdog_dir is not None:
+            # Let the independent collector do the work. Do not pause a
+            # producer/ALTER thread for another HTTP request or dump sleep.
+            (watchdog_dir / 'capture-request').write_text(test_name + '\n')
+            return
         sys.stderr.write(
             f'Capturing QuestDB diagnostics after timeout in {test_name}.\n')
 
@@ -736,6 +754,30 @@ class QuestDbFixture(QuestDbFixtureBase):
 
         if dump_requested:
             time.sleep(2)
+
+    @staticmethod
+    def _watchdog_dir():
+        directory = os.environ.get('QWP_WS_FUZZ_WATCHDOG_DIR')
+        if directory and os.environ.get('QWP_WS_FUZZ_DIAGNOSTICS') == '1':
+            return pathlib.Path(directory).resolve()
+        return None
+
+    def finish_fuzz_diagnostics(self):
+        directory = self._watchdog_dir()
+        if directory is None:
+            return
+        # Handshake before DROP: stop new probes and let pending collection
+        # finish. Waiting for the watchdog's acknowledgment closes the race
+        # between its capture-started marker and this teardown thread.
+        # This is after workload assertions, outside sender timeout budgets.
+        (directory / 'workload-finished').touch()
+        deadline = time.monotonic() + 15
+        while not (directory / 'watchdog-stopped').exists():
+            if time.monotonic() >= deadline:
+                (directory / 'capture-error').write_text(
+                    'watchdog did not stop before teardown\n')
+                break
+            time.sleep(0.05)
 
     def stop(self, wait_timeout_sec=30):
         if self._tls_proxy:

--- a/system_test/fixture.py
+++ b/system_test/fixture.py
@@ -309,6 +309,9 @@ class QuestDbFixtureBase:
     def capture_timeout_diagnostics(self, test_name):
         pass
 
+    def process_pid(self):
+        return None
+
     def http_headers(self):
         if not getattr(self, 'http_auth', False):
             return {}
@@ -515,6 +518,11 @@ class QuestDbFixture(QuestDbFixtureBase):
         sys.stderr.write(textwrap.indent(log, '    '))
         sys.stderr.write('\n\n')
 
+    def process_pid(self):
+        if self._proc is None or self._proc.poll() is not None:
+            return None
+        return self._proc.pid
+
     def start(self):
         if self.http_server_port is None:
             ports = discover_avail_ports(3)
@@ -704,6 +712,17 @@ class QuestDbFixture(QuestDbFixtureBase):
     def capture_timeout_diagnostics(self, test_name):
         sys.stderr.write(
             f'Capturing QuestDB diagnostics after timeout in {test_name}.\n')
+
+        # Request the dump before making another network call. If the timeout
+        # is transient, even the one-second /ping probe below can otherwise
+        # miss the threads while they are still blocked.
+        dump_requested = self._request_thread_dump()
+        if dump_requested:
+            sys.stderr.write(
+                f'Requested a JVM thread dump in `{self._log_path}`.\n')
+        else:
+            sys.stderr.write('Could not request a JVM thread dump.\n')
+
         req = urllib.request.Request(
             f'http://127.0.0.1:{self.http_server_port}/ping',
             headers=self.http_headers(),
@@ -715,12 +734,8 @@ class QuestDbFixture(QuestDbFixtureBase):
         except Exception as e:
             sys.stderr.write(f'QuestDB /ping after timeout failed: {e!r}.\n')
 
-        if self._request_thread_dump():
-            sys.stderr.write(
-                f'Requested a JVM thread dump in `{self._log_path}`.\n')
+        if dump_requested:
             time.sleep(2)
-        else:
-            sys.stderr.write('Could not request a JVM thread dump.\n')
 
     def stop(self, wait_timeout_sec=30):
         if self._tls_proxy:

--- a/system_test/qwp_ws_disk_load.py
+++ b/system_test/qwp_ws_disk_load.py
@@ -142,9 +142,11 @@ def main():
     parser.add_argument('directory', type=Path)
     parser.add_argument('--run', type=int, required=True)
     parser.add_argument('--pattern', choices=('pwrite', 'mapped'), default='pwrite')
+    parser.add_argument('--mode', choices=('paired', 'probe'), default='paired')
     args = parser.parse_args()
     try:
-        run(args.directory, mode_for_run(args.run), pattern=args.pattern)
+        run(args.directory, 'probe' if args.mode == 'probe' else mode_for_run(args.run),
+            pattern=args.pattern)
     except Exception as exc:
         (args.directory / 'disk-load-error').write_text(repr(exc) + '\n')
         raise

--- a/system_test/qwp_ws_disk_load.py
+++ b/system_test/qwp_ws_disk_load.py
@@ -1,10 +1,12 @@
 """Bounded filesystem perturbation with per-call elapsed and process CPU clocks.
 
-Only touches a newly created 64 KiB file in this attempt's artifact directory.
+Only touches a newly created file in this attempt's artifact directory (1 MiB
+maximum with the mapped pattern; 64 KiB with the original pwrite pattern).
 This generates filesystem work; it does not emulate a known hosted-disk quota.
 """
 import argparse
 import json
+import mmap
 import os
 from pathlib import Path
 import time
@@ -16,7 +18,8 @@ def mode_for_run(run):
     return 'load' if run % 4 in (2, 3) else 'probe'
 
 
-def cycle(fd, payload, record, clock=time.monotonic_ns, cpu=time.process_time_ns):
+def cycle(fd, payload, record, clock=time.monotonic_ns, cpu=time.process_time_ns,
+          pattern='pwrite'):
     def measure(stage, action):
         started, cpu_start = clock(), cpu()
         wall_start = time.time_ns()
@@ -27,6 +30,21 @@ def cycle(fd, payload, record, clock=time.monotonic_ns, cpu=time.process_time_ns
                     cpu_ns=cpu_end - cpu_start, wall_start_ns=wall_start))
         return result
 
+    if pattern == 'mapped':
+        # Match the ordering of MemoryCMARWImpl.close: dirty mapped data,
+        # unmap, then shrink. No msync/fsync, which would drain the dirty pages
+        # before the operation we want to observe. Growth is sparse, not a
+        # claim to reproduce QuestDB's physical F_PREALLOCATE behavior.
+        measure('grow', lambda: os.ftruncate(fd, 1024 * 1024))
+        mapping = measure('mmap', lambda: mmap.mmap(fd, 1024 * 1024, access=mmap.ACCESS_WRITE))
+        try:
+            measure('mapped_write', lambda: mapping.__setitem__(slice(0, len(payload)), payload))
+        finally:
+            measure('munmap', mapping.close)
+        measure('shrink', lambda: os.ftruncate(fd, len(payload)))
+        return
+    if pattern != 'pwrite':
+        raise ValueError('unknown disk pattern')
     measure('truncate', lambda: os.ftruncate(fd, 0))
     written = measure('pwrite', lambda: os.pwrite(fd, payload, 0))
     if written != len(payload):
@@ -34,19 +52,21 @@ def cycle(fd, payload, record, clock=time.monotonic_ns, cpu=time.process_time_ns
     measure('fsync', lambda: os.fsync(fd))
 
 
-def run(directory, mode, max_cycles=4096, max_seconds=60):
+def run(directory, mode, max_cycles=4096, max_seconds=60, pattern='pwrite'):
     directory = Path(directory)
     if mode not in ('probe', 'load'):
         raise ValueError('unknown disk mode')
+    if pattern not in ('pwrite', 'mapped'):
+        raise ValueError('unknown disk pattern')
     payload = os.urandom(64 * 1024)
     # O_EXCL prevents overwriting any existing artifact or following a symlink.
-    fd = os.open(directory / 'disk-load.data', os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    fd = os.open(directory / 'disk-load.data', os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
     try:
         with (directory / 'disk-load.jsonl').open('x') as output:
             def record(value):
                 output.write(json.dumps(value) + '\n')
 
-            record(dict(event='ready', mode=mode, pid=os.getpid(),
+            record(dict(event='ready', mode=mode, pattern=pattern, pid=os.getpid(),
                         max_bytes=max_cycles * len(payload), max_seconds=max_seconds))
             output.flush()
             (directory / 'disk-load-ready').touch()
@@ -62,13 +82,17 @@ def run(directory, mode, max_cycles=4096, max_seconds=60):
             count = 0
             while (count < max_cycles and time.monotonic() - started < max_seconds
                    and not (directory / 'workload-finished').exists()):
-                cycle(fd, payload, record)
+                cycle(fd, payload, record, pattern=pattern)
                 count += 1
                 if time.monotonic() - last_flush >= 1:
                     output.flush()
                     last_flush = time.monotonic()
                 if mode == 'probe':
                     time.sleep(1)
+                elif pattern == 'mapped':
+                    # Pace the finite byte budget across the workload, instead
+                    # of spending all 4096 cycles in its first few seconds.
+                    time.sleep(.01)
             if count == 0:
                 raise RuntimeError('disk experiment had no overlap with workload')
             record(dict(event='finished', cycles=count, bytes_written=count * len(payload),
@@ -84,9 +108,10 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('directory', type=Path)
     parser.add_argument('--run', type=int, required=True)
+    parser.add_argument('--pattern', choices=('pwrite', 'mapped'), default='pwrite')
     args = parser.parse_args()
     try:
-        run(args.directory, mode_for_run(args.run))
+        run(args.directory, mode_for_run(args.run), pattern=args.pattern)
     except Exception as exc:
         (args.directory / 'disk-load-error').write_text(repr(exc) + '\n')
         raise

--- a/system_test/qwp_ws_disk_load.py
+++ b/system_test/qwp_ws_disk_load.py
@@ -1,0 +1,96 @@
+"""Bounded filesystem perturbation with per-call elapsed and process CPU clocks.
+
+Only touches a newly created 64 KiB file in this attempt's artifact directory.
+This generates filesystem work; it does not emulate a known hosted-disk quota.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import time
+
+
+def mode_for_run(run):
+    if run < 1:
+        raise ValueError('run must be positive')
+    return 'load' if run % 4 in (2, 3) else 'probe'
+
+
+def cycle(fd, payload, record, clock=time.monotonic_ns, cpu=time.process_time_ns):
+    def measure(stage, action):
+        started, cpu_start = clock(), cpu()
+        wall_start = time.time_ns()
+        result = action()
+        finished, cpu_end = clock(), cpu()
+        record(dict(event='syscall', stage=stage, start_ns=started,
+                    end_ns=finished, elapsed_ns=finished - started,
+                    cpu_ns=cpu_end - cpu_start, wall_start_ns=wall_start))
+        return result
+
+    measure('truncate', lambda: os.ftruncate(fd, 0))
+    written = measure('pwrite', lambda: os.pwrite(fd, payload, 0))
+    if written != len(payload):
+        raise RuntimeError(f'short diagnostic write: {written}/{len(payload)}')
+    measure('fsync', lambda: os.fsync(fd))
+
+
+def run(directory, mode, max_cycles=4096, max_seconds=60):
+    directory = Path(directory)
+    if mode not in ('probe', 'load'):
+        raise ValueError('unknown disk mode')
+    payload = os.urandom(64 * 1024)
+    # O_EXCL prevents overwriting any existing artifact or following a symlink.
+    fd = os.open(directory / 'disk-load.data', os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with (directory / 'disk-load.jsonl').open('x') as output:
+            def record(value):
+                output.write(json.dumps(value) + '\n')
+
+            record(dict(event='ready', mode=mode, pid=os.getpid(),
+                        max_bytes=max_cycles * len(payload), max_seconds=max_seconds))
+            output.flush()
+            (directory / 'disk-load-ready').touch()
+            waiting_since = time.monotonic()
+            # Do not spend the load budget on the 72 missing-table prefix.
+            while not (directory / 'show-columns.tsv').exists():
+                if (directory / 'workload-finished').exists():
+                    raise RuntimeError('workload ended before the first SHOW COLUMNS probe')
+                if time.monotonic() - waiting_since > 30:
+                    raise TimeoutError('no SHOW COLUMNS probe within disk setup deadline')
+                time.sleep(.05)
+            started = last_flush = time.monotonic()
+            count = 0
+            while (count < max_cycles and time.monotonic() - started < max_seconds
+                   and not (directory / 'workload-finished').exists()):
+                cycle(fd, payload, record)
+                count += 1
+                if time.monotonic() - last_flush >= 1:
+                    output.flush()
+                    last_flush = time.monotonic()
+                if mode == 'probe':
+                    time.sleep(1)
+            if count == 0:
+                raise RuntimeError('disk experiment had no overlap with workload')
+            record(dict(event='finished', cycles=count, bytes_written=count * len(payload),
+                        elapsed_seconds=time.monotonic() - started,
+                        reason='workload_finished' if (directory / 'workload-finished').exists()
+                        else 'bounded_budget', wall_ns=time.time_ns()))
+        (directory / 'disk-load-finished').touch()
+    finally:
+        os.close(fd)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('directory', type=Path)
+    parser.add_argument('--run', type=int, required=True)
+    args = parser.parse_args()
+    try:
+        run(args.directory, mode_for_run(args.run))
+    except Exception as exc:
+        (args.directory / 'disk-load-error').write_text(repr(exc) + '\n')
+        raise
+
+
+if __name__ == '__main__':
+    main()

--- a/system_test/qwp_ws_disk_load.py
+++ b/system_test/qwp_ws_disk_load.py
@@ -5,11 +5,42 @@ maximum with the mapped pattern; 64 KiB with the original pwrite pattern).
 This generates filesystem work; it does not emulate a known hosted-disk quota.
 """
 import argparse
+import ctypes
+import functools
 import json
 import mmap
 import os
 from pathlib import Path
 import time
+
+
+@functools.cache
+def mapping_api():
+    # CPython mmap.__new__ issues F_FULLFSYNC on macOS. Raw libc calls are
+    # essential here: we are measuring dirty mapping/unmap/shrink ordering,
+    # not an implicit full disk flush. Supported diagnostic hosts are LP64.
+    library = ctypes.CDLL(None, use_errno=True)
+    library.mmap.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int,
+                            ctypes.c_int, ctypes.c_int, ctypes.c_int64]
+    library.mmap.restype = ctypes.c_void_p
+    library.munmap.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+    library.munmap.restype = ctypes.c_int
+    return library
+
+
+def map_shared(fd, size):
+    address = mapping_api().mmap(None, size, mmap.PROT_READ | mmap.PROT_WRITE,
+                                 mmap.MAP_SHARED, fd, 0)
+    if address == ctypes.c_void_p(-1).value:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+    return address
+
+
+def unmap(address, size):
+    if mapping_api().munmap(address, size) != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
 
 
 def mode_for_run(run):
@@ -36,11 +67,11 @@ def cycle(fd, payload, record, clock=time.monotonic_ns, cpu=time.process_time_ns
         # before the operation we want to observe. Growth is sparse, not a
         # claim to reproduce QuestDB's physical F_PREALLOCATE behavior.
         measure('grow', lambda: os.ftruncate(fd, 1024 * 1024))
-        mapping = measure('mmap', lambda: mmap.mmap(fd, 1024 * 1024, access=mmap.ACCESS_WRITE))
+        mapping = measure('mmap', lambda: map_shared(fd, 1024 * 1024))
         try:
-            measure('mapped_write', lambda: mapping.__setitem__(slice(0, len(payload)), payload))
+            measure('mapped_write', lambda: ctypes.memmove(mapping, payload, len(payload)))
         finally:
-            measure('munmap', mapping.close)
+            measure('munmap', lambda: unmap(mapping, 1024 * 1024))
         measure('shrink', lambda: os.ftruncate(fd, len(payload)))
         return
     if pattern != 'pwrite':
@@ -58,6 +89,8 @@ def run(directory, mode, max_cycles=4096, max_seconds=60, pattern='pwrite'):
         raise ValueError('unknown disk mode')
     if pattern not in ('pwrite', 'mapped'):
         raise ValueError('unknown disk pattern')
+    if pattern == 'mapped':
+        mapping_api()  # Resolve functions before workload timing starts.
     payload = os.urandom(64 * 1024)
     # O_EXCL prevents overwriting any existing artifact or following a symlink.
     fd = os.open(directory / 'disk-load.data', os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)

--- a/system_test/qwp_ws_fuzz.py
+++ b/system_test/qwp_ws_fuzz.py
@@ -1336,7 +1336,8 @@ class AlterThread(threading.Thread):
             stop_event: threading.Event,
             record_failure,
             failure_counter: list,
-            log):
+            log,
+            on_transient_network_error=None):
         super().__init__(name='qwp-ws-fuzz-alter', daemon=True)
         self._sql_query = sql_query
         self._list_columns = list_columns
@@ -1348,7 +1349,13 @@ class AlterThread(threading.Thread):
         self._record_failure = record_failure
         self._failure_counter = failure_counter
         self._log = log
+        self._on_transient_network_error = on_transient_network_error
         self.applied_conversions = 0
+
+    def _notify_transient_network_error(self, operation: str, exc):
+        if self._on_transient_network_error is not None:
+            self._on_transient_network_error(
+                f'{operation}: {type(exc).__name__}: {exc}')
 
     def run(self):
         remaining = self._convert_budget
@@ -1370,6 +1377,8 @@ class AlterThread(threading.Thread):
         except Exception as e:  # noqa: BLE001 — fixture surfaces a few error shapes
             if is_transient_network_error(e):
                 # Server is mid-bounce; the next iteration will retry.
+                self._notify_transient_network_error(
+                    f'list_columns({table_name!r})', e)
                 return False
             self._log(
                 f'fuzz alter: list_columns({table_name!r}) failed: {e}')
@@ -1404,6 +1413,7 @@ class AlterThread(threading.Thread):
                     self._log(
                         f'fuzz alter: transient network error '
                         f'({type(e).__name__}: {e}); retrying')
+                    self._notify_transient_network_error(stmt, e)
                     return False
                 message = str(e)
                 if any(p in message.lower() for p in _ALTER_TOLERATED_PATTERNS):

--- a/system_test/qwp_ws_pressure.py
+++ b/system_test/qwp_ws_pressure.py
@@ -40,6 +40,7 @@ def main():
     gate = commands.add_parser('gate')
     gate.add_argument('mode', choices=('natural', 'warn'))
     gate.add_argument('--pid', type=int)
+    gate.add_argument('--timeout', type=int, choices=range(1, 61), default=20)
     args = parser.parse_args()
     if args.command == 'mode':
         print(mode_for_run(args.plan, args.run))
@@ -56,7 +57,7 @@ def main():
         print(json.dumps(dict(wall_ns=time.time_ns(), monotonic_ns=time.monotonic_ns(),
                               mode=args.mode, level=level)), flush=True)
 
-    wait_for_level(args.mode, read_level, record)
+    wait_for_level(args.mode, read_level, record, timeout=args.timeout)
 
 
 if __name__ == '__main__':

--- a/system_test/qwp_ws_pressure.py
+++ b/system_test/qwp_ws_pressure.py
@@ -1,0 +1,63 @@
+"""Bounded pressure setup for the focused macOS experiment, before workload."""
+import argparse
+import json
+import os
+import subprocess
+import time
+
+
+def mode_for_run(plan, run):
+    if run < 1:
+        raise ValueError('run must be positive')
+    if plan == 'paired':
+        return 'warn' if run % 4 in (2, 3) else 'natural'
+    if plan not in ('natural', 'warn'):
+        raise ValueError(f'unknown pressure plan: {plan}')
+    return plan
+
+
+def wait_for_level(mode, read_level, record, timeout=20,
+                   clock=time.monotonic, sleep=time.sleep):
+    target = {'natural': 1, 'warn': 2}[mode]
+    started = clock()
+    while clock() - started < timeout:
+        level = read_level()
+        record(level)
+        if level == target:
+            return
+        if level not in (1, 2):
+            raise RuntimeError(f'unsafe or unknown pressure level: {level}')
+        sleep(0.25)
+    raise RuntimeError(f'pressure target {mode} was not reached in {timeout}s')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest='command', required=True)
+    plan = commands.add_parser('mode')
+    plan.add_argument('plan', choices=('natural', 'warn', 'paired'))
+    plan.add_argument('run', type=int)
+    gate = commands.add_parser('gate')
+    gate.add_argument('mode', choices=('natural', 'warn'))
+    gate.add_argument('--pid', type=int)
+    args = parser.parse_args()
+    if args.command == 'mode':
+        print(mode_for_run(args.plan, args.run))
+        return
+
+    def read_level():
+        if args.pid is not None:
+            os.kill(args.pid, 0)
+        return int(subprocess.check_output(
+            ['sysctl', '-n', 'kern.memorystatus_vm_pressure_level'],
+            text=True, timeout=2).strip())
+
+    def record(level):
+        print(json.dumps(dict(wall_ns=time.time_ns(), monotonic_ns=time.monotonic_ns(),
+                              mode=args.mode, level=level)), flush=True)
+
+    wait_for_level(args.mode, read_level, record)
+
+
+if __name__ == '__main__':
+    main()

--- a/system_test/qwp_ws_startup_gate.py
+++ b/system_test/qwp_ws_startup_gate.py
@@ -1,0 +1,49 @@
+"""Diagnostic-only replay of the missing-table prefix before ingestion starts.
+
+This restores an ALTER RNG position, not the unknown original startup delay.
+The real ALTER loop still executes every query and consumes every RNG draw.
+"""
+import threading
+import time
+
+
+class StartupGate:
+    def __init__(self, missing_lookups, log, timeout=30):
+        if not 1 <= missing_lookups <= 200:
+            raise ValueError('startup prefix must contain 1..200 lookups')
+        self.target = missing_lookups
+        self.count = 0
+        self.log = log
+        self.timeout = timeout
+        self.ready = threading.Event()
+        self.error = None
+        self.started = time.monotonic()
+
+    def wait(self):
+        if not self.ready.wait(self.timeout):
+            raise TimeoutError('diagnostic startup prefix did not complete')
+        if self.error is not None:
+            raise RuntimeError(self.error)
+
+    def lookup(self, list_columns, table_name):
+        if self.ready.is_set():
+            return list_columns(table_name)
+        try:
+            list_columns(table_name)
+        except Exception as exc:
+            if 'table does not exist' not in str(exc).lower():
+                self.error = f'unexpected startup lookup failure: {exc}'
+                self.ready.set()
+                raise
+            self.count += 1
+            self.log(f'diagnostic startup lookup={self.count}/{self.target} '
+                     f'table={table_name}')
+            if self.count == self.target:
+                self.log('diagnostic startup producers released '
+                         f'after={self.count} missing lookups '
+                         f'elapsed={time.monotonic() - self.started:.6f}s')
+                self.ready.set()
+            raise
+        self.error = 'startup prefix unexpectedly found an existing table'
+        self.ready.set()
+        raise RuntimeError(self.error)

--- a/system_test/qwp_ws_system_trace.py
+++ b/system_test/qwp_ws_system_trace.py
@@ -1,0 +1,270 @@
+"""Bounded macOS System Trace collector and cheap pre-build capability check.
+
+Runs as root on the disposable CI worker so the collector owns its xctrace
+child and can stop it without a second sudo invocation. Never changes SIP or
+developer-security settings. All writable runtime paths are explicit.
+"""
+
+import argparse
+import ctypes
+from functools import lru_cache
+import json
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import uuid
+
+from qwp_ws_trace_export import export_and_validate
+
+# The unchanged fixture gate has a 30-second budget; leave time for watchdog
+# startup and the host snapshot after the recorder is ready.
+START_TIMEOUT = 15
+FINISH_TIMEOUT = 30
+RECORD_SECONDS = 30
+MIN_FREE_BYTES = 2 * 1024 ** 3
+
+
+@lru_cache(maxsize=1)
+def mach_clock():
+    class Timebase(ctypes.Structure):
+        _fields_ = [('numer', ctypes.c_uint32), ('denom', ctypes.c_uint32)]
+
+    lib = ctypes.CDLL('/usr/lib/libSystem.B.dylib')
+    lib.mach_absolute_time.restype = ctypes.c_uint64
+    lib.mach_absolute_time.argtypes = []
+    lib.mach_timebase_info.argtypes = [ctypes.POINTER(Timebase)]
+    info = Timebase()
+    if lib.mach_timebase_info(ctypes.byref(info)) or not info.denom:
+        raise RuntimeError('Cannot read Mach clock timebase')
+    return lib.mach_absolute_time, info.numer, info.denom
+
+
+def clocks():
+    before = time.monotonic_ns()
+    wall = time.time_ns()
+    fields = dict(wall_ns=wall, monotonic_ns=before)
+    if sys.platform == 'darwin':
+        read, numer, denom = mach_clock()
+        fields.update(mach_absolute_ticks=read(), mach_numer=numer, mach_denom=denom)
+    fields['clock_read_span_ns'] = time.monotonic_ns() - before
+    return fields
+
+
+def marker(directory, name, **fields):
+    # Readers must not see a partially written JSON document.
+    path = directory / name
+    temporary = path.with_suffix(path.suffix + '.partial')
+    temporary.write_text(json.dumps(dict(**clocks(), **fields)) + '\n')
+    temporary.replace(path)
+
+
+def request_stop(directory, reason):
+    """Watchdog-owned request. Collector records when it actually sends SIGINT."""
+    path = directory / 'system-trace-stop-request.json'
+    if not path.exists():
+        marker(directory, path.name, reason=reason)
+
+
+class StartedNotification:
+    """Use xctrace's explicit ready notification, not output text or a sleep."""
+
+    def __init__(self):
+        self.name = 'io.questdb.ci.system-trace.' + uuid.uuid4().hex
+        self.lib = ctypes.CDLL('/usr/lib/system/libsystem_notify.dylib')
+        self.lib.notify_register_check.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+        self.lib.notify_register_check.restype = ctypes.c_uint32
+        self.lib.notify_check.argtypes = [ctypes.c_int, ctypes.POINTER(ctypes.c_int)]
+        self.lib.notify_check.restype = ctypes.c_uint32
+        self.lib.notify_cancel.argtypes = [ctypes.c_int]
+        self.lib.notify_cancel.restype = ctypes.c_uint32
+        self.token = ctypes.c_int()
+        if self.lib.notify_register_check(self.name.encode(), ctypes.byref(self.token)):
+            raise RuntimeError('Cannot register xctrace readiness notification')
+        # notify_check is initially true even before a post. Clear it BEFORE
+        # launching the recorder, then require a subsequent real notification.
+        try:
+            self.check()
+        except Exception:
+            self.close()
+            raise
+
+    def check(self):
+        changed = ctypes.c_int()
+        if self.lib.notify_check(self.token, ctypes.byref(changed)):
+            raise RuntimeError('Cannot check xctrace readiness notification')
+        return bool(changed.value)
+
+    def close(self):
+        self.lib.notify_cancel(self.token)
+
+
+def stop_child(child):
+    if child.poll() is None:
+        child.send_signal(signal.SIGINT)
+        try:
+            child.wait(timeout=FINISH_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            child.kill()
+            child.wait(timeout=5)
+            raise RuntimeError('xctrace did not finalize after SIGINT')
+
+
+def collect(directory, pid, on_ready=None):
+    child = None
+    notification = None
+    interrupted = False
+
+    def interrupt(*_):
+        nonlocal interrupted
+        interrupted = True
+
+    previous = {sig: signal.signal(sig, interrupt) for sig in (signal.SIGINT, signal.SIGTERM)}
+    try:
+        if (directory / 'system.trace').exists():
+            raise RuntimeError('Refusing to overwrite an existing trace')
+        notification = StartedNotification()
+        with (directory / 'system-trace-record.log').open('w') as log:
+            marker(directory, 'system-trace-launch.json', pid=pid)
+            child = subprocess.Popen([
+                '/usr/bin/xcrun', 'xctrace', 'record', '--template', 'System Trace',
+                '--attach', str(pid), '--time-limit', f'{RECORD_SECONDS}s',
+                '--no-prompt', '--notify-tracing-started', notification.name,
+                '--output', str(directory / 'system.trace')],
+                stdout=log, stderr=subprocess.STDOUT)
+            deadline = time.monotonic() + START_TIMEOUT
+            while not notification.check():
+                if interrupted or child.poll() is not None or time.monotonic() >= deadline:
+                    raise RuntimeError('System Trace did not signal readiness; inspect record log')
+                time.sleep(0.02)
+            marker(directory, 'system-trace-ready.json', pid=pid)
+            if on_ready is not None:
+                on_ready()
+            deadline = time.monotonic() + RECORD_SECONDS
+            next_health_check = 0
+            request = directory / 'system-trace-stop-request.json'
+            while not request.exists():
+                if interrupted:
+                    raise RuntimeError('System Trace collector interrupted')
+                if child.poll() is not None or time.monotonic() >= deadline:
+                    raise RuntimeError('Recording expired before workload completion/timeout')
+                if time.monotonic() >= next_health_check:
+                    if shutil.disk_usage(directory).free < MIN_FREE_BYTES:
+                        raise RuntimeError('System Trace disk-space safety stop')
+                    os.kill(pid, 0)
+                    next_health_check = time.monotonic() + 1
+                time.sleep(0.02)
+            reason = json.loads(request.read_text())
+            if child.poll() is not None:
+                raise RuntimeError('Recorder exited before stop request')
+            child.send_signal(signal.SIGINT)
+            marker(directory, 'system-trace-stop-sent.json', reason=reason['reason'],
+                   request_wall_ns=reason['wall_ns'])
+            # A delayed controller might have lost the failed probe from the
+            # template's rolling window. Do not count that as a useful capture.
+            stop_lag = time.monotonic_ns() - reason['monotonic_ns']
+            child.wait(timeout=FINISH_TIMEOUT)
+            marker(directory, 'system-trace-recorded.json', returncode=child.returncode,
+                   stop_lag_ms=stop_lag / 1e6)
+            if child.returncode != 0:
+                raise RuntimeError(f'xctrace exited {child.returncode}')
+            if stop_lag > 2_000_000_000:
+                raise RuntimeError('Trace stop was over two seconds late; onset may be lost')
+        export_and_validate(directory, pid)
+    except Exception as exc:
+        marker(directory, 'system-trace-error.json', error=repr(exc))
+        raise
+    finally:
+        try:
+            if child is not None:
+                stop_child(child)
+        finally:
+            if notification is not None:
+                notification.close()
+            for sig, handler in previous.items():
+                signal.signal(sig, handler)
+            marker(directory, 'system-trace-finished.json')
+
+
+def smoke_target(directory):
+    # Exercise real open/truncate/write/close and sleeping thread states on the
+    # worker filesystem for five seconds, without compiling or starting Java.
+    deadline = time.monotonic() + START_TIMEOUT + 10
+    while not (directory / 'smoke-go').exists():
+        if time.monotonic() >= deadline:
+            raise RuntimeError('Smoke workload was never released')
+        time.sleep(0.02)
+    marker(directory, 'smoke-start.json', pid=os.getpid())
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        with (directory / 'smoke-data').open('wb') as data:
+            data.truncate(65536)
+            data.write(b'qwp trace capability check\n')
+        time.sleep(0.01)
+    marker(directory, 'smoke-end.json')
+    request_stop(directory, 'preflight-complete')
+    # Keep the attach target alive through recording finalization/export.
+    deadline = time.monotonic() + 150
+    while not (directory / 'system-trace-finished.json').exists():
+        if time.monotonic() >= deadline:
+            raise RuntimeError('Smoke recorder did not finish')
+        time.sleep(0.05)
+
+
+def preflight(directory):
+    with (directory / 'capability.log').open('w') as log:
+        for command in (['/usr/bin/xcodebuild', '-version'],
+                        ['/usr/bin/xcrun', 'xctrace', 'list', 'templates'],
+                        ['/usr/bin/xcrun', 'xctrace', 'help', 'record']):
+            subprocess.run(command, stdout=log, stderr=subprocess.STDOUT,
+                           timeout=15, check=True)
+    with (directory / 'smoke-target.log').open('w') as log:
+        target = subprocess.Popen([sys.executable, __file__, 'smoke-target',
+                                   '--run-dir', str(directory)], stdout=log,
+                                  stderr=subprocess.STDOUT)
+        try:
+            collect(directory, target.pid, on_ready=lambda: (directory / 'smoke-go').touch())
+            target.wait(timeout=5)
+            if target.returncode != 0:
+                raise RuntimeError('Smoke workload failed')
+        finally:
+            if target.poll() is None:
+                target.terminate()
+                target.wait(timeout=5)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('mode', choices=['preflight', 'collect', 'smoke-target'])
+    parser.add_argument('--run-dir', type=Path, required=True)
+    parser.add_argument('--pid', type=int)
+    args = parser.parse_args()
+    directory = args.run_dir.resolve()
+    if sys.platform != 'darwin' or any(
+            directory == path or path in directory.parents for path in (Path('/tmp'), Path('/private/tmp'))):
+        parser.error('Requires macOS and a worker-filesystem artifact directory, not /tmp')
+    os.umask(0o022)  # root-generated artifacts must remain readable by uploader
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / 'tmp').mkdir(exist_ok=True)
+    os.environ['TMPDIR'] = str(directory / 'tmp')
+    try:
+        if args.mode == 'smoke-target':
+            smoke_target(directory)
+        elif args.mode == 'preflight':
+            preflight(directory)
+        else:
+            if args.pid is None or args.pid <= 1:
+                parser.error('collect requires a managed target PID > 1')
+            collect(directory, args.pid)
+    except Exception as exc:
+        marker(directory, 'system-trace-error.json', error=repr(exc))
+        print(f'System Trace unavailable or incomplete: {exc}', file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/system_test/qwp_ws_system_trace.py
+++ b/system_test/qwp_ws_system_trace.py
@@ -23,6 +23,7 @@ from qwp_ws_trace_export import export_and_validate
 # The unchanged fixture gate has a 30-second budget; leave time for watchdog
 # startup and the host snapshot after the recorder is ready.
 START_TIMEOUT = 15
+PREFLIGHT_START_TIMEOUT = 60
 FINISH_TIMEOUT = 30
 RECORD_SECONDS = 30
 MIN_FREE_BYTES = 2 * 1024 ** 3
@@ -113,7 +114,80 @@ def stop_child(child):
             raise RuntimeError('xctrace did not finalize after SIGINT')
 
 
-def collect(directory, pid, on_ready=None):
+def capture_startup_state(directory, child, target_pid):
+    """Best-effort evidence before stopping a recorder that never became ready."""
+    results = []
+
+    def run(name, command, timeout):
+        result = dict(command=command)
+        try:
+            with (directory / name).open('w') as log:
+                completed = subprocess.run(command, stdout=log, stderr=subprocess.STDOUT,
+                                           timeout=timeout, check=False)
+                result['returncode'] = completed.returncode
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            result['error'] = repr(exc)
+        results.append(result)
+
+    run('system-trace-startup-processes.log', [
+        '/bin/ps', '-p', f'{child.pid},{target_pid},{os.getpid()}',
+        '-o', 'pid,ppid,pgid,state,%cpu,rss,etime,command'], 5)
+    # Sample only a still-owned, live recorder, never another process by name.
+    # This is after startup failure, not during the test or a successful start.
+    sampling_returncode = child.poll()
+    if sampling_returncode is None:
+        run('system-trace-startup-sample-command.log', [
+            '/usr/bin/sample', str(child.pid), '1', '10', '-file',
+            str(directory / 'system-trace-startup-sample.txt')], 10)
+    marker(directory, 'system-trace-startup-diagnostics.json', commands=results,
+           recorder_returncode_at_sampling=sampling_returncode,
+           sample_present=(directory / 'system-trace-startup-sample.txt').is_file())
+
+
+def wait_for_ready(directory, child, target_pid, notification, timeout, interrupted):
+    started = time.monotonic()
+    next_progress = 0
+    with (directory / 'system-trace-startup.jsonl').open('w') as progress:
+        while True:
+            elapsed = time.monotonic() - started
+            returncode = child.poll()
+            if interrupted():
+                reason = 'interrupted'
+            elif returncode is not None:
+                reason = 'recorder_exited'
+            elif notification.check():
+                marker(directory, 'system-trace-ready.json', pid=target_pid,
+                       recorder_pid=child.pid, startup_seconds=elapsed)
+                return
+            elif elapsed >= timeout:
+                reason = 'readiness_timeout'
+            else:
+                reason = None
+            if elapsed >= next_progress or reason is not None:
+                progress.write(json.dumps(dict(
+                    **clocks(), recorder_pid=child.pid, elapsed_seconds=elapsed,
+                    returncode=returncode, reason=reason)) + '\n')
+                progress.flush()
+                next_progress = elapsed + 5
+            if reason is not None:
+                # Preserve spontaneous exit vs. still running BEFORE our SIGINT.
+                marker(directory, 'system-trace-startup-failure.json', reason=reason,
+                       recorder_pid=child.pid, target_pid=target_pid,
+                       returncode_before_cleanup=returncode, elapsed_seconds=elapsed,
+                       timeout_seconds=timeout)
+                if reason != 'interrupted':
+                    try:
+                        capture_startup_state(directory, child, target_pid)
+                    except Exception as exc:
+                        marker(directory, 'system-trace-startup-diagnostics-error.json',
+                               error=repr(exc))
+                raise RuntimeError(f'System Trace startup {reason}: recorder PID {child.pid}, '
+                                   f'exit={returncode}, elapsed={elapsed:.3f}s, budget={timeout}s; '
+                                   'inspect system-trace-startup-* artifacts')
+            time.sleep(0.02)
+
+
+def collect(directory, pid, on_ready=None, start_timeout=START_TIMEOUT):
     child = None
     notification = None
     interrupted = False
@@ -128,19 +202,16 @@ def collect(directory, pid, on_ready=None):
             raise RuntimeError('Refusing to overwrite an existing trace')
         notification = StartedNotification()
         with (directory / 'system-trace-record.log').open('w') as log:
-            marker(directory, 'system-trace-launch.json', pid=pid)
-            child = subprocess.Popen([
+            command = [
                 '/usr/bin/xcrun', 'xctrace', 'record', '--template', 'System Trace',
                 '--attach', str(pid), '--time-limit', f'{RECORD_SECONDS}s',
                 '--no-prompt', '--notify-tracing-started', notification.name,
-                '--output', str(directory / 'system.trace')],
-                stdout=log, stderr=subprocess.STDOUT)
-            deadline = time.monotonic() + START_TIMEOUT
-            while not notification.check():
-                if interrupted or child.poll() is not None or time.monotonic() >= deadline:
-                    raise RuntimeError('System Trace did not signal readiness; inspect record log')
-                time.sleep(0.02)
-            marker(directory, 'system-trace-ready.json', pid=pid)
+                '--output', str(directory / 'system.trace')]
+            marker(directory, 'system-trace-launch.json', pid=pid, command=command,
+                   startup_timeout_seconds=start_timeout)
+            child = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT)
+            marker(directory, 'system-trace-recorder.json', pid=child.pid, target_pid=pid)
+            wait_for_ready(directory, child, pid, notification, start_timeout, lambda: interrupted)
             if on_ready is not None:
                 on_ready()
             deadline = time.monotonic() + RECORD_SECONDS
@@ -180,7 +251,16 @@ def collect(directory, pid, on_ready=None):
     finally:
         try:
             if child is not None:
-                stop_child(child)
+                try:
+                    marker(directory, 'system-trace-cleanup.json', recorder_pid=child.pid,
+                           returncode_before_cleanup=child.poll())
+                finally:
+                    # Diagnostic writes must never prevent reaping our child.
+                    try:
+                        stop_child(child)
+                    finally:
+                        marker(directory, 'system-trace-recorder-exit.json', recorder_pid=child.pid,
+                               returncode=child.poll())
         finally:
             if notification is not None:
                 notification.close()
@@ -192,8 +272,12 @@ def collect(directory, pid, on_ready=None):
 def smoke_target(directory):
     # Exercise real open/truncate/write/close and sleeping thread states on the
     # worker filesystem for five seconds, without compiling or starting Java.
-    deadline = time.monotonic() + START_TIMEOUT + 10
+    # Allow the longer cold-start preflight plus failure sampling/finalization.
+    # This process must not disappear while the recorder is still attaching.
+    deadline = time.monotonic() + PREFLIGHT_START_TIMEOUT + FINISH_TIMEOUT + 30
     while not (directory / 'smoke-go').exists():
+        if (directory / 'system-trace-finished.json').exists():
+            return  # Parent owns the startup error; do not overwrite it.
         if time.monotonic() >= deadline:
             raise RuntimeError('Smoke workload was never released')
         time.sleep(0.02)
@@ -226,7 +310,8 @@ def preflight(directory):
                                    '--run-dir', str(directory)], stdout=log,
                                   stderr=subprocess.STDOUT)
         try:
-            collect(directory, target.pid, on_ready=lambda: (directory / 'smoke-go').touch())
+            collect(directory, target.pid, on_ready=lambda: (directory / 'smoke-go').touch(),
+                    start_timeout=PREFLIGHT_START_TIMEOUT)
             target.wait(timeout=5)
             if target.returncode != 0:
                 raise RuntimeError('Smoke workload failed')

--- a/system_test/qwp_ws_system_trace.py
+++ b/system_test/qwp_ws_system_trace.py
@@ -20,9 +20,9 @@ import uuid
 
 from qwp_ws_trace_export import export_and_validate
 
-# The unchanged fixture gate has a 30-second budget; leave time for watchdog
-# startup and the host snapshot after the recorder is ready.
-START_TIMEOUT = 15
+# Build 268361 needed 18.7 seconds just to start recording. Traced attempts
+# have a separate 90-second setup gate; no workload timeout is extended.
+START_TIMEOUT = 60
 PREFLIGHT_START_TIMEOUT = 60
 FINISH_TIMEOUT = 30
 RECORD_SECONDS = 30

--- a/system_test/qwp_ws_trace_export.py
+++ b/system_test/qwp_ws_trace_export.py
@@ -1,0 +1,96 @@
+"""Validate discovered xctrace tables; never mistake a .trace directory for data."""
+
+import json
+from pathlib import Path
+import re
+import subprocess
+import time
+import xml.etree.ElementTree as ET
+
+
+def table_kind(schema):
+    name = re.sub('[^a-z]', '', schema.lower())
+    if 'syscall' in name or 'systemcall' in name:
+        return 'syscall'
+    if 'threadstate' in name and 'sample' not in name:
+        return 'thread-state'
+    return None
+
+
+def discover_tables(toc):
+    # Export by position, not a guessed schema name or an interpolated XPath.
+    runs = ET.parse(toc).findall('./run')
+    if len(runs) != 1:
+        raise RuntimeError('Expected exactly one recording run in System Trace')
+    tables = runs[0].findall('./data/table')
+    return [(i, table.attrib.get('schema', ''), table_kind(table.attrib.get('schema', '')))
+            for i, table in enumerate(tables, 1)
+            if table_kind(table.attrib.get('schema', ''))]
+
+
+def inspect_rows(path, target_pid, deadline=None):
+    """Resolve xctrace's interned id/ref values, including process inside thread."""
+    # Large syscall tables must not become a multi-GB Python tree on a 7-GiB
+    # worker. Keep only PID associations for interned values and discard rows.
+    refs = {}
+    pending = {}
+    stack = []
+    rows = matching = 0
+    for event, node in ET.iterparse(path, events=('start', 'end')):
+        if event == 'start':
+            stack.append(node)
+            continue
+        found = set(refs.get(node.attrib.get('ref'), ()))
+        if node.tag == 'pid' and (node.text or '').isdigit():
+            found.add(int(node.text))
+        for child in node:
+            found.update(pending.pop(id(child), ()))
+        if found and 'id' in node.attrib:
+            refs[node.attrib['id']] = found
+        pending[id(node)] = found
+        if node.tag == 'row':
+            rows += 1
+            if deadline is not None and rows % 1000 == 0 and time.monotonic() >= deadline:
+                raise RuntimeError('System Trace export/validation exceeded its time budget')
+            matching += target_pid in found
+            pending.pop(id(node))
+            if len(stack) > 1:
+                stack[-2].remove(node)
+            node.clear()
+        stack.pop()
+    # A sampled thread-state field in a CPU profile is deliberately insufficient:
+    # the caller only exports the actual syscall/thread-state tables from TOC.
+    return dict(rows=rows, target_rows=matching)
+
+
+def export_and_validate(directory, target_pid):
+    directory = Path(directory)
+    trace = directory / 'system.trace'
+    toc = directory / 'system-trace-toc.xml'
+    deadline = time.monotonic() + 60
+    with (directory / 'system-trace-export.log').open('w') as log:
+        def export(path, *selection):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RuntimeError('System Trace export/validation exceeded its time budget')
+            subprocess.run(['/usr/bin/xcrun', 'xctrace', 'export', '--input', str(trace),
+                            *selection, '--output', str(path)],
+                           stdout=log, stderr=subprocess.STDOUT,
+                           timeout=min(30, remaining), check=True)
+
+        export(toc, '--toc')
+        tables = discover_tables(toc)
+        if not {'syscall', 'thread-state'} <= {kind for _, _, kind in tables}:
+            raise RuntimeError('System Trace lacks syscall/thread-state tables; inspect TOC')
+        results = []
+        for index, schema, kind in tables:
+            path = directory / f'system-trace-table-{index}.xml'
+            export(path, '--xpath', f'/trace-toc/run[1]/data/table[{index}]')
+            results.append(dict(schema=schema, kind=kind, file=path.name,
+                                **inspect_rows(path, target_pid, deadline)))
+        for kind in ('syscall', 'thread-state'):
+            if not any(row['kind'] == kind and row['target_rows'] > 0 for row in results):
+                raise RuntimeError(f'No {kind} events for target PID {target_pid}')
+    result = dict(pid=target_pid, tables=results)
+    (directory / 'system-trace-valid.json').write_text(json.dumps(result, indent=2) + '\n')
+    return result

--- a/system_test/qwp_ws_watchdog.py
+++ b/system_test/qwp_ws_watchdog.py
@@ -16,6 +16,8 @@ import threading
 import time
 import urllib.request
 
+from qwp_ws_system_trace import request_stop
+
 
 def write_event(stream, event, **fields):
     stream.write(json.dumps(dict(
@@ -39,14 +41,29 @@ def heartbeat(run_dir, stop, delayed):
             previous_write_ms = (time.monotonic() - now) * 1000
 
 
+def stop_system_trace(run_dir, reason):
+    request_stop(run_dir, reason)
+    deadline = time.monotonic() + 3
+    while not (run_dir / 'system-trace-stop-sent.json').exists():
+        if (run_dir / 'system-trace-error.json').exists() or time.monotonic() > deadline:
+            raise RuntimeError('System Trace did not acknowledge onset/completion stop')
+        time.sleep(0.02)
+
+
 def capture(run_dir, pid, reason):
-    """One native sample and three JVM dump requests; no HTTP dependency."""
+    """Stop the active trace, or take native/JVM samples; no HTTP dependency."""
     (run_dir / 'capture-started').write_text(reason + '\n')
     sample = None
     with (run_dir / 'capture.jsonl').open('w') as log, \
             (run_dir / 'sample-command.log').open('w') as sample_log:
         try:
             write_event(log, 'capture_start', reason=reason, pid=pid)
+            if (run_dir / 'system-trace-enabled').exists():
+                stop_system_trace(run_dir, reason)
+                write_event(log, 'system_trace_stop_acknowledged')
+                # No additional profilers in this arm. The recorder finalizes
+                # independently; the harness validates exported data afterward.
+                return
             if sys.platform == 'darwin':
                 # Explicit output path: sample otherwise writes into /tmp.
                 try:
@@ -110,16 +127,17 @@ def watch(run_dir, pid, port, stop):
                     break
                 reason = None
                 started = time.monotonic()
+                started_wall_ns = time.time_ns()
                 try:
                     with opener.open(f'http://127.0.0.1:{port}/ping', timeout=1) as resp:
                         if resp.status != 204:
                             reason = f'ping HTTP {resp.status}'
                     write_event(log, 'ping', elapsed_ms=(time.monotonic() - started) * 1000,
-                                error=reason)
+                                started_wall_ns=started_wall_ns, error=reason)
                 except Exception as exc:
                     reason = f'ping: {type(exc).__name__}: {exc}'
                     write_event(log, 'ping', elapsed_ms=(time.monotonic() - started) * 1000,
-                                error=reason)
+                                started_wall_ns=started_wall_ns, error=reason)
                 request = run_dir / 'capture-request'
                 if request.exists():
                     reason = request.read_text()
@@ -130,12 +148,20 @@ def watch(run_dir, pid, port, stop):
                     # Publish synchronously so teardown sees an in-flight
                     # capture even before the collector thread is scheduled.
                     (run_dir / 'capture-started').write_text(reason + '\n')
+                    if (run_dir / 'system-trace-enabled').exists():
+                        request_stop(run_dir, reason)
                     collector = threading.Thread(
                         target=capture, args=(run_dir, pid, reason),
                         name='watchdog-capture')
                     collector.start()
                 stop.wait(max(0, 1 - (time.monotonic() - started)))
     finally:
+        if (run_dir / 'system-trace-enabled').exists():
+            try:
+                stop_system_trace(run_dir, 'workload-finished' if (run_dir / 'workload-finished').exists()
+                                  else 'watchdog-stopped')
+            except Exception as exc:
+                (run_dir / 'capture-error').write_text(repr(exc) + '\n')
         stop.set()
         pulse.join(timeout=2)
         if collector is not None:

--- a/system_test/qwp_ws_watchdog.py
+++ b/system_test/qwp_ws_watchdog.py
@@ -125,7 +125,7 @@ def capture(run_dir, pid, reason):
                     write_event(log, 'kernel_sample_start')
                     subprocess.run(['sudo', '-n', 'env', f'TMPDIR={directory / "tmp"}',
                                     sys.executable, str(controller), str(directory),
-                                    '--record', '--limit', '25'],
+                                    '--record-raw', '--limit', '25'],
                                    stdout=sample_log, stderr=subprocess.STDOUT,
                                    timeout=35, check=True)
                     if not (directory / 'recorder-validation.json').is_file():

--- a/system_test/qwp_ws_watchdog.py
+++ b/system_test/qwp_ws_watchdog.py
@@ -18,6 +18,7 @@ import sys
 import threading
 import time
 import urllib.request
+import urllib.parse
 
 from qwp_ws_system_trace import request_stop
 
@@ -218,6 +219,74 @@ def capture(run_dir, pid, reason):
             (run_dir / 'capture-complete').touch()
 
 
+def query_reader(run_dir, port, stop, max_requests=300, max_seconds=60):
+    """Opt-in stress traffic, not an unchanged replay. Never retry a timeout.
+
+    One serial reader starts only after an existing fuzz cursor is observed.
+    Keep events in memory so diagnostic writes cannot precede an HTTP call.
+    Socket timeouts bound inactivity, not a slowly trickling response's lifetime.
+    """
+    records = deque(maxlen=602)
+
+    def record(event, **fields):
+        records.append(dict(event=event, wall_ns=time.time_ns(),
+                            monotonic_ns=time.monotonic_ns(), **fields))
+
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    waiting_since = time.monotonic()
+    table = None
+    try:
+        while not stop.is_set() and not (run_dir / 'workload-finished').exists():
+            try:
+                with (run_dir / 'show-columns.tsv').open() as source:
+                    for line in source.read(65536).splitlines():
+                        fields = line.split('\t')
+                        if len(fields) == 8 and fields[6] == 'cursor-enter' and fields[5].lower() in (
+                                'weather0', 'weather1', 'weather2', 'weather3'):
+                            table = fields[5]
+                            break
+            except FileNotFoundError:
+                pass
+            if table is not None:
+                break
+            if time.monotonic() - waiting_since >= 30:
+                record('gate_timeout')
+                return
+            stop.wait(.05)
+        if table is None:
+            return
+        record('ready', table=table, max_requests=min(max_requests, 300),
+               max_seconds=max_seconds, interval_seconds=.2)
+        started = time.monotonic()
+        url = f'http://127.0.0.1:{port}/exec?' + urllib.parse.urlencode(
+            {'query': f'SHOW COLUMNS FROM {table}'})
+        for index in range(min(max_requests, 300)):
+            if stop.is_set() or (run_dir / 'workload-finished').exists() or time.monotonic() - started >= max_seconds:
+                break
+            record('query_start', index=index, table=table)
+            try:
+                with opener.open(url, timeout=5) as response:
+                    body = response.read(1048577)
+                    if len(body) > 1048576:
+                        raise ValueError('diagnostic response exceeds 1 MiB')
+                    data = json.loads(body)
+                    if response.status != 200 or 'error' in data or 'dataset' not in data:
+                        raise ValueError('unsuccessful diagnostic SQL response')
+                record('query_finish', index=index, bytes=len(body))
+            except Exception as exc:
+                record('query_error', index=index, error=repr(exc))
+                break  # At most one abandoned request, never a retry backlog.
+            if stop.wait(.2):
+                break
+    except Exception as exc:
+        record('reader_error', error=repr(exc))
+    finally:
+        record('stopped')
+        with (run_dir / 'query-reader.jsonl').open('w') as output:
+            for row in records:
+                output.write(json.dumps(row) + '\n')
+
+
 def watch(run_dir, pid, port, stop):
     buffered = (run_dir / 'memory-heartbeat-enabled').exists()
     kernel = (run_dir / 'kernel-stacks-enabled').exists()
@@ -228,6 +297,7 @@ def watch(run_dir, pid, port, stop):
                              name='watchdog-heartbeat', daemon=True)
     pulse.start()
     collector = None
+    reader = None
     query_observer = QueryObserverProgress(run_dir)
     ping_failures = 0
     # Do not inherit proxy settings for the loopback probe.
@@ -240,6 +310,10 @@ def watch(run_dir, pid, port, stop):
                 if stop.wait(0.05):
                     return
             delayed.clear()  # Do not turn a pre-workload gate delay into onset.
+            if (run_dir / 'query-reader-enabled').exists():
+                reader = threading.Thread(target=query_reader, args=(run_dir, port, stop),
+                                          name='diagnostic-query-reader', daemon=True)
+                reader.start()
             while not stop.is_set():
                 if not pulse.is_alive():
                     raise RuntimeError('independent heartbeat stopped')
@@ -303,9 +377,12 @@ def watch(run_dir, pid, port, stop):
             except Exception as exc:
                 (run_dir / 'capture-error').write_text(repr(exc) + '\n')
         stop.set()
+        shutdown_deadline = time.monotonic() + (47 if kernel else 17)
         pulse.join(timeout=2)
+        if reader is not None:
+            reader.join(timeout=min(6, max(0, shutdown_deadline - time.monotonic())))
         if collector is not None:
-            collector.join(timeout=45 if (run_dir / 'kernel-stacks-enabled').exists() else 15)
+            collector.join(timeout=max(0, shutdown_deadline - time.monotonic()))
         (run_dir / 'watchdog-stopped').touch()
 
 

--- a/system_test/qwp_ws_watchdog.py
+++ b/system_test/qwp_ws_watchdog.py
@@ -139,9 +139,14 @@ def watch(run_dir, pid, port, stop):
                     write_event(log, 'ping', elapsed_ms=(time.monotonic() - started) * 1000,
                                 started_wall_ns=started_wall_ns, error=reason)
                 request = run_dir / 'capture-request'
+                if (run_dir / 'show-columns-enabled').exists():
+                    # Keep ping/heartbeat telemetry, but reserve invasive capture
+                    # for a slow query or an actual workload failure in this arm.
+                    slow_query = run_dir / 'show-columns-slow'
+                    reason = ('slow SHOW COLUMNS: ' + slow_query.read_text()) if slow_query.exists() else None
                 if request.exists():
                     reason = request.read_text()
-                if delayed.is_set() and reason is None:
+                if delayed.is_set() and reason is None and not (run_dir / 'show-columns-enabled').exists():
                     reason = 'watchdog heartbeat gap exceeded 1 second'
                 # Recheck after the probe: never diagnose teardown as onset.
                 if reason and collector is None and not (run_dir / 'workload-finished').exists():

--- a/system_test/qwp_ws_watchdog.py
+++ b/system_test/qwp_ws_watchdog.py
@@ -50,6 +50,34 @@ def stop_system_trace(run_dir, reason):
         time.sleep(0.02)
 
 
+class QueryObserverProgress:
+    """External fallback: absence of telemetry is not proof of a JVM pause."""
+
+    def __init__(self, run_dir):
+        self.path = run_dir / 'show-columns.tsv'
+        self.size = None
+        self.changed_at = None
+
+    def check(self, now):
+        try:
+            size = self.path.stat().st_size
+        except FileNotFoundError:
+            size = 0
+        if self.size is None:
+            # The helper starts lazily on the first SHOW COLUMNS. Do not
+            # diagnose its absence before it has published any telemetry.
+            if size > 0:
+                self.size, self.changed_at = size, now
+            return None
+        if size != self.size and size > 0:
+            self.size, self.changed_at = size, now
+            return None
+        elapsed = now - self.changed_at
+        if elapsed >= 5:
+            return f'Java query observer telemetry stopped advancing for {elapsed:.3f}s; cause unknown'
+        return None
+
+
 def capture(run_dir, pid, reason):
     """Stop the active trace, or take native/JVM samples; no HTTP dependency."""
     (run_dir / 'capture-started').write_text(reason + '\n')
@@ -103,6 +131,7 @@ def watch(run_dir, pid, port, stop):
                              name='watchdog-heartbeat', daemon=True)
     pulse.start()
     collector = None
+    query_observer = QueryObserverProgress(run_dir)
     # Do not inherit proxy settings for the loopback probe.
     opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
     try:
@@ -144,6 +173,9 @@ def watch(run_dir, pid, port, stop):
                     # for a slow query or an actual workload failure in this arm.
                     slow_query = run_dir / 'show-columns-slow'
                     reason = ('slow SHOW COLUMNS: ' + slow_query.read_text()) if slow_query.exists() else None
+                    observer_reason = query_observer.check(time.monotonic())
+                    if reason is None:
+                        reason = observer_reason
                 if request.exists():
                     reason = request.read_text()
                 if delayed.is_set() and reason is None and not (run_dir / 'show-columns-enabled').exists():

--- a/system_test/qwp_ws_watchdog.py
+++ b/system_test/qwp_ws_watchdog.py
@@ -7,6 +7,8 @@ lets us identify one source of observer delay). All artifacts stay in run_dir.
 
 import argparse
 from collections import deque
+from contextlib import contextmanager
+import io
 import json
 import os
 from pathlib import Path
@@ -25,6 +27,19 @@ def write_event(stream, event, **fields):
         event=event, wall_ns=time.time_ns(), monotonic_ns=time.monotonic_ns(),
         **fields)) + '\n')
     stream.flush()
+
+
+@contextmanager
+def event_log(path, buffered=False):
+    if not buffered:
+        with path.open('w') as stream:
+            yield stream
+        return
+    with io.StringIO() as stream:
+        try:
+            yield stream
+        finally:
+            path.write_text(stream.getvalue())
 
 
 def heartbeat(run_dir, stop, delayed):
@@ -102,8 +117,52 @@ class QueryObserverProgress:
         return None
 
 
+def capture_kernel(run_dir, pid, reason):
+    """No diagnostic file writes until the recorder has returned its bytes."""
+    directory = run_dir / 'kernel-stacks'  # created before watchdog-ready
+    controller = Path(__file__).resolve().parents[1] / 'ci/diagnostics/kernel_wait_preflight.py'
+    with event_log(run_dir / 'capture.jsonl', buffered=True) as log:
+        try:
+            write_event(log, 'capture_start', reason=reason, pid=pid)
+            write_event(log, 'kernel_sample_start')
+            try:
+                result = subprocess.run(
+                    ['sudo', '-n', 'env', f'TMPDIR={directory / "tmp"}',
+                     sys.executable, str(controller), str(directory),
+                     '--record-raw', '--limit', '25'],
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=35, check=True)
+                write_event(log, 'kernel_sample_received', bytes=len(result.stdout))
+                if not result.stdout:
+                    raise RuntimeError('empty raw kernel capture')
+                # Raw bytes are now in this process, outside recorder timeout.
+                (directory / 'spindump.raw').write_bytes(result.stdout)
+                (run_dir / 'sample-command.log').write_bytes(result.stderr)
+                (directory / 'recorder-validation.json').write_text(json.dumps(
+                    dict(format='raw', bytes=len(result.stdout), decoded=False)) + '\n')
+                write_event(log, 'kernel_sample_complete')
+            except Exception as exc:
+                write_event(log, 'kernel_sample_error', error=repr(exc))
+                partial = getattr(exc, 'stdout', None)
+                if partial:
+                    (directory / 'spindump.partial.raw').write_bytes(partial)
+                stderr = getattr(exc, 'stderr', None)
+                if stderr:
+                    (run_dir / 'sample-command.log').write_bytes(stderr)
+                (run_dir / 'capture-error').write_text(repr(exc) + '\n')
+            for index in range(3):
+                os.kill(pid, signal.SIGQUIT)
+                write_event(log, 'sigquit_requested', index=index)
+                time.sleep(0.5)
+        finally:
+            write_event(log, 'capture_complete')
+            (run_dir / 'capture-started').write_text(reason + '\n')
+            (run_dir / 'capture-complete').touch()
+
+
 def capture(run_dir, pid, reason):
     """Stop the active trace, or take native/JVM samples; no HTTP dependency."""
+    if sys.platform == 'darwin' and (run_dir / 'kernel-stacks-enabled').exists():
+        return capture_kernel(run_dir, pid, reason)
     (run_dir / 'capture-started').write_text(reason + '\n')
     sample = None
     with (run_dir / 'capture.jsonl').open('w') as log, \
@@ -116,25 +175,7 @@ def capture(run_dir, pid, reason):
                 # No additional profilers in this arm. The recorder finalizes
                 # independently; the harness validates exported data afterward.
                 return
-            if sys.platform == 'darwin' and (run_dir / 'kernel-stacks-enabled').exists():
-                try:
-                    directory = run_dir / 'kernel-stacks'
-                    directory.mkdir()
-                    (directory / 'tmp').mkdir()
-                    controller = Path(__file__).resolve().parents[1] / 'ci/diagnostics/kernel_wait_preflight.py'
-                    write_event(log, 'kernel_sample_start')
-                    subprocess.run(['sudo', '-n', 'env', f'TMPDIR={directory / "tmp"}',
-                                    sys.executable, str(controller), str(directory),
-                                    '--record-raw', '--limit', '25'],
-                                   stdout=sample_log, stderr=subprocess.STDOUT,
-                                   timeout=35, check=True)
-                    if not (directory / 'recorder-validation.json').is_file():
-                        raise RuntimeError('kernel sample produced no validation')
-                    write_event(log, 'kernel_sample_complete')
-                except Exception as exc:
-                    write_event(log, 'kernel_sample_error', error=repr(exc))
-                    (run_dir / 'capture-error').write_text(repr(exc) + '\n')
-            elif sys.platform == 'darwin':
+            if sys.platform == 'darwin':
                 # Explicit output path: sample otherwise writes into /tmp.
                 try:
                     sample = subprocess.Popen(
@@ -178,6 +219,10 @@ def capture(run_dir, pid, reason):
 
 
 def watch(run_dir, pid, port, stop):
+    buffered = (run_dir / 'memory-heartbeat-enabled').exists()
+    kernel = (run_dir / 'kernel-stacks-enabled').exists()
+    if kernel:
+        (run_dir / 'kernel-stacks/tmp').mkdir(parents=True, exist_ok=True)
     delayed = threading.Event()
     pulse = threading.Thread(target=heartbeat, args=(run_dir, stop, delayed),
                              name='watchdog-heartbeat', daemon=True)
@@ -188,7 +233,7 @@ def watch(run_dir, pid, port, stop):
     # Do not inherit proxy settings for the loopback probe.
     opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
     try:
-        with (run_dir / 'watchdog.jsonl').open('w') as log:
+        with event_log(run_dir / 'watchdog.jsonl', buffered=buffered) as log:
             write_event(log, 'ready', pid=pid, port=port)
             (run_dir / 'watchdog-ready').touch()
             while not (run_dir / 'start-test').exists():
@@ -241,7 +286,8 @@ def watch(run_dir, pid, port, stop):
                 if reason and collector is None and not (run_dir / 'workload-finished').exists():
                     # Publish synchronously so teardown sees an in-flight
                     # capture even before the collector thread is scheduled.
-                    (run_dir / 'capture-started').write_text(reason + '\n')
+                    if not kernel:
+                        (run_dir / 'capture-started').write_text(reason + '\n')
                     if (run_dir / 'system-trace-enabled').exists():
                         request_stop(run_dir, reason)
                     collector = threading.Thread(

--- a/system_test/qwp_ws_watchdog.py
+++ b/system_test/qwp_ws_watchdog.py
@@ -92,7 +92,25 @@ def capture(run_dir, pid, reason):
                 # No additional profilers in this arm. The recorder finalizes
                 # independently; the harness validates exported data afterward.
                 return
-            if sys.platform == 'darwin':
+            if sys.platform == 'darwin' and (run_dir / 'kernel-stacks-enabled').exists():
+                try:
+                    directory = run_dir / 'kernel-stacks'
+                    directory.mkdir()
+                    (directory / 'tmp').mkdir()
+                    controller = Path(__file__).resolve().parents[1] / 'ci/diagnostics/kernel_wait_preflight.py'
+                    write_event(log, 'kernel_sample_start')
+                    subprocess.run(['sudo', '-n', 'env', f'TMPDIR={directory / "tmp"}',
+                                    sys.executable, str(controller), str(directory),
+                                    '--record', '--limit', '25'],
+                                   stdout=sample_log, stderr=subprocess.STDOUT,
+                                   timeout=35, check=True)
+                    if not (directory / 'recorder-validation.json').is_file():
+                        raise RuntimeError('kernel sample produced no validation')
+                    write_event(log, 'kernel_sample_complete')
+                except Exception as exc:
+                    write_event(log, 'kernel_sample_error', error=repr(exc))
+                    (run_dir / 'capture-error').write_text(repr(exc) + '\n')
+            elif sys.platform == 'darwin':
                 # Explicit output path: sample otherwise writes into /tmp.
                 try:
                     sample = subprocess.Popen(
@@ -181,11 +199,14 @@ def watch(run_dir, pid, port, stop):
                 if (run_dir / 'show-columns-enabled').exists():
                     # Keep ping/heartbeat telemetry, but reserve invasive capture
                     # for a slow query or an actual workload failure in this arm.
+                    ping_reason = reason
                     slow_query = run_dir / 'show-columns-slow'
                     reason = ('slow SHOW COLUMNS: ' + slow_query.read_text()) if slow_query.exists() else None
                     observer_reason = query_observer.check(time.monotonic())
                     if reason is None:
                         reason = observer_reason
+                    if reason is None and ping_reason and (run_dir / 'kernel-ping-capture-enabled').exists():
+                        reason = 'kernel resource follow-up: ' + ping_reason
                 if request.exists():
                     reason = request.read_text()
                 if delayed.is_set() and reason is None and not (run_dir / 'show-columns-enabled').exists():
@@ -212,7 +233,7 @@ def watch(run_dir, pid, port, stop):
         stop.set()
         pulse.join(timeout=2)
         if collector is not None:
-            collector.join(timeout=15)
+            collector.join(timeout=45 if (run_dir / 'kernel-stacks-enabled').exists() else 15)
         (run_dir / 'watchdog-stopped').touch()
 
 

--- a/system_test/qwp_ws_watchdog.py
+++ b/system_test/qwp_ws_watchdog.py
@@ -105,15 +105,25 @@ def capture(run_dir, pid, reason):
                     (run_dir / 'capture-error').write_text(repr(exc) + '\n')
             else:
                 write_event(log, 'native_sample_unavailable', platform=sys.platform)
+            if sample is not None:
+                try:
+                    # SIGQUIT prints at a JVM safepoint. A blocked stdout can
+                    # extend that pause, so finish native sampling first;
+                    # otherwise we can profile our own dump-induced stall.
+                    rc = sample.wait(timeout=10)
+                    write_event(log, 'native_sample_exit', returncode=rc)
+                    if rc != 0 or not (run_dir / 'native-sample.txt').is_file():
+                        raise RuntimeError('native sample failed or produced no output')
+                except Exception as exc:
+                    write_event(log, 'native_sample_error', error=repr(exc))
+                    (run_dir / 'capture-error').write_text(repr(exc) + '\n')
+                    if sample.poll() is None:
+                        sample.kill()
+                        sample.wait()
             for index in range(3):
                 os.kill(pid, signal.SIGQUIT)
                 write_event(log, 'sigquit_requested', index=index)
                 time.sleep(0.5)
-            if sample is not None:
-                rc = sample.wait(timeout=10)
-                write_event(log, 'native_sample_exit', returncode=rc)
-                if rc != 0 or not (run_dir / 'native-sample.txt').is_file():
-                    raise RuntimeError('native sample failed or produced no output')
         except Exception as exc:
             write_event(log, 'capture_error', error=repr(exc))
             (run_dir / 'capture-error').write_text(repr(exc) + '\n')

--- a/system_test/qwp_ws_watchdog.py
+++ b/system_test/qwp_ws_watchdog.py
@@ -6,6 +6,7 @@ lets us identify one source of observer delay). All artifacts stay in run_dir.
 """
 
 import argparse
+from collections import deque
 import json
 import os
 from pathlib import Path
@@ -27,6 +28,29 @@ def write_event(stream, event, **fields):
 
 
 def heartbeat(run_dir, stop, delayed):
+    if (run_dir / 'memory-heartbeat-enabled').exists():
+        # A filesystem stall must not stall the scheduling observer itself.
+        # Keep at most ~34 minutes at 4 Hz; report loss explicitly if exceeded.
+        records = deque(maxlen=8192)
+        dropped = 0
+        previous = time.monotonic()
+        while not stop.wait(0.25):
+            now = time.monotonic()
+            gap_ms = (now - previous) * 1000
+            previous = now
+            if gap_ms > 1000:
+                delayed.set()
+            if len(records) == records.maxlen:
+                dropped += 1
+            records.append(dict(event='heartbeat', wall_ns=time.time_ns(),
+                                monotonic_ns=time.monotonic_ns(), gap_ms=gap_ms,
+                                previous_write_ms=0, buffered=True))
+        with (run_dir / 'heartbeat.jsonl').open('w') as log:
+            for record in records:
+                log.write(json.dumps(record) + '\n')
+        if dropped:
+            (run_dir / 'capture-error').write_text(f'memory heartbeat dropped {dropped} events\n')
+        return
     with (run_dir / 'heartbeat.jsonl').open('w') as log:
         previous = time.monotonic()
         previous_write_ms = 0.0
@@ -160,6 +184,7 @@ def watch(run_dir, pid, port, stop):
     pulse.start()
     collector = None
     query_observer = QueryObserverProgress(run_dir)
+    ping_failures = 0
     # Do not inherit proxy settings for the loopback probe.
     opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
     try:
@@ -196,6 +221,7 @@ def watch(run_dir, pid, port, stop):
                     write_event(log, 'ping', elapsed_ms=(time.monotonic() - started) * 1000,
                                 started_wall_ns=started_wall_ns, error=reason)
                 request = run_dir / 'capture-request'
+                ping_failures = ping_failures + 1 if reason else 0
                 if (run_dir / 'show-columns-enabled').exists():
                     # Keep ping/heartbeat telemetry, but reserve invasive capture
                     # for a slow query or an actual workload failure in this arm.
@@ -205,7 +231,7 @@ def watch(run_dir, pid, port, stop):
                     observer_reason = query_observer.check(time.monotonic())
                     if reason is None:
                         reason = observer_reason
-                    if reason is None and ping_reason and (run_dir / 'kernel-ping-capture-enabled').exists():
+                    if reason is None and ping_reason and ping_failures >= 2 and (run_dir / 'kernel-ping-capture-enabled').exists():
                         reason = 'kernel resource follow-up: ' + ping_reason
                 if request.exists():
                     reason = request.read_text()

--- a/system_test/qwp_ws_watchdog.py
+++ b/system_test/qwp_ws_watchdog.py
@@ -1,0 +1,163 @@
+"""Independent, bounded onset capture for the macOS QWP diagnostic job.
+
+The heartbeat never makes HTTP calls or waits for stack collection. Its gaps
+are *observer* delays, not proof of a host pause (including log-write latency
+lets us identify one source of observer delay). All artifacts stay in run_dir.
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import threading
+import time
+import urllib.request
+
+
+def write_event(stream, event, **fields):
+    stream.write(json.dumps(dict(
+        event=event, wall_ns=time.time_ns(), monotonic_ns=time.monotonic_ns(),
+        **fields)) + '\n')
+    stream.flush()
+
+
+def heartbeat(run_dir, stop, delayed):
+    with (run_dir / 'heartbeat.jsonl').open('w') as log:
+        previous = time.monotonic()
+        previous_write_ms = 0.0
+        while not stop.wait(0.25):
+            now = time.monotonic()
+            gap_ms = (now - previous) * 1000
+            previous = now
+            if gap_ms > 1000:
+                delayed.set()
+            write_event(log, 'heartbeat', gap_ms=gap_ms,
+                        previous_write_ms=previous_write_ms)
+            previous_write_ms = (time.monotonic() - now) * 1000
+
+
+def capture(run_dir, pid, reason):
+    """One native sample and three JVM dump requests; no HTTP dependency."""
+    (run_dir / 'capture-started').write_text(reason + '\n')
+    sample = None
+    with (run_dir / 'capture.jsonl').open('w') as log, \
+            (run_dir / 'sample-command.log').open('w') as sample_log:
+        try:
+            write_event(log, 'capture_start', reason=reason, pid=pid)
+            if sys.platform == 'darwin':
+                # Explicit output path: sample otherwise writes into /tmp.
+                try:
+                    sample = subprocess.Popen(
+                        ['/usr/bin/sample', str(pid), '3', '10', '-file',
+                         str(run_dir / 'native-sample.txt')],
+                        stdout=sample_log, stderr=subprocess.STDOUT)
+                except OSError as exc:
+                    # A missing/denied native tool must not suppress SIGQUIT.
+                    write_event(log, 'native_sample_error', error=repr(exc))
+                    (run_dir / 'capture-error').write_text(repr(exc) + '\n')
+            else:
+                write_event(log, 'native_sample_unavailable', platform=sys.platform)
+            for index in range(3):
+                os.kill(pid, signal.SIGQUIT)
+                write_event(log, 'sigquit_requested', index=index)
+                time.sleep(0.5)
+            if sample is not None:
+                rc = sample.wait(timeout=10)
+                write_event(log, 'native_sample_exit', returncode=rc)
+                if rc != 0 or not (run_dir / 'native-sample.txt').is_file():
+                    raise RuntimeError('native sample failed or produced no output')
+        except Exception as exc:
+            write_event(log, 'capture_error', error=repr(exc))
+            (run_dir / 'capture-error').write_text(repr(exc) + '\n')
+        finally:
+            if sample is not None and sample.poll() is None:
+                sample.kill()
+                sample.wait()
+            write_event(log, 'capture_complete')
+            (run_dir / 'capture-complete').touch()
+
+
+def watch(run_dir, pid, port, stop):
+    delayed = threading.Event()
+    pulse = threading.Thread(target=heartbeat, args=(run_dir, stop, delayed),
+                             name='watchdog-heartbeat', daemon=True)
+    pulse.start()
+    collector = None
+    # Do not inherit proxy settings for the loopback probe.
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    try:
+        with (run_dir / 'watchdog.jsonl').open('w') as log:
+            write_event(log, 'ready', pid=pid, port=port)
+            (run_dir / 'watchdog-ready').touch()
+            while not (run_dir / 'start-test').exists():
+                if stop.wait(0.05):
+                    return
+            delayed.clear()  # Do not turn a pre-workload gate delay into onset.
+            while not stop.is_set():
+                if not pulse.is_alive():
+                    raise RuntimeError('independent heartbeat stopped')
+                if (run_dir / 'workload-finished').exists():
+                    # A producer can report a failure immediately before
+                    # finishing. Capture that explicit request before acking
+                    # teardown, even if the probe loop has not seen it yet.
+                    request = run_dir / 'capture-request'
+                    if collector is None and request.exists():
+                        capture(run_dir, pid, request.read_text())
+                    write_event(log, 'workload_finished')
+                    break
+                reason = None
+                started = time.monotonic()
+                try:
+                    with opener.open(f'http://127.0.0.1:{port}/ping', timeout=1) as resp:
+                        if resp.status != 204:
+                            reason = f'ping HTTP {resp.status}'
+                    write_event(log, 'ping', elapsed_ms=(time.monotonic() - started) * 1000,
+                                error=reason)
+                except Exception as exc:
+                    reason = f'ping: {type(exc).__name__}: {exc}'
+                    write_event(log, 'ping', elapsed_ms=(time.monotonic() - started) * 1000,
+                                error=reason)
+                request = run_dir / 'capture-request'
+                if request.exists():
+                    reason = request.read_text()
+                if delayed.is_set() and reason is None:
+                    reason = 'watchdog heartbeat gap exceeded 1 second'
+                # Recheck after the probe: never diagnose teardown as onset.
+                if reason and collector is None and not (run_dir / 'workload-finished').exists():
+                    # Publish synchronously so teardown sees an in-flight
+                    # capture even before the collector thread is scheduled.
+                    (run_dir / 'capture-started').write_text(reason + '\n')
+                    collector = threading.Thread(
+                        target=capture, args=(run_dir, pid, reason),
+                        name='watchdog-capture')
+                    collector.start()
+                stop.wait(max(0, 1 - (time.monotonic() - started)))
+    finally:
+        stop.set()
+        pulse.join(timeout=2)
+        if collector is not None:
+            collector.join(timeout=15)
+        (run_dir / 'watchdog-stopped').touch()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--run-dir', type=Path, required=True)
+    args = parser.parse_args()
+    run_dir = args.run_dir.resolve()
+    endpoint = json.loads((run_dir / 'watchdog-endpoint.json').read_text())
+    pid, port = endpoint['pid'], endpoint['port']
+    if not isinstance(pid, int) or pid <= 1 or not isinstance(port, int) or not 0 < port < 65536:
+        parser.error('invalid managed-server PID or port')
+    os.kill(pid, 0)
+    stop = threading.Event()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        signal.signal(sig, lambda *_: stop.set())
+    watch(run_dir, pid, port, stop)
+
+
+if __name__ == '__main__':
+    main()

--- a/system_test/test.py
+++ b/system_test/test.py
@@ -110,6 +110,7 @@ from fixture import (
     QuestDbExternalFixture,
     QuestDbFixture,
     TlsProxyFixture,
+    retry,
     install_questdb,
     install_questdb_from_repo,
     list_questdb_releases,
@@ -2619,12 +2620,25 @@ class TestQwpWsFuzz(QwpWsTestSupport, unittest.TestCase):
         failure_counter = [0]
         failure_messages = []
         fail_lock = threading.Lock()
+        diagnostics_requested = [False]
+        diagnostics_enabled = (
+            os.environ.get('QWP_WS_FUZZ_DIAGNOSTICS') == '1')
 
         def record_failure(msg: str):
+            capture_diagnostics = False
             with fail_lock:
                 failure_messages.append(msg)
                 failure_counter[0] += 1
+                if diagnostics_enabled and not diagnostics_requested[0]:
+                    diagnostics_requested[0] = True
+                    capture_diagnostics = True
             self._log(msg)
+            if capture_diagnostics:
+                try:
+                    QDB_FIXTURE.capture_timeout_diagnostics(self.id())
+                except Exception as e:  # noqa: BLE001 — diagnostics are best effort
+                    self._log(
+                        f'immediate QuestDB diagnostics failed: {e!r}')
 
         if fuzz.max_bounces > 0 and not (
                 hasattr(QDB_FIXTURE, 'stop') and hasattr(QDB_FIXTURE, 'start')):
@@ -2770,6 +2784,9 @@ class TestQwpWsFuzz(QwpWsTestSupport, unittest.TestCase):
         except Exception as e:  # noqa: BLE001
             record_failure(f'connect failed for {sender_id}: {e}')
             return
+        diagnostics_enabled = (
+            os.environ.get('QWP_WS_FUZZ_DIAGNOSTICS') == '1')
+        drain_started = None
         try:
             points = 0
             for _ in range(load.num_of_iterations):
@@ -2787,14 +2804,41 @@ class TestQwpWsFuzz(QwpWsTestSupport, unittest.TestCase):
                 sender.flush()
                 if load.wait_between_iterations_ms > 0:
                     time.sleep(load.wait_between_iterations_ms / 1000.0)
+            if diagnostics_enabled:
+                self._log_sender_progress(sender_id, sender, 'drain-start')
+            drain_started = time.monotonic()
             sender.close_drain()
+            if diagnostics_enabled:
+                self._log_sender_progress(
+                    sender_id,
+                    sender,
+                    'drain-complete',
+                    time.monotonic() - drain_started)
         except Exception as e:  # noqa: BLE001
+            if diagnostics_enabled:
+                elapsed = None if drain_started is None else (
+                    time.monotonic() - drain_started)
+                self._log_sender_progress(
+                    sender_id, sender, 'producer-failed', elapsed)
             record_failure(f'producer {sender_id} failed: {e}')
         finally:
             try:
                 sender.close(False)
             except Exception:  # noqa: BLE001
                 pass
+
+    def _log_sender_progress(self, sender_id, sender, event, elapsed=None):
+        try:
+            progress = (
+                f'published_fsn={sender.published_fsn()}, '
+                f'acked_fsn={sender.acked_fsn()}')
+        except Exception as e:  # noqa: BLE001 — diagnostics must not affect the test
+            progress = f'progress_unavailable={e!r}'
+        elapsed_text = '' if elapsed is None else f', elapsed={elapsed:.3f}s'
+        now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        self._log(
+            f'diagnostics event={event}, at={now}, sender={sender_id}, '
+            f'{progress}{elapsed_text}')
 
     def _r(self):
         """Shorthand alias for the master RNG used in test parameterization."""
@@ -4342,11 +4386,15 @@ def _stop_and_maybe_wipe(fixture):
     and want that server log to survive for the CI "Compress QuestDB server
     log on failure" archive step. So skip the wipe whenever an exception is
     propagating — including the ``SystemExit`` from ``sys.exit(1)`` —
-    detected via ``sys.exc_info()`` captured before ``stop()`` runs.
+    detected via ``sys.exc_info()`` captured before ``stop()`` runs. The
+    focused QWP/WS diagnostic job also preserves successful runs long enough
+    for its wrapper to copy the server log into the published artifact.
     """
     failed = sys.exc_info()[0] is not None
+    preserve_diagnostics = (
+        os.environ.get('QWP_WS_FUZZ_DIAGNOSTICS') == '1')
     fixture.stop()
-    if not failed:
+    if not failed and not preserve_diagnostics:
         fixture.wipe_data_dir()
 
 
@@ -4504,6 +4552,21 @@ def run_with_fixtures(args):
                 QDB_FIXTURE.http = False
                 QDB_FIXTURE.protocol_version = latest_protocol
                 QDB_FIXTURE.drop_all_tables()
+                ready_file = os.environ.get('QWP_WS_FUZZ_READY_FILE')
+                go_file = os.environ.get('QWP_WS_FUZZ_GO_FILE')
+                if ready_file or go_file:
+                    if not ready_file or not go_file:
+                        raise RuntimeError(
+                            'QWP_WS_FUZZ_READY_FILE and '
+                            'QWP_WS_FUZZ_GO_FILE must be set together')
+                    pathlib.Path(ready_file).touch()
+                    retry(
+                        lambda: pathlib.Path(go_file).exists(),
+                        timeout_sec=30,
+                        every=0.05,
+                        backoff_till=0.05,
+                        lead_sleep=0,
+                        msg='Timed out waiting for QWP/WS diagnostic gate')
                 if not _run_selected_tests(SUITE_QWP_WS_FUZZ):
                     sys.exit(1)
             finally:

--- a/system_test/test.py
+++ b/system_test/test.py
@@ -2460,6 +2460,7 @@ class TestQwpWsFuzz(QwpWsTestSupport, unittest.TestCase):
 
     def tearDown(self):
         if isinstance(QDB_FIXTURE, QuestDbFixture) and QDB_FIXTURE._proc:
+            QDB_FIXTURE.finish_fuzz_diagnostics()
             for name in self._created_tables:
                 self._drop_table_if_exists(name)
             QDB_FIXTURE.http_sql_query(
@@ -2485,10 +2486,9 @@ class TestQwpWsFuzz(QwpWsTestSupport, unittest.TestCase):
         sys.stderr.flush()
 
     def _list_columns(self, table_name: str):
-        try:
-            resp = sql_query(f'SHOW COLUMNS FROM \'{table_name}\'')
-        except Exception:
-            return []
+        # AlterThread already tolerates lookup failures and reports transient
+        # ones to diagnostics. Swallowing here hid SHOW COLUMNS stalls.
+        resp = sql_query(f'SHOW COLUMNS FROM \'{table_name}\'')
         cols = resp.get('columns') or []
         dataset = resp.get('dataset') or []
         name_idx = type_idx = None

--- a/system_test/test.py
+++ b/system_test/test.py
@@ -4579,7 +4579,7 @@ def run_with_fixtures(args):
                     pathlib.Path(ready_file).touch()
                     retry(
                         lambda: pathlib.Path(go_file).exists(),
-                        timeout_sec=30,
+                        timeout_sec=QDB_FIXTURE.fuzz_diagnostic_gate_timeout(),
                         every=0.05,
                         backoff_till=0.05,
                         lead_sleep=0,

--- a/system_test/test.py
+++ b/system_test/test.py
@@ -2624,6 +2624,19 @@ class TestQwpWsFuzz(QwpWsTestSupport, unittest.TestCase):
         diagnostics_enabled = (
             os.environ.get('QWP_WS_FUZZ_DIAGNOSTICS') == '1')
 
+        startup_gate = None
+        startup_prefix = int(os.environ.get('QWP_WS_STARTUP_LOOKUPS', '0'))
+        if startup_prefix:
+            if not diagnostics_enabled or fuzz.column_convert_prob <= 0:
+                raise ValueError('startup prefix requires diagnostics and ALTER workload')
+            from qwp_ws_startup_gate import StartupGate
+            startup_gate = StartupGate(startup_prefix, self._log)
+
+        def list_columns_for_alter(table_name):
+            if startup_gate is not None:
+                return startup_gate.lookup(self._list_columns, table_name)
+            return self._list_columns(table_name)
+
         def capture_diagnostics(reason: str):
             if not diagnostics_enabled:
                 return
@@ -2669,7 +2682,7 @@ class TestQwpWsFuzz(QwpWsTestSupport, unittest.TestCase):
                     name=f'qwp-ws-fuzz-producer-{thread_index}',
                     args=(
                         sender_id, producer_sf, load, fuzz, thread_seed_rng,
-                        tables, next_ts, record_failure))
+                        tables, next_ts, record_failure, startup_gate))
                 producer_threads.append(thread)
                 thread.start()
 
@@ -2681,7 +2694,7 @@ class TestQwpWsFuzz(QwpWsTestSupport, unittest.TestCase):
                     * fuzz.column_convert_prob))
                 alter_thread = qwp_ws_fuzz.AlterThread(
                     sql_query=sql_query,
-                    list_columns=self._list_columns,
+                    list_columns=list_columns_for_alter,
                     tables=list(tables.keys()),
                     convert_budget=budget,
                     rnd=self._master_rng.child(),
@@ -2759,7 +2772,7 @@ class TestQwpWsFuzz(QwpWsTestSupport, unittest.TestCase):
                 self.fail(str(e))
 
     def _producer_loop(self, sender_id, sf_root, load, fuzz, rnd,
-                       tables, next_ts, record_failure):
+                       tables, next_ts, record_failure, startup_gate=None):
         # A post-restart SFA replay storm can starve the server's accept loop
         # for ~1.5 min, so bounce variants need a wider drain budget; kept
         # equal so the reconnect sub-budget never trips first.
@@ -2789,6 +2802,8 @@ class TestQwpWsFuzz(QwpWsTestSupport, unittest.TestCase):
             reconnect_max_backoff_millis=250,
             close_flush_timeout_millis=budget_millis)
         try:
+            if startup_gate is not None:
+                startup_gate.wait()
             sender = self._connect_sender(conf)
         except Exception as e:  # noqa: BLE001
             record_failure(f'connect failed for {sender_id}: {e}')

--- a/system_test/test.py
+++ b/system_test/test.py
@@ -2624,21 +2624,29 @@ class TestQwpWsFuzz(QwpWsTestSupport, unittest.TestCase):
         diagnostics_enabled = (
             os.environ.get('QWP_WS_FUZZ_DIAGNOSTICS') == '1')
 
-        def record_failure(msg: str):
-            capture_diagnostics = False
+        def capture_diagnostics(reason: str):
+            if not diagnostics_enabled:
+                return
+            should_capture = False
             with fail_lock:
-                failure_messages.append(msg)
-                failure_counter[0] += 1
-                if diagnostics_enabled and not diagnostics_requested[0]:
+                if not diagnostics_requested[0]:
                     diagnostics_requested[0] = True
-                    capture_diagnostics = True
-            self._log(msg)
-            if capture_diagnostics:
+                    should_capture = True
+            if should_capture:
+                self._log(
+                    f'triggering immediate QuestDB diagnostics: {reason}')
                 try:
                     QDB_FIXTURE.capture_timeout_diagnostics(self.id())
                 except Exception as e:  # noqa: BLE001 — diagnostics are best effort
                     self._log(
                         f'immediate QuestDB diagnostics failed: {e!r}')
+
+        def record_failure(msg: str):
+            with fail_lock:
+                failure_messages.append(msg)
+                failure_counter[0] += 1
+            self._log(msg)
+            capture_diagnostics(msg)
 
         if fuzz.max_bounces > 0 and not (
                 hasattr(QDB_FIXTURE, 'stop') and hasattr(QDB_FIXTURE, 'start')):
@@ -2681,7 +2689,8 @@ class TestQwpWsFuzz(QwpWsTestSupport, unittest.TestCase):
                     stop_event=stop_event,
                     record_failure=record_failure,
                     failure_counter=failure_counter,
-                    log=self._log)
+                    log=self._log,
+                    on_transient_network_error=capture_diagnostics)
                 alter_thread.start()
 
             bounce_thread = None
@@ -4554,11 +4563,19 @@ def run_with_fixtures(args):
                 QDB_FIXTURE.drop_all_tables()
                 ready_file = os.environ.get('QWP_WS_FUZZ_READY_FILE')
                 go_file = os.environ.get('QWP_WS_FUZZ_GO_FILE')
+                pid_file = os.environ.get('QWP_WS_FUZZ_PID_FILE')
                 if ready_file or go_file:
                     if not ready_file or not go_file:
                         raise RuntimeError(
                             'QWP_WS_FUZZ_READY_FILE and '
                             'QWP_WS_FUZZ_GO_FILE must be set together')
+                    if pid_file:
+                        server_pid = QDB_FIXTURE.process_pid()
+                        if server_pid is None:
+                            raise RuntimeError(
+                                'Managed QuestDB process PID is unavailable')
+                        pathlib.Path(pid_file).write_text(
+                            f'{server_pid}\n', encoding='ascii')
                     pathlib.Path(ready_file).touch()
                     retry(
                         lambda: pathlib.Path(go_file).exists(),

--- a/system_test/test_fixture_unit.py
+++ b/system_test/test_fixture_unit.py
@@ -169,7 +169,7 @@ class TimeoutDiagnosticsTest(unittest.TestCase):
                     'QWP_WS_MEMORY_PRESSURE': 'natural'}):
                 self.assertEqual(qdb.fuzz_diagnostic_gate_timeout(), 30)
                 with mock.patch.dict(fixture.os.environ, {'QWP_WS_MEMORY_PRESSURE': 'paired'}):
-                    self.assertEqual(qdb.fuzz_diagnostic_gate_timeout(), 60)
+                    self.assertEqual(qdb.fuzz_diagnostic_gate_timeout(), 90)
                     with mock.patch.dict(fixture.os.environ, {'QWP_WS_FUZZ_DIAGNOSTICS': '0'}):
                         self.assertEqual(qdb.fuzz_diagnostic_gate_timeout(), 30)
                 (directory / 'system-trace-enabled').touch()

--- a/system_test/test_fixture_unit.py
+++ b/system_test/test_fixture_unit.py
@@ -169,11 +169,16 @@ class TimeoutDiagnosticsTest(unittest.TestCase):
             qdb._proc = mock.Mock()
             qdb._proc.poll.return_value = None
             stderr = io.StringIO()
+
+            def timeout_after_dump(*_args, **_kwargs):
+                self.assertTrue(qdb._proc.send_signal.called)
+                raise TimeoutError('timed out')
+
             with contextlib.redirect_stderr(stderr), \
                     mock.patch.object(
                         fixture.urllib.request,
                         'urlopen',
-                        side_effect=TimeoutError('timed out')), \
+                        side_effect=timeout_after_dump), \
                     mock.patch.object(fixture.time, 'sleep'):
                 qdb.capture_timeout_diagnostics('example.test')
 

--- a/system_test/test_fixture_unit.py
+++ b/system_test/test_fixture_unit.py
@@ -159,6 +159,21 @@ class PrintLogTest(unittest.TestCase):
 
 
 class TimeoutDiagnosticsTest(unittest.TestCase):
+    def test_kernel_report_wait_is_bounded_after_workload_completion(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = pathlib.Path(tmp)
+            (directory / 'kernel-stacks-enabled').touch()
+            qdb = _make_fixture(tmp)
+            with mock.patch.dict(fixture.os.environ, {
+                    'QWP_WS_FUZZ_DIAGNOSTICS': '1',
+                    'QWP_WS_FUZZ_WATCHDOG_DIR': str(directory)}), \
+                    mock.patch.object(fixture.time, 'monotonic', side_effect=[0, 20, 40, 51]), \
+                    mock.patch.object(fixture.time, 'sleep') as sleep:
+                qdb.finish_fuzz_diagnostics()
+            self.assertTrue((directory / 'workload-finished').exists())
+            self.assertEqual(sleep.call_count, 2)
+            self.assertIn('did not stop', (directory / 'capture-error').read_text())
+
     def test_only_traced_or_pressure_diagnostic_setup_gets_longer_gate(self):
         with tempfile.TemporaryDirectory() as tmp:
             directory = pathlib.Path(tmp)

--- a/system_test/test_fixture_unit.py
+++ b/system_test/test_fixture_unit.py
@@ -159,14 +159,19 @@ class PrintLogTest(unittest.TestCase):
 
 
 class TimeoutDiagnosticsTest(unittest.TestCase):
-    def test_only_traced_diagnostic_setup_gets_longer_gate(self):
+    def test_only_traced_or_pressure_diagnostic_setup_gets_longer_gate(self):
         with tempfile.TemporaryDirectory() as tmp:
             directory = pathlib.Path(tmp)
             qdb = _make_fixture(tmp)
             with mock.patch.dict(fixture.os.environ, {
                     'QWP_WS_FUZZ_DIAGNOSTICS': '1',
-                    'QWP_WS_FUZZ_WATCHDOG_DIR': str(directory)}):
+                    'QWP_WS_FUZZ_WATCHDOG_DIR': str(directory),
+                    'QWP_WS_MEMORY_PRESSURE': 'natural'}):
                 self.assertEqual(qdb.fuzz_diagnostic_gate_timeout(), 30)
+                with mock.patch.dict(fixture.os.environ, {'QWP_WS_MEMORY_PRESSURE': 'paired'}):
+                    self.assertEqual(qdb.fuzz_diagnostic_gate_timeout(), 60)
+                    with mock.patch.dict(fixture.os.environ, {'QWP_WS_FUZZ_DIAGNOSTICS': '0'}):
+                        self.assertEqual(qdb.fuzz_diagnostic_gate_timeout(), 30)
                 (directory / 'system-trace-enabled').touch()
                 self.assertEqual(qdb.fuzz_diagnostic_gate_timeout(), 90)
                 with mock.patch.dict(fixture.os.environ, {'QWP_WS_FUZZ_DIAGNOSTICS': '0'}):

--- a/system_test/test_fixture_unit.py
+++ b/system_test/test_fixture_unit.py
@@ -160,6 +160,52 @@ class PrintLogTest(unittest.TestCase):
 
 class TimeoutDiagnosticsTest(unittest.TestCase):
 
+    def test_watchdog_request_does_not_block_on_http_or_dump(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            qdb = _make_fixture(tmp_dir)
+            with mock.patch.dict(fixture.os.environ, {
+                    'QWP_WS_FUZZ_DIAGNOSTICS': '1',
+                    'QWP_WS_FUZZ_WATCHDOG_DIR': tmp_dir}), \
+                    mock.patch.object(fixture.urllib.request, 'urlopen') as ping, \
+                    mock.patch.object(qdb, '_request_thread_dump') as dump:
+                qdb.capture_timeout_diagnostics('lookup timeout')
+            self.assertEqual(
+                (pathlib.Path(tmp_dir) / 'capture-request').read_text(),
+                'lookup timeout\n')
+            ping.assert_not_called()
+            dump.assert_not_called()
+
+    def test_teardown_waits_for_requested_capture(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            qdb = _make_fixture(tmp_dir)
+            directory = pathlib.Path(tmp_dir)
+            (directory / 'capture-request').touch()
+
+            def complete_capture(_seconds):
+                self.assertTrue((directory / 'workload-finished').exists())
+                (directory / 'capture-complete').touch()
+                (directory / 'watchdog-stopped').touch()
+
+            with mock.patch.dict(fixture.os.environ, {
+                    'QWP_WS_FUZZ_DIAGNOSTICS': '1',
+                    'QWP_WS_FUZZ_WATCHDOG_DIR': tmp_dir}), \
+                    mock.patch.object(fixture.time, 'sleep', complete_capture):
+                qdb.finish_fuzz_diagnostics()
+            self.assertTrue((directory / 'workload-finished').exists())
+
+    def test_teardown_wait_is_bounded_if_watchdog_dies(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            qdb = _make_fixture(tmp_dir)
+            directory = pathlib.Path(tmp_dir)
+            (directory / 'capture-request').touch()
+            with mock.patch.dict(fixture.os.environ, {
+                    'QWP_WS_FUZZ_DIAGNOSTICS': '1',
+                    'QWP_WS_FUZZ_WATCHDOG_DIR': tmp_dir}), \
+                    mock.patch.object(fixture.time, 'monotonic', side_effect=[0, 16]):
+                qdb.finish_fuzz_diagnostics()
+            self.assertTrue((directory / 'capture-error').exists())
+            self.assertTrue((directory / 'workload-finished').exists())
+
     @unittest.skipUnless(
         hasattr(signal, 'SIGQUIT'), 'SIGQUIT is POSIX-only')
     def test_probes_ping_and_requests_thread_dump(self):

--- a/system_test/test_fixture_unit.py
+++ b/system_test/test_fixture_unit.py
@@ -159,6 +159,19 @@ class PrintLogTest(unittest.TestCase):
 
 
 class TimeoutDiagnosticsTest(unittest.TestCase):
+    def test_only_traced_diagnostic_setup_gets_longer_gate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = pathlib.Path(tmp)
+            qdb = _make_fixture(tmp)
+            with mock.patch.dict(fixture.os.environ, {
+                    'QWP_WS_FUZZ_DIAGNOSTICS': '1',
+                    'QWP_WS_FUZZ_WATCHDOG_DIR': str(directory)}):
+                self.assertEqual(qdb.fuzz_diagnostic_gate_timeout(), 30)
+                (directory / 'system-trace-enabled').touch()
+                self.assertEqual(qdb.fuzz_diagnostic_gate_timeout(), 90)
+                with mock.patch.dict(fixture.os.environ, {'QWP_WS_FUZZ_DIAGNOSTICS': '0'}):
+                    self.assertEqual(qdb.fuzz_diagnostic_gate_timeout(), 30)
+
 
     def test_watchdog_request_does_not_block_on_http_or_dump(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/system_test/test_qwp_ws_disk_load_unit.py
+++ b/system_test/test_qwp_ws_disk_load_unit.py
@@ -36,6 +36,28 @@ class DiskLoadTest(unittest.TestCase):
                 run(root, 'load')
             self.assertFalse((root / 'disk-load-finished').exists())
 
+    def test_real_mapped_work_and_pacing(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / 'show-columns.tsv').touch()
+            with patch('qwp_ws_disk_load.time.sleep') as sleep:
+                run(root, 'load', max_cycles=2, pattern='mapped')
+            self.assertEqual(sleep.call_count, 2)
+            sleep.assert_called_with(.01)
+            rows = [json.loads(s) for s in (root / 'disk-load.jsonl').read_text().splitlines()]
+            self.assertEqual(rows[0]['pattern'], 'mapped')
+            self.assertEqual(rows[-1]['bytes_written'], 128 * 1024)
+            self.assertEqual((root / 'disk-load.data').stat().st_size, 64 * 1024)
+            self.assertEqual([r['stage'] for r in rows if r['event'] == 'syscall'],
+                             ['grow', 'mmap', 'mapped_write', 'munmap', 'shrink'] * 2)
+            self.assertTrue((root / 'disk-load-finished').exists())
+
+    def test_bad_pattern_creates_no_file(self):
+        with tempfile.TemporaryDirectory() as temp:
+            with self.assertRaisesRegex(ValueError, 'pattern'):
+                run(temp, 'load', pattern='invalid')
+            self.assertEqual(list(Path(temp).iterdir()), [])
+
     def test_short_write_fails(self):
         with patch('qwp_ws_disk_load.os.ftruncate'), patch('qwp_ws_disk_load.os.pwrite', return_value=1):
             with self.assertRaisesRegex(RuntimeError, 'short diagnostic write'):

--- a/system_test/test_qwp_ws_disk_load_unit.py
+++ b/system_test/test_qwp_ws_disk_load_unit.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from qwp_ws_disk_load import cycle, mode_for_run, run
+from qwp_ws_disk_load import cycle, map_shared, mode_for_run, run
 
 
 class DiskLoadTest(unittest.TestCase):
@@ -40,7 +40,9 @@ class DiskLoadTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             (root / 'show-columns.tsv').touch()
-            with patch('qwp_ws_disk_load.time.sleep') as sleep:
+            with patch('qwp_ws_disk_load.time.sleep') as sleep, \
+                    patch('qwp_ws_disk_load.os.urandom', return_value=b'z' * 65536), \
+                    patch('qwp_ws_disk_load.mmap.mmap', side_effect=AssertionError('implicit F_FULLFSYNC')):
                 run(root, 'load', max_cycles=2, pattern='mapped')
             self.assertEqual(sleep.call_count, 2)
             sleep.assert_called_with(.01)
@@ -48,9 +50,14 @@ class DiskLoadTest(unittest.TestCase):
             self.assertEqual(rows[0]['pattern'], 'mapped')
             self.assertEqual(rows[-1]['bytes_written'], 128 * 1024)
             self.assertEqual((root / 'disk-load.data').stat().st_size, 64 * 1024)
+            self.assertEqual((root / 'disk-load.data').read_bytes(), b'z' * 65536)
             self.assertEqual([r['stage'] for r in rows if r['event'] == 'syscall'],
                              ['grow', 'mmap', 'mapped_write', 'munmap', 'shrink'] * 2)
             self.assertTrue((root / 'disk-load-finished').exists())
+
+    def test_raw_mapping_failure_raises_before_write(self):
+        with self.assertRaises(OSError):
+            map_shared(-1, 1024 * 1024)
 
     def test_bad_pattern_creates_no_file(self):
         with tempfile.TemporaryDirectory() as temp:

--- a/system_test/test_qwp_ws_disk_load_unit.py
+++ b/system_test/test_qwp_ws_disk_load_unit.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from qwp_ws_disk_load import cycle, mode_for_run, run
+
+
+class DiskLoadTest(unittest.TestCase):
+    def test_balanced_order(self):
+        self.assertEqual([mode_for_run(i) for i in range(1, 9)],
+                         ['probe', 'load', 'load', 'probe'] * 2)
+
+    def test_real_bounded_work(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / 'show-columns.tsv').touch()
+            run(root, 'load', max_cycles=2)
+            rows = [json.loads(s) for s in (root / 'disk-load.jsonl').read_text().splitlines()]
+            self.assertEqual(rows[-1]['bytes_written'], 128 * 1024)
+            self.assertEqual(rows[-1]['reason'], 'bounded_budget')
+            self.assertEqual((root / 'disk-load.data').stat().st_size, 64 * 1024)
+            self.assertEqual([r['stage'] for r in rows if r['event'] == 'syscall'],
+                             ['truncate', 'pwrite', 'fsync'] * 2)
+            self.assertTrue((root / 'disk-load-finished').exists())
+            with self.assertRaises(FileExistsError):
+                run(root, 'load', max_cycles=2)
+
+    def test_stops_after_workload(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / 'show-columns.tsv').touch()
+            (root / 'workload-finished').touch()
+            with self.assertRaisesRegex(RuntimeError, 'no overlap'):
+                run(root, 'load')
+            self.assertFalse((root / 'disk-load-finished').exists())
+
+    def test_short_write_fails(self):
+        with patch('qwp_ws_disk_load.os.ftruncate'), patch('qwp_ws_disk_load.os.pwrite', return_value=1):
+            with self.assertRaisesRegex(RuntimeError, 'short diagnostic write'):
+                cycle(123, b'abc', lambda _: None)

--- a/system_test/test_qwp_ws_fuzz_unit.py
+++ b/system_test/test_qwp_ws_fuzz_unit.py
@@ -231,6 +231,21 @@ class AlterThreadTransientErrorTest(unittest.TestCase):
         self.assertIn('ALTER TABLE', observed[0])
         self.assertIn('TimeoutError: timed out', observed[0])
 
+    def test_real_list_columns_timeout_reaches_diagnostics(self):
+        observed = []
+        thread, counter, failures = self._make_thread(
+            AssertionError('ALTER must not execute'), observed.append)
+        case = system_test.TestQwpWsFuzz('test_add_columns')
+        thread._list_columns = case._list_columns
+        with mock.patch.object(system_test, 'sql_query',
+                               side_effect=TimeoutError('lookup timed out')):
+            self.assertFalse(thread._try_one_alter('weather0'))
+        self.assertEqual(counter[0], 0)
+        self.assertEqual(failures, [])
+        self.assertEqual(len(observed), 1)
+        self.assertIn("list_columns('weather0')", observed[0])
+        self.assertIn('lookup timed out', observed[0])
+
     def test_url_error_is_swallowed(self):
         self._assert_transient(urllib.error.URLError('Connection refused'))
 

--- a/system_test/test_qwp_ws_fuzz_unit.py
+++ b/system_test/test_qwp_ws_fuzz_unit.py
@@ -158,7 +158,7 @@ class AlterThreadTransientErrorTest(unittest.TestCase):
     (Windows mid-bounce) were classified as fatal alter failures."""
 
     @staticmethod
-    def _make_thread(sql_query_raises):
+    def _make_thread(sql_query_raises, on_transient_network_error=None):
         """Build an AlterThread without starting it. `sql_query_raises`
         is the exception class to raise on the next SQL call."""
         list_columns_result = [{'name': 'price', 'type': 'DOUBLE'}]
@@ -186,7 +186,8 @@ class AlterThreadTransientErrorTest(unittest.TestCase):
             stop_event=threading.Event(),
             record_failure=record_failure,
             failure_counter=failure_counter,
-            log=lambda _msg: None)
+            log=lambda _msg: None,
+            on_transient_network_error=on_transient_network_error)
         return thread, failure_counter, failures
 
     def _assert_transient(self, exc):
@@ -215,6 +216,20 @@ class AlterThreadTransientErrorTest(unittest.TestCase):
         # The exact failure that took Windows CI down:
         #   `fuzz alter: unexpected failure on weather2.location -> VARCHAR: timed out`
         self._assert_transient(TimeoutError('timed out'))
+
+    def test_timeout_notifies_diagnostics_callback(self):
+        observed = []
+        thread, counter, failures = self._make_thread(
+            TimeoutError('timed out'), observed.append)
+
+        result = thread._try_one_alter('weather0')
+
+        self.assertFalse(result)
+        self.assertEqual(counter[0], 0)
+        self.assertEqual(failures, [])
+        self.assertEqual(len(observed), 1)
+        self.assertIn('ALTER TABLE', observed[0])
+        self.assertIn('TimeoutError: timed out', observed[0])
 
     def test_url_error_is_swallowed(self):
         self._assert_transient(urllib.error.URLError('Connection refused'))

--- a/system_test/test_qwp_ws_kernel_preflight_unit.py
+++ b/system_test/test_qwp_ws_kernel_preflight_unit.py
@@ -9,11 +9,31 @@ import zipfile
 from unittest import mock
 
 from ci.diagnostics import kernel_wait_preflight as recorder
+from ci.diagnostics import decode_kernel_capture as decoder
 from ci.diagnostics.kernel_wait_preflight import command, decode_command, inspect_report, raw_command
 from ci.diagnostics.decode_kernel_capture import extract_member
 
 
 class KernelPreflightTest(unittest.TestCase):
+    def test_symbols_only_fetch_does_not_download_raw_or_run_decoder(self):
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            output = directory / 'output'
+            sources = ((1, 'unused', 'unused', 'spindump.raw'),
+                       (2, 'symbols', hashlib.sha256(b'symbol bytes').hexdigest(), 'symbols.spindump'))
+            def download(command, **kwargs):
+                self.assertEqual(command[0], 'curl')
+                with zipfile.ZipFile(command[-1], 'w') as z:
+                    z.writestr('symbols', b'symbol bytes')
+            with mock.patch.object(sys, 'argv', ['decoder', str(output), '--symbols-only',
+                                                 '--source-directory', str(directory / 'inputs')]), \
+                    mock.patch.object(decoder, 'SOURCES', sources), \
+                    mock.patch.object(decoder.subprocess, 'run', side_effect=download) as run:
+                decoder.main()
+            self.assertEqual(run.call_count, 1)
+            self.assertEqual((output / 'symbols.spindump').read_bytes(), b'symbol bytes')
+            self.assertFalse((output / 'spindump.raw').exists())
+
     def test_decoder_member_is_hash_pinned_and_does_not_extract_other_paths(self):
         with tempfile.TemporaryDirectory() as temp:
             directory = Path(temp)

--- a/system_test/test_qwp_ws_kernel_preflight_unit.py
+++ b/system_test/test_qwp_ws_kernel_preflight_unit.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import io
 import subprocess
 import sys
 import tempfile
@@ -10,6 +11,33 @@ from ci.diagnostics.kernel_wait_preflight import command, decode_command, inspec
 
 
 class KernelPreflightTest(unittest.TestCase):
+    def test_raw_timeout_forwards_partial_binary_and_native_error(self):
+        output, errors = io.BytesIO(), io.BytesIO()
+        failure = subprocess.TimeoutExpired('spindump', 30, output=b'partial', stderr=b'native detail')
+        with mock.patch.object(sys, 'argv', ['recorder', '/unused', '--record-raw']), \
+                mock.patch.object(recorder.subprocess, 'run', side_effect=failure), \
+                mock.patch.object(sys, 'stdout', mock.Mock(buffer=output)), \
+                mock.patch.object(sys, 'stderr', mock.Mock(buffer=errors)):
+            with self.assertRaises(subprocess.TimeoutExpired):
+                recorder.main()
+        self.assertEqual(output.getvalue(), b'partial')
+        self.assertEqual(errors.getvalue(), b'native detail')
+
+    def test_raw_controller_transfers_binary_over_pipes_without_files(self):
+        with tempfile.TemporaryDirectory() as temp:
+            output, errors = io.BytesIO(), io.BytesIO()
+            child = [sys.executable, '-c',
+                     'import sys; sys.stdout.buffer.write(bytes([0,255,10,13])); '
+                     'sys.stderr.write("sampler status")']
+            with mock.patch.object(sys, 'argv', ['recorder', temp, '--record-raw']), \
+                    mock.patch.object(recorder, 'raw_command', return_value=child), \
+                    mock.patch.object(sys, 'stdout', mock.Mock(buffer=output)), \
+                    mock.patch.object(sys, 'stderr', mock.Mock(buffer=errors)):
+                recorder.main()
+            self.assertEqual(output.getvalue(), bytes([0, 255, 10, 13]))
+            self.assertEqual(errors.getvalue(), b'sampler status')
+            self.assertEqual(list(Path(temp).iterdir()), [])
+
     def test_decode_timeout_preserves_raw_capture(self):
         with tempfile.TemporaryDirectory() as temp:
             directory = Path(temp)
@@ -29,16 +57,17 @@ class KernelPreflightTest(unittest.TestCase):
             directory = Path(temp)
             (directory / 'spindump.raw').touch()
             with mock.patch.object(sys, 'argv', ['recorder', temp, '--record-raw']), \
-                    mock.patch.object(recorder.subprocess, 'run'):
+                    mock.patch.object(recorder.subprocess, 'run',
+                                      return_value=subprocess.CompletedProcess([], 0, stdout=b'', stderr=b'')):
                 with self.assertRaisesRegex(RuntimeError, 'empty raw'):
                     recorder.main()
             self.assertFalse((directory / 'recorder-validation.json').exists())
 
-    def test_raw_capture_defers_symbols_and_keeps_explicit_path(self):
+    def test_raw_capture_defers_symbols_and_avoids_output_files(self):
         directory = Path('/artifact/kernel-stacks')
-        args = raw_command(directory)
+        args = raw_command()
         self.assertEqual(args, ['/usr/sbin/spindump', '-notarget', '3', '20',
-                                '-o', str(directory / 'spindump.raw'),
+                                '-noFile',
                                 '-noText', '-noSymbolicate', '-timelimit', '25',
                                 '-noProcessingWhileSampling'])
         decode = decode_command(directory)

--- a/system_test/test_qwp_ws_kernel_preflight_unit.py
+++ b/system_test/test_qwp_ws_kernel_preflight_unit.py
@@ -1,11 +1,52 @@
 from pathlib import Path
+import subprocess
+import sys
 import tempfile
 import unittest
+from unittest import mock
 
-from ci.diagnostics.kernel_wait_preflight import command, inspect_report
+from ci.diagnostics import kernel_wait_preflight as recorder
+from ci.diagnostics.kernel_wait_preflight import command, decode_command, inspect_report, raw_command
 
 
 class KernelPreflightTest(unittest.TestCase):
+    def test_decode_timeout_preserves_raw_capture(self):
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            raw = directory / 'spindump.raw'
+            raw.write_bytes(b'captured binary fixture')
+            with mock.patch.object(sys, 'argv', ['recorder', temp, '--decode']), \
+                    mock.patch.object(recorder.subprocess, 'run',
+                                      side_effect=subprocess.TimeoutExpired('spindump', 65)) as run:
+                with self.assertRaises(subprocess.TimeoutExpired):
+                    recorder.main()
+            self.assertEqual(raw.read_bytes(), b'captured binary fixture')
+            self.assertEqual(run.call_args.kwargs['timeout'], 65)
+            self.assertFalse((directory / 'decode-validation.json').exists())
+
+    def test_empty_raw_capture_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            (directory / 'spindump.raw').touch()
+            with mock.patch.object(sys, 'argv', ['recorder', temp, '--record-raw']), \
+                    mock.patch.object(recorder.subprocess, 'run'):
+                with self.assertRaisesRegex(RuntimeError, 'empty raw'):
+                    recorder.main()
+            self.assertFalse((directory / 'recorder-validation.json').exists())
+
+    def test_raw_capture_defers_symbols_and_keeps_explicit_path(self):
+        directory = Path('/artifact/kernel-stacks')
+        args = raw_command(directory)
+        self.assertEqual(args, ['/usr/sbin/spindump', '-notarget', '3', '20',
+                                '-o', str(directory / 'spindump.raw'),
+                                '-noText', '-noSymbolicate', '-timelimit', '25',
+                                '-noProcessingWhileSampling'])
+        decode = decode_command(directory)
+        self.assertEqual(decode[decode.index('-i')+1], str(directory / 'spindump.raw'))
+        self.assertIn('-symbolicate', decode)
+        self.assertIn('-noBinary', decode)
+        self.assertEqual(decode[-2:], ['-timelimit', '60'])
+
     def test_bounded_system_sample_and_explicit_output(self):
         with tempfile.TemporaryDirectory() as temp:
             directory = Path(temp)

--- a/system_test/test_qwp_ws_kernel_preflight_unit.py
+++ b/system_test/test_qwp_ws_kernel_preflight_unit.py
@@ -12,7 +12,8 @@ class KernelPreflightTest(unittest.TestCase):
             self.assertEqual(command(directory),
                 ['/usr/sbin/spindump', '-notarget', '3', '20',
                  '-o', str(directory / 'spindump.txt'), '-timeline', '-symbolicate',
-                 '-timelimit', '45', '-timestampsInCallTrees', 'all'])
+                 '-timelimit', '45', '-timestampsInCallTrees', 'all',
+                 '-noProcessingWhileSampling'])
 
     def test_named_kernel_frames_not_user_frames_or_image_list(self):
         result = inspect_report('kernel.release.vmapple\n'
@@ -26,3 +27,11 @@ class KernelPreflightTest(unittest.TestCase):
     def test_user_only_report_is_not_kernel_access(self):
         self.assertEqual(inspect_report('20 fsync (libsystem_kernel.dylib)')
                          ['named_kernel_frame_lines'], 0)
+
+    def test_hosted_report_v60_star_precedes_sample_count(self):
+        report = (' *156  IOWorkLoop::threadMain() + 0 (kernel.release.vmapple + 8226852)\n'
+                  '   *1    ??? (kernel.release.vmapple + 34328)\n'
+                  ' *0xfffffe0007d7c000 - 0xfffffe000866bfff kernel.release.vmapple\n')
+        result = inspect_report(report)
+        self.assertEqual(result['kernel_frame_lines'], 2)
+        self.assertEqual(result['named_kernel_frame_lines'], 1)

--- a/system_test/test_qwp_ws_kernel_preflight_unit.py
+++ b/system_test/test_qwp_ws_kernel_preflight_unit.py
@@ -11,7 +11,8 @@ class KernelPreflightTest(unittest.TestCase):
             directory = Path(temp)
             self.assertEqual(command(directory),
                 ['/usr/sbin/spindump', '-notarget', '3', '20',
-                 '-file', str(directory / 'spindump.txt'), '-timeline', '-symbolicate'])
+                 '-o', str(directory / 'spindump.txt'), '-timeline', '-symbolicate',
+                 '-timelimit', '45', '-timestampsInCallTrees', 'all'])
 
     def test_named_kernel_frames_not_user_frames_or_image_list(self):
         result = inspect_report('kernel.release.vmapple\n'

--- a/system_test/test_qwp_ws_kernel_preflight_unit.py
+++ b/system_test/test_qwp_ws_kernel_preflight_unit.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import tempfile
+import unittest
+
+from ci.diagnostics.kernel_wait_preflight import command, inspect_report
+
+
+class KernelPreflightTest(unittest.TestCase):
+    def test_bounded_system_sample_and_explicit_output(self):
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            self.assertEqual(command(directory),
+                ['/usr/sbin/spindump', '-notarget', '3', '20',
+                 '-file', str(directory / 'spindump.txt'), '-timeline', '-symbolicate'])
+
+    def test_named_kernel_frames_not_user_frames_or_image_list(self):
+        result = inspect_report('kernel.release.vmapple\n'
+                                '  20 malloc (libsystem_malloc.dylib)\n'
+                                '  15 *thread_block_reason + 123 (kernel)\n'
+                                '  12 *??? [0xfffffff]\n')
+        self.assertEqual(result['kernel_frame_lines'], 2)
+        self.assertEqual(result['named_kernel_frame_lines'], 1)
+        self.assertFalse(result['apfs_present'])
+
+    def test_user_only_report_is_not_kernel_access(self):
+        self.assertEqual(inspect_report('20 fsync (libsystem_kernel.dylib)')
+                         ['named_kernel_frame_lines'], 0)

--- a/system_test/test_qwp_ws_kernel_preflight_unit.py
+++ b/system_test/test_qwp_ws_kernel_preflight_unit.py
@@ -1,16 +1,39 @@
 from pathlib import Path
 import io
+import hashlib
 import subprocess
 import sys
 import tempfile
 import unittest
+import zipfile
 from unittest import mock
 
 from ci.diagnostics import kernel_wait_preflight as recorder
 from ci.diagnostics.kernel_wait_preflight import command, decode_command, inspect_report, raw_command
+from ci.diagnostics.decode_kernel_capture import extract_member
 
 
 class KernelPreflightTest(unittest.TestCase):
+    def test_decoder_member_is_hash_pinned_and_does_not_extract_other_paths(self):
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            archive = directory / 'input.zip'
+            output = directory / 'raw'
+            with zipfile.ZipFile(archive, 'w') as z:
+                z.writestr('wanted', b'raw bytes')
+                z.writestr('../unwanted', b'never extract')
+            with self.assertRaisesRegex(RuntimeError, 'hash mismatch'):
+                extract_member(archive, 'wanted', 'bad hash', output)
+            self.assertFalse(output.exists())
+            extract_member(archive, 'wanted', hashlib.sha256(b'raw bytes').hexdigest(), output)
+            self.assertEqual(output.read_bytes(), b'raw bytes')
+            self.assertEqual(sorted(p.name for p in directory.iterdir()), ['input.zip', 'raw'])
+
+    def test_decoder_uses_retained_symbols_not_live_process_inspection(self):
+        args = decode_command(Path('/capture'), Path('/retained/symbols'))
+        self.assertEqual(args[-2:], ['-symbols', '/retained/symbols'])
+        self.assertNotIn('-inspectLiveSystem', args)
+
     def test_raw_timeout_forwards_partial_binary_and_native_error(self):
         output, errors = io.BytesIO(), io.BytesIO()
         failure = subprocess.TimeoutExpired('spindump', 30, output=b'partial', stderr=b'native detail')

--- a/system_test/test_qwp_ws_pressure_unit.py
+++ b/system_test/test_qwp_ws_pressure_unit.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest import mock
+
+from qwp_ws_pressure import mode_for_run, wait_for_level
+
+
+class PressureTest(unittest.TestCase):
+    def test_balanced_plan(self):
+        self.assertEqual([mode_for_run('paired', n) for n in range(1, 13)],
+                         ['natural', 'warn', 'warn', 'natural'] * 3)
+        self.assertEqual(mode_for_run('natural', 2), 'natural')
+        self.assertEqual(mode_for_run('warn', 1), 'warn')
+        for plan, run in [('bad', 1), ('paired', 0)]:
+            with self.assertRaises(ValueError):
+                mode_for_run(plan, run)
+
+    def test_gate_requires_actual_target(self):
+        read = mock.Mock(side_effect=[1, 1, 2])
+        record, sleep = mock.Mock(), mock.Mock()
+        wait_for_level('warn', read, record, clock=lambda: 0, sleep=sleep)
+        self.assertEqual(record.call_args_list, [mock.call(1), mock.call(1), mock.call(2)])
+        self.assertEqual(sleep.call_count, 2)
+
+    def test_natural_waits_for_recovery(self):
+        read = mock.Mock(side_effect=[2, 1])
+        wait_for_level('natural', read, mock.Mock(), clock=lambda: 0, sleep=mock.Mock())
+        self.assertEqual(read.call_count, 2)
+
+    def test_gate_rejects_critical_unknown_and_unreached(self):
+        for level in (0, 4):
+            with self.assertRaisesRegex(RuntimeError, 'unsafe or unknown'):
+                wait_for_level('warn', lambda: level, mock.Mock())
+        with self.assertRaisesRegex(RuntimeError, 'not reached'):
+            wait_for_level('warn', mock.Mock(), mock.Mock(), clock=mock.Mock(side_effect=[0, 21]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/system_test/test_qwp_ws_pressure_unit.py
+++ b/system_test/test_qwp_ws_pressure_unit.py
@@ -26,6 +26,16 @@ class PressureTest(unittest.TestCase):
         wait_for_level('natural', read, mock.Mock(), clock=lambda: 0, sleep=mock.Mock())
         self.assertEqual(read.call_count, 2)
 
+    def test_warning_can_arrive_after_old_twenty_second_bound(self):
+        record = mock.Mock()
+        wait_for_level('warn', mock.Mock(side_effect=[1, 2]), record,
+                       timeout=45, clock=mock.Mock(side_effect=[0, 20, 36]),
+                       sleep=mock.Mock())
+        self.assertEqual(record.call_args_list, [mock.call(1), mock.call(2)])
+        with self.assertRaisesRegex(RuntimeError, 'not reached'):
+            wait_for_level('warn', mock.Mock(), mock.Mock(), timeout=45,
+                           clock=mock.Mock(side_effect=[0, 46]))
+
     def test_gate_rejects_critical_unknown_and_unreached(self):
         for level in (0, 4):
             with self.assertRaisesRegex(RuntimeError, 'unsafe or unknown'):

--- a/system_test/test_qwp_ws_soak_summary_unit.py
+++ b/system_test/test_qwp_ws_soak_summary_unit.py
@@ -1,0 +1,74 @@
+"""Check repetition telemetry without allocating a CI worker or starting Java."""
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).resolve().parents[1] / 'ci' / 'summarize_qwp_ws_run.py'
+SPEC = importlib.util.spec_from_file_location('qwp_soak_summary', SCRIPT)
+SUMMARY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(SUMMARY)
+
+
+class SoakSummaryTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.directory = Path(self.temp.name)
+        (self.directory / 'test.log').write_text('Ran 1 test in 8.234s\n\nOK\n')
+        self.write_events('watchdog.jsonl', [dict(event='ready'),
+                                           dict(event='ping', elapsed_ms=4.5, error=None),
+                                           dict(event='workload_finished')])
+        self.write_events('heartbeat.jsonl', [dict(event='heartbeat', gap_ms=251.1)])
+
+    def write_events(self, name, events):
+        (self.directory / name).write_text(''.join(json.dumps(event) + '\n' for event in events))
+
+    def test_success_without_capture(self):
+        result = SUMMARY.summarize(self.directory)
+        self.assertEqual(result['unittest_seconds'], 8.234)
+        self.assertEqual(result['ping_count'], 1)
+        self.assertEqual(result['ping_errors'], 0)
+        self.assertEqual(result['max_ping_ms'], 4.5)
+        self.assertEqual(result['max_heartbeat_gap_ms'], 251.1)
+        self.assertIsNone(result['capture_reason'])
+        self.assertEqual(result['missing_telemetry'], [])
+
+    def test_recovered_ping_stall_is_preserved(self):
+        self.write_events('watchdog.jsonl', [dict(event='ping', elapsed_ms=1002, error='timeout'),
+                                           dict(event='ping', elapsed_ms=2, error=None)])
+        (self.directory / 'capture-started').write_text('ping timeout\n')
+        result = SUMMARY.summarize(self.directory)
+        self.assertEqual(result['ping_errors'], 1)
+        self.assertEqual(result['max_ping_ms'], 1002)
+        self.assertEqual(result['capture_reason'], 'ping timeout')
+
+    def test_drain_metrics_match_test_progress_format(self):
+        (self.directory / 'test.log').write_text(
+            '[qwp_ws_fuzz] diagnostics event=drain-start, sender=t0\n'
+            '[qwp_ws_fuzz] diagnostics event=drain-complete, sender=t0, elapsed=3.576s\n'
+            '[qwp_ws_fuzz] diagnostics event=drain-complete, sender=t1, elapsed=0.450s\n'
+            '[qwp_ws_fuzz] diagnostics event=producer-failed, sender=t2, elapsed=120.001s\n')
+        result = SUMMARY.summarize(self.directory)
+        self.assertEqual(result['max_drain_seconds'], 3.576)
+        self.assertIsNone(result['unittest_seconds'])
+
+    def test_no_probe_is_not_reported_as_zero_latency(self):
+        self.write_events('watchdog.jsonl', [dict(event='ready')])
+        self.assertIsNone(SUMMARY.summarize(self.directory)['max_ping_ms'])
+
+    def test_missing_file_is_explicit(self):
+        (self.directory / 'heartbeat.jsonl').unlink()
+        result = SUMMARY.summarize(self.directory)
+        self.assertEqual(result['missing_telemetry'], ['heartbeat.jsonl'])
+        self.assertIsNone(result['max_heartbeat_gap_ms'])
+
+    def test_truncated_json_is_not_a_healthy_record(self):
+        (self.directory / 'watchdog.jsonl').write_text('{"event":')
+        with self.assertRaises(json.JSONDecodeError):
+            SUMMARY.summarize(self.directory)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/system_test/test_qwp_ws_soak_summary_unit.py
+++ b/system_test/test_qwp_ws_soak_summary_unit.py
@@ -34,6 +34,16 @@ class SoakSummaryTest(unittest.TestCase):
         self.assertEqual(result['max_heartbeat_gap_ms'], 251.1)
         self.assertIsNone(result['capture_reason'])
         self.assertEqual(result['missing_telemetry'], [])
+        self.assertFalse(result['system_trace'])
+        self.assertFalse(result['system_trace_valid'])
+
+    def test_trace_error_overrides_valid_marker(self):
+        (self.directory / 'system-trace-enabled').touch()
+        (self.directory / 'system-trace-valid.json').write_text('{}')
+        self.assertTrue(SUMMARY.summarize(self.directory)['system_trace'])
+        self.assertTrue(SUMMARY.summarize(self.directory)['system_trace_valid'])
+        (self.directory / 'system-trace-error.json').write_text('{}')
+        self.assertFalse(SUMMARY.summarize(self.directory)['system_trace_valid'])
 
     def test_recovered_ping_stall_is_preserved(self):
         self.write_events('watchdog.jsonl', [dict(event='ping', elapsed_ms=1002, error='timeout'),

--- a/system_test/test_qwp_ws_startup_gate_unit.py
+++ b/system_test/test_qwp_ws_startup_gate_unit.py
@@ -1,0 +1,51 @@
+import unittest
+
+from qwp_ws_startup_gate import StartupGate
+
+
+class StartupGateTest(unittest.TestCase):
+    def test_releases_only_after_actual_missing_lookups(self):
+        gate = StartupGate(3, lambda _: None)
+        calls = []
+
+        def missing(table):
+            calls.append(table)
+            raise RuntimeError(f'table does not exist [table={table}]')
+
+        for index in range(3):
+            with self.assertRaisesRegex(RuntimeError, 'table does not exist'):
+                gate.lookup(missing, f'weather{index}')
+            self.assertEqual(gate.ready.is_set(), index == 2)
+        gate.wait()
+        self.assertEqual(calls, ['weather0', 'weather1', 'weather2'])
+        self.assertEqual(gate.lookup(lambda _: ['column'], 'weather0'), ['column'])
+        self.assertEqual(gate.count, 3)
+
+    def test_unexpected_error_unblocks_producers_with_failure(self):
+        gate = StartupGate(72, lambda _: None)
+
+        def timeout(_):
+            raise TimeoutError('network timeout')
+
+        with self.assertRaises(TimeoutError):
+            gate.lookup(timeout, 'weather0')
+        with self.assertRaisesRegex(RuntimeError, 'unexpected startup lookup'):
+            gate.wait()
+        self.assertEqual(gate.count, 0)
+
+    def test_existing_table_is_not_counted(self):
+        gate = StartupGate(72, lambda _: None)
+        with self.assertRaisesRegex(RuntimeError, 'existing table'):
+            gate.lookup(lambda _: [], 'weather0')
+        with self.assertRaisesRegex(RuntimeError, 'existing table'):
+            gate.wait()
+
+    def test_wait_is_bounded(self):
+        gate = StartupGate(72, lambda _: None, timeout=0)
+        with self.assertRaises(TimeoutError):
+            gate.wait()
+
+    def test_invalid_target(self):
+        for count in (0, -1, 201):
+            with self.assertRaises(ValueError):
+                StartupGate(count, lambda _: None)

--- a/system_test/test_qwp_ws_system_trace_unit.py
+++ b/system_test/test_qwp_ws_system_trace_unit.py
@@ -1,0 +1,259 @@
+"""Exercise trace validation and collector failure paths without macOS or sudo."""
+
+import json
+from pathlib import Path
+import signal
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+import qwp_ws_system_trace as trace
+import qwp_ws_trace_export as export
+
+
+ROWS = '''<trace-query-result><node>
+<row><thread id="t"><process id="p"><pid id="pid">123</pid></process></thread></row>
+<row><thread ref="t"/></row>
+<row><process ref="p"/></row>
+<row><process><pid ref="pid"/></process></row>
+<row><process><pid>456</pid></process></row>
+</node></trace-query-result>'''
+
+
+class TraceExportTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.directory = Path(self.temp.name)
+
+    def toc(self, schemas=('time-sample', 'syscall', 'thread-state')):
+        return '<trace-toc><run><data>' + ''.join(
+            f'<table schema="{schema}"/>' for schema in schemas) + '</data></run></trace-toc>'
+
+    def fake_export(self, command, **kwargs):
+        self.assertTrue(kwargs['check'])
+        self.assertLessEqual(kwargs['timeout'], 30)
+        output = Path(command[command.index('--output') + 1])
+        output.write_text(self.toc() if '--toc' in command else ROWS)
+
+    def test_discovers_numeric_positions_without_accepting_cpu_samples(self):
+        path = self.directory / 'toc.xml'
+        path.write_text(self.toc(('time-sample', 'thread-state-sample', 'syscall',
+                                  'thread-state')))
+        self.assertEqual(export.discover_tables(path), [
+            (3, 'syscall', 'syscall'), (4, 'thread-state', 'thread-state')])
+
+    def test_rejects_ambiguous_multiple_recording_runs(self):
+        path = self.directory / 'toc.xml'
+        path.write_text('<trace-toc><run/><run/></trace-toc>')
+        with self.assertRaisesRegex(RuntimeError, 'exactly one'):
+            export.discover_tables(path)
+
+    def test_resolves_nested_pid_references_across_discarded_rows(self):
+        path = self.directory / 'rows.xml'
+        path.write_text(ROWS)
+        self.assertEqual(export.inspect_rows(path, 123), dict(rows=5, target_rows=4))
+        self.assertEqual(export.inspect_rows(path, 456), dict(rows=5, target_rows=1))
+        self.assertEqual(export.inspect_rows(path, 789), dict(rows=5, target_rows=0))
+
+    def test_empty_table_is_not_evidence(self):
+        path = self.directory / 'rows.xml'
+        path.write_text('<trace-query-result><node/></trace-query-result>')
+        self.assertEqual(export.inspect_rows(path, 123), dict(rows=0, target_rows=0))
+
+    def test_validation_deadline_bounds_large_xml(self):
+        path = self.directory / 'rows.xml'
+        path.write_text('<node>' + '<row><pid>123</pid></row>' * 2000 + '</node>')
+        with self.assertRaisesRegex(RuntimeError, 'time budget'):
+            export.inspect_rows(path, 123, deadline=0)
+
+    def test_exports_both_event_tables_and_validates_target_not_just_trace_directory(self):
+        with mock.patch.object(export.subprocess, 'run', side_effect=self.fake_export) as run:
+            result = export.export_and_validate(self.directory, 123)
+        self.assertEqual(len(result['tables']), 2)
+        self.assertEqual([row['target_rows'] for row in result['tables']], [4, 4])
+        self.assertEqual(run.call_args_list[1].args[0][-3],
+                         '/trace-toc/run[1]/data/table[2]')
+        self.assertEqual(run.call_args_list[2].args[0][-3],
+                         '/trace-toc/run[1]/data/table[3]')
+        self.assertTrue((self.directory / 'system-trace-valid.json').exists())
+
+    def test_events_for_other_pid_do_not_pass(self):
+        with mock.patch.object(export.subprocess, 'run', side_effect=self.fake_export):
+            with self.assertRaisesRegex(RuntimeError, 'No syscall events for target PID 789'):
+                export.export_and_validate(self.directory, 789)
+        self.assertFalse((self.directory / 'system-trace-valid.json').exists())
+
+    def test_missing_scheduler_table_fails_preflight(self):
+        def fake(command, **kwargs):
+            Path(command[-1]).write_text(self.toc(('syscall', 'time-sample')))
+
+        with mock.patch.object(export.subprocess, 'run', side_effect=fake):
+            with self.assertRaisesRegex(RuntimeError, 'lacks syscall/thread-state'):
+                export.export_and_validate(self.directory, 123)
+
+    def test_export_tool_error_cannot_produce_valid_marker(self):
+        with mock.patch.object(export.subprocess, 'run',
+                               side_effect=subprocess.CalledProcessError(1, 'xctrace')):
+            with self.assertRaises(subprocess.CalledProcessError):
+                export.export_and_validate(self.directory, 123)
+        self.assertFalse((self.directory / 'system-trace-valid.json').exists())
+
+
+class CollectorTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.directory = Path(self.temp.name)
+        self.child = mock.Mock(returncode=None)
+        self.child.poll.side_effect = lambda: self.child.returncode
+
+        def finish(**kwargs):
+            self.child.returncode = 0
+            return 0
+
+        self.child.wait.side_effect = finish
+        self.notification = mock.Mock(name='notification')
+        self.notification.name = 'test-ready-notification'
+        self.notification.check.return_value = True
+        self.patch(trace, 'StartedNotification', return_value=self.notification)
+        self.launch = self.patch(trace.subprocess, 'Popen', return_value=self.child)
+        self.validate = self.patch(trace, 'export_and_validate')
+        self.patch(trace.os, 'kill')
+        self.disk = self.patch(trace.shutil, 'disk_usage', return_value=mock.Mock(free=10**12))
+
+    def patch(self, target, name, **kwargs):
+        patcher = mock.patch.object(target, name, **kwargs)
+        result = patcher.start()
+        self.addCleanup(patcher.stop)
+        return result
+
+    def request(self):
+        self.assertTrue((self.directory / 'system-trace-ready.json').exists())
+        trace.request_stop(self.directory, 'ping timeout')
+
+    def assert_failed(self):
+        self.assertTrue((self.directory / 'system-trace-error.json').exists())
+        self.assertTrue((self.directory / 'system-trace-finished.json').exists())
+        self.validate.assert_not_called()
+        self.notification.close.assert_called_once()
+
+    def test_ready_then_sigint_then_export_and_signal_handlers_restored(self):
+        previous = signal.getsignal(signal.SIGTERM)
+
+        def validate(directory, pid):
+            self.child.send_signal.assert_called_once_with(signal.SIGINT)
+            self.assertEqual(self.child.returncode, 0)
+            self.assertTrue((directory / 'system-trace-stop-sent.json').exists())
+
+        self.validate.side_effect = validate
+        trace.collect(self.directory, 123, on_ready=self.request)
+        self.assertEqual(signal.getsignal(signal.SIGTERM), previous)
+        self.assertEqual(self.launch.call_args.args[0], [
+            '/usr/bin/xcrun', 'xctrace', 'record', '--template', 'System Trace',
+            '--attach', '123', '--time-limit', '30s', '--no-prompt',
+            '--notify-tracing-started', 'test-ready-notification',
+            '--output', str(self.directory / 'system.trace')])
+        self.validate.assert_called_once_with(self.directory, 123)
+        self.assertFalse((self.directory / 'system-trace-error.json').exists())
+
+    def test_first_stop_request_preserves_original_clock_and_reason(self):
+        trace.request_stop(self.directory, 'ping timeout')
+        first = (self.directory / 'system-trace-stop-request.json').read_text()
+        trace.request_stop(self.directory, 'workload-finished')
+        self.assertEqual((self.directory / 'system-trace-stop-request.json').read_text(), first)
+        self.assertGreater(json.loads(first)['monotonic_ns'], 0)
+
+    def test_recorder_exits_without_ready(self):
+        self.notification.check.return_value = False
+        self.child.returncode = 1
+        with self.assertRaisesRegex(RuntimeError, 'did not signal readiness'):
+            trace.collect(self.directory, 123)
+        self.assertFalse((self.directory / 'system-trace-ready.json').exists())
+        self.assert_failed()
+
+    def test_disk_guard_stops_and_reaps_recorder(self):
+        self.disk.return_value.free = 0
+        with self.assertRaisesRegex(RuntimeError, 'disk-space safety stop'):
+            trace.collect(self.directory, 123)
+        self.child.send_signal.assert_called_once_with(signal.SIGINT)
+        self.child.wait.assert_called_once()
+        self.assert_failed()
+
+    def test_recording_expiry_is_not_a_successful_capture(self):
+        with mock.patch.object(trace, 'RECORD_SECONDS', 0):
+            with self.assertRaisesRegex(RuntimeError, 'Recording expired'):
+                trace.collect(self.directory, 123)
+        self.assert_failed()
+
+    def test_nonzero_recording_exit_is_a_failure(self):
+        def finish(**kwargs):
+            self.child.returncode = 2
+            return 2
+
+        self.child.wait.side_effect = finish
+        with self.assertRaisesRegex(RuntimeError, 'xctrace exited 2'):
+            trace.collect(self.directory, 123, on_ready=self.request)
+        self.assert_failed()
+
+    def test_delayed_stop_is_rejected(self):
+        def request():
+            self.request()
+            path = self.directory / 'system-trace-stop-request.json'
+            contents = json.loads(path.read_text())
+            contents['monotonic_ns'] -= 3_000_000_000
+            path.write_text(json.dumps(contents))
+
+        with self.assertRaisesRegex(RuntimeError, 'over two seconds late'):
+            trace.collect(self.directory, 123, on_ready=request)
+        self.assert_failed()
+
+    def test_cancellation_stops_and_reaps_owned_child(self):
+        def cancel():
+            signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+
+        with self.assertRaisesRegex(RuntimeError, 'collector interrupted'):
+            trace.collect(self.directory, 123, on_ready=cancel)
+        self.child.send_signal.assert_called_once_with(signal.SIGINT)
+        self.assert_failed()
+
+    def test_hung_finalization_is_killed_and_marked_failed(self):
+        self.child.wait.side_effect = [subprocess.TimeoutExpired('xctrace', 30),
+                                       subprocess.TimeoutExpired('xctrace', 30), 0]
+        with self.assertRaisesRegex(RuntimeError, 'did not finalize'):
+            trace.collect(self.directory, 123, on_ready=self.request)
+        self.child.kill.assert_called_once()
+        self.assert_failed()
+
+
+class NotificationTest(unittest.TestCase):
+    def test_initial_registration_state_is_consumed_before_real_ready(self):
+        library = mock.Mock()
+        library.notify_register_check.return_value = 0
+        changes = iter([1, 0, 1])
+
+        def check(token, changed):
+            changed._obj.value = next(changes)
+            return 0
+
+        library.notify_check.side_effect = check
+        with mock.patch.object(trace.ctypes, 'CDLL', return_value=library):
+            notification = trace.StartedNotification()
+            self.assertFalse(notification.check())
+            self.assertTrue(notification.check())
+            notification.close()
+        library.notify_cancel.assert_called_once_with(notification.token)
+
+    def test_notification_failure_is_explicit(self):
+        library = mock.Mock()
+        library.notify_register_check.return_value = 0
+        library.notify_check.return_value = 1
+        with mock.patch.object(trace.ctypes, 'CDLL', return_value=library):
+            with self.assertRaisesRegex(RuntimeError, 'Cannot check'):
+                trace.StartedNotification()
+        library.notify_cancel.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/system_test/test_qwp_ws_system_trace_unit.py
+++ b/system_test/test_qwp_ws_system_trace_unit.py
@@ -191,7 +191,7 @@ class CollectorTest(unittest.TestCase):
 
         self.patch(trace.time, 'sleep', side_effect=advance)
 
-    def test_slow_preflight_start_is_allowed_without_extending_test_gate(self):
+    def test_observed_18_second_start_is_allowed(self):
         self.simulated_clock()
         self.notification.check.side_effect = lambda: self.elapsed >= 18
         trace.collect(self.directory, 123, on_ready=self.request,
@@ -199,11 +199,11 @@ class CollectorTest(unittest.TestCase):
         ready = json.loads((self.directory / 'system-trace-ready.json').read_text())
         self.assertGreaterEqual(ready['startup_seconds'], 18)
         self.assertEqual(trace.PREFLIGHT_START_TIMEOUT, 60)
-        self.assertEqual(trace.START_TIMEOUT, 15)
+        self.assertEqual(trace.START_TIMEOUT, 60)
         self.startup_diagnostics.assert_not_called()
         self.validate.assert_called_once()
 
-    def test_default_gate_still_fails_at_15_seconds_with_original_state_saved(self):
+    def test_startup_still_fails_at_60_seconds_with_original_state_saved(self):
         self.simulated_clock()
         self.notification.check.return_value = False
 
@@ -217,9 +217,9 @@ class CollectorTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, 'readiness_timeout'):
             trace.collect(self.directory, 123)
         failure = json.loads((self.directory / 'system-trace-startup-failure.json').read_text())
-        self.assertGreaterEqual(failure['elapsed_seconds'], 15)
-        self.assertLess(failure['elapsed_seconds'], 15.1)
-        self.assertEqual(failure['timeout_seconds'], 15)
+        self.assertGreaterEqual(failure['elapsed_seconds'], 60)
+        self.assertLess(failure['elapsed_seconds'], 60.1)
+        self.assertEqual(failure['timeout_seconds'], 60)
         exit_event = json.loads((self.directory / 'system-trace-recorder-exit.json').read_text())
         self.assertEqual(exit_event['returncode'], 0)  # after our cleanup, not spontaneous
         self.startup_diagnostics.assert_called_once_with(self.directory, self.child, 123)

--- a/system_test/test_qwp_ws_system_trace_unit.py
+++ b/system_test/test_qwp_ws_system_trace_unit.py
@@ -4,12 +4,16 @@ import json
 from pathlib import Path
 import signal
 import subprocess
+import sys
 import tempfile
 import unittest
 from unittest import mock
 
 import qwp_ws_system_trace as trace
 import qwp_ws_trace_export as export
+
+REAL_POPEN = subprocess.Popen
+REAL_KILL = trace.os.kill
 
 
 ROWS = '''<trace-query-result><node>
@@ -106,7 +110,7 @@ class CollectorTest(unittest.TestCase):
         self.temp = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp.cleanup)
         self.directory = Path(self.temp.name)
-        self.child = mock.Mock(returncode=None)
+        self.child = mock.Mock(pid=321, returncode=None)
         self.child.poll.side_effect = lambda: self.child.returncode
 
         def finish(**kwargs):
@@ -120,6 +124,7 @@ class CollectorTest(unittest.TestCase):
         self.patch(trace, 'StartedNotification', return_value=self.notification)
         self.launch = self.patch(trace.subprocess, 'Popen', return_value=self.child)
         self.validate = self.patch(trace, 'export_and_validate')
+        self.startup_diagnostics = self.patch(trace, 'capture_startup_state')
         self.patch(trace.os, 'kill')
         self.disk = self.patch(trace.shutil, 'disk_usage', return_value=mock.Mock(free=10**12))
 
@@ -168,10 +173,173 @@ class CollectorTest(unittest.TestCase):
     def test_recorder_exits_without_ready(self):
         self.notification.check.return_value = False
         self.child.returncode = 1
-        with self.assertRaisesRegex(RuntimeError, 'did not signal readiness'):
+        with self.assertRaisesRegex(RuntimeError, 'recorder_exited'):
             trace.collect(self.directory, 123)
         self.assertFalse((self.directory / 'system-trace-ready.json').exists())
+        failure = json.loads((self.directory / 'system-trace-startup-failure.json').read_text())
+        self.assertEqual(failure['returncode_before_cleanup'], 1)
+        self.assertEqual(failure['recorder_pid'], 321)
+        self.child.send_signal.assert_not_called()
         self.assert_failed()
+
+    def simulated_clock(self):
+        self.elapsed = 0
+        self.patch(trace.time, 'monotonic', side_effect=lambda: self.elapsed)
+
+        def advance(seconds):
+            self.elapsed += seconds
+
+        self.patch(trace.time, 'sleep', side_effect=advance)
+
+    def test_slow_preflight_start_is_allowed_without_extending_test_gate(self):
+        self.simulated_clock()
+        self.notification.check.side_effect = lambda: self.elapsed >= 18
+        trace.collect(self.directory, 123, on_ready=self.request,
+                      start_timeout=trace.PREFLIGHT_START_TIMEOUT)
+        ready = json.loads((self.directory / 'system-trace-ready.json').read_text())
+        self.assertGreaterEqual(ready['startup_seconds'], 18)
+        self.assertEqual(trace.PREFLIGHT_START_TIMEOUT, 60)
+        self.assertEqual(trace.START_TIMEOUT, 15)
+        self.startup_diagnostics.assert_not_called()
+        self.validate.assert_called_once()
+
+    def test_default_gate_still_fails_at_15_seconds_with_original_state_saved(self):
+        self.simulated_clock()
+        self.notification.check.return_value = False
+
+        def diagnose(*_args):
+            self.child.send_signal.assert_not_called()
+            failure = json.loads((self.directory / 'system-trace-startup-failure.json').read_text())
+            self.assertEqual(failure['reason'], 'readiness_timeout')
+            self.assertIsNone(failure['returncode_before_cleanup'])
+
+        self.startup_diagnostics.side_effect = diagnose
+        with self.assertRaisesRegex(RuntimeError, 'readiness_timeout'):
+            trace.collect(self.directory, 123)
+        failure = json.loads((self.directory / 'system-trace-startup-failure.json').read_text())
+        self.assertGreaterEqual(failure['elapsed_seconds'], 15)
+        self.assertLess(failure['elapsed_seconds'], 15.1)
+        self.assertEqual(failure['timeout_seconds'], 15)
+        exit_event = json.loads((self.directory / 'system-trace-recorder-exit.json').read_text())
+        self.assertEqual(exit_event['returncode'], 0)  # after our cleanup, not spontaneous
+        self.startup_diagnostics.assert_called_once_with(self.directory, self.child, 123)
+        self.assert_failed()
+
+    def test_failed_startup_diagnostics_cannot_hide_original_error_or_skip_cleanup(self):
+        self.notification.check.return_value = False
+        self.startup_diagnostics.side_effect = OSError('sample unavailable')
+        with self.assertRaisesRegex(RuntimeError, 'readiness_timeout'):
+            trace.collect(self.directory, 123, start_timeout=0)
+        self.child.send_signal.assert_called_once_with(signal.SIGINT)
+        self.assertTrue((self.directory / 'system-trace-startup-diagnostics-error.json').exists())
+        self.assert_failed()
+
+    def test_cancellation_during_startup_does_not_wait_for_sampling(self):
+        def cancel():
+            signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+            return False
+
+        self.notification.check.side_effect = cancel
+        with self.assertRaisesRegex(RuntimeError, 'startup interrupted'):
+            trace.collect(self.directory, 123)
+        self.startup_diagnostics.assert_not_called()
+        self.child.send_signal.assert_called_once_with(signal.SIGINT)
+        self.assert_failed()
+
+    def test_cleanup_marker_write_failure_cannot_leak_recorder(self):
+        original_marker = trace.marker
+
+        def marker(directory, name, **fields):
+            if name == 'system-trace-cleanup.json':
+                raise OSError('injected diagnostic write failure')
+            original_marker(directory, name, **fields)
+
+        self.notification.check.return_value = False
+        with mock.patch.object(trace, 'marker', side_effect=marker):
+            with self.assertRaisesRegex(OSError, 'injected diagnostic write failure'):
+                trace.collect(self.directory, 123, start_timeout=0)
+        self.child.send_signal.assert_called_once_with(signal.SIGINT)
+        self.assertEqual(self.child.returncode, 0)
+        self.assert_failed()
+
+    def test_preflight_passes_its_own_longer_deadline_to_collector(self):
+        target = mock.Mock(pid=456, returncode=0)
+        target.poll.return_value = 0
+        with mock.patch.object(trace.subprocess, 'run'), \
+                mock.patch.object(trace.subprocess, 'Popen', return_value=target), \
+                mock.patch.object(trace, 'collect') as collect:
+            trace.preflight(self.directory)
+        self.assertEqual(collect.call_args.kwargs['start_timeout'], 60)
+        self.assertFalse((self.directory / 'smoke-go').exists())
+        collect.call_args.kwargs['on_ready']()
+        self.assertTrue((self.directory / 'smoke-go').exists())
+
+    def test_smoke_target_survives_old_25_second_deadline_and_waits_for_ready(self):
+        self.simulated_clock()
+        elapsed_at_start = []
+        original_sleep = trace.time.sleep.side_effect
+
+        def advance(seconds):
+            original_sleep(seconds)
+            if self.elapsed >= 50 and not (self.directory / 'smoke-go').exists():
+                elapsed_at_start.append(self.elapsed)
+                (self.directory / 'smoke-go').touch()
+            if (self.directory / 'system-trace-stop-request.json').exists():
+                (self.directory / 'system-trace-finished.json').touch()
+
+        trace.time.sleep.side_effect = advance
+        trace.smoke_target(self.directory)
+        self.assertGreaterEqual(elapsed_at_start[0], 50)
+        self.assertTrue((self.directory / 'smoke-end.json').exists())
+
+    def test_smoke_target_leaves_parent_startup_failure_intact(self):
+        (self.directory / 'system-trace-finished.json').write_text('{}')
+        (self.directory / 'system-trace-error.json').write_text('original startup failure')
+        trace.smoke_target(self.directory)
+        self.assertFalse((self.directory / 'smoke-start.json').exists())
+        self.assertEqual((self.directory / 'system-trace-error.json').read_text(),
+                         'original startup failure')
+
+    def test_real_recorder_exit_status_survives_cleanup(self):
+        self.notification.check.return_value = False
+        self.launch.side_effect = lambda _command, **kwargs: REAL_POPEN(
+            [sys.executable, '-c', 'raise SystemExit(7)'], **kwargs)
+        with self.assertRaisesRegex(RuntimeError, 'recorder_exited'):
+            trace.collect(self.directory, 123, start_timeout=5)
+        failure = json.loads((self.directory / 'system-trace-startup-failure.json').read_text())
+        exited = json.loads((self.directory / 'system-trace-recorder-exit.json').read_text())
+        self.assertEqual(failure['returncode_before_cleanup'], 7)
+        self.assertEqual(exited['returncode'], 7)
+        self.assert_failed()
+
+    def test_real_stalled_recorder_is_stopped_and_reaped(self):
+        self.notification.check.return_value = False
+        children = []
+
+        def launch(_command, **kwargs):
+            child = REAL_POPEN([
+                sys.executable, '-c',
+                'import signal, time; signal.signal(signal.SIGINT, signal.SIG_DFL); time.sleep(30)'],
+                **kwargs)
+            children.append(child)
+            return child
+
+        self.launch.side_effect = launch
+        # Popen.send_signal uses os.kill too; do not let the target-liveness
+        # mock silently turn this real-child cleanup check into a 30s sleep.
+        with mock.patch.object(trace.os, 'kill', REAL_KILL):
+            try:
+                with self.assertRaisesRegex(RuntimeError, 'readiness_timeout'):
+                    trace.collect(self.directory, 123, start_timeout=0.1)
+                self.assertEqual(children[0].returncode, -signal.SIGINT)
+                failure = json.loads((self.directory / 'system-trace-startup-failure.json').read_text())
+                self.assertIsNone(failure['returncode_before_cleanup'])
+                self.assert_failed()
+            finally:
+                for child in children:
+                    if child.poll() is None:
+                        child.kill()
+                        child.wait(timeout=5)
 
     def test_disk_guard_stops_and_reaps_recorder(self):
         self.disk.return_value.free = 0
@@ -225,6 +393,45 @@ class CollectorTest(unittest.TestCase):
             trace.collect(self.directory, 123, on_ready=self.request)
         self.child.kill.assert_called_once()
         self.assert_failed()
+
+
+class StartupDiagnosticsTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.directory = Path(self.temp.name)
+        self.child = mock.Mock(pid=321)
+
+    def test_samples_live_recorder_with_explicit_path_and_bounded_commands(self):
+        self.child.poll.return_value = None
+        with mock.patch.object(trace.subprocess, 'run', return_value=mock.Mock(returncode=0)) as run:
+            trace.capture_startup_state(self.directory, self.child, 123)
+        self.assertEqual(run.call_count, 2)
+        self.assertEqual(run.call_args_list[0].args[0][:2], ['/bin/ps', '-p'])
+        self.assertTrue(run.call_args_list[0].args[0][2].startswith('321,123,'))
+        self.assertEqual(run.call_args_list[0].kwargs['timeout'], 5)
+        self.assertEqual(run.call_args_list[1].args[0], [
+            '/usr/bin/sample', '321', '1', '10', '-file',
+            str(self.directory / 'system-trace-startup-sample.txt')])
+        self.assertEqual(run.call_args_list[1].kwargs['timeout'], 10)
+        details = json.loads((self.directory / 'system-trace-startup-diagnostics.json').read_text())
+        self.assertEqual([c['returncode'] for c in details['commands']], [0, 0])
+
+    def test_exited_recorder_is_not_sampled(self):
+        self.child.poll.return_value = 1
+        with mock.patch.object(trace.subprocess, 'run', return_value=mock.Mock(returncode=0)) as run:
+            trace.capture_startup_state(self.directory, self.child, 123)
+        run.assert_called_once()
+
+    def test_failed_process_snapshot_does_not_suppress_sample_or_failure_details(self):
+        self.child.poll.return_value = None
+        with mock.patch.object(trace.subprocess, 'run', side_effect=[
+                subprocess.TimeoutExpired('ps', 5), mock.Mock(returncode=3)]) as run:
+            trace.capture_startup_state(self.directory, self.child, 123)
+        self.assertEqual(run.call_count, 2)
+        details = json.loads((self.directory / 'system-trace-startup-diagnostics.json').read_text())
+        self.assertIn('TimeoutExpired', details['commands'][0]['error'])
+        self.assertEqual(details['commands'][1]['returncode'], 3)
 
 
 class NotificationTest(unittest.TestCase):

--- a/system_test/test_qwp_ws_trace_decode_unit.py
+++ b/system_test/test_qwp_ws_trace_decode_unit.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+import tempfile
+import unittest
+import zipfile
+
+from ci.diagnostics.decode_system_trace import PREFIX, content_hash, extract, selections
+
+
+class TraceDecodeTest(unittest.TestCase):
+    def test_selects_vm_and_scheduler_without_guessing_positions(self):
+        with tempfile.TemporaryDirectory() as temp:
+            toc = Path(temp) / 'toc.xml'
+            toc.write_text('<trace-toc><run><data>'
+                           '<table schema="syscall"/>'
+                           '<table schema="virtual-memory"/>'
+                           '<table schema="context-switch"/>'
+                           '<table schema="kdebug" codes="0x1,0x40"/>'
+                           '</data></run></trace-toc>')
+            self.assertEqual([index for index, _ in selections(toc)], [2, 3, 4])
+
+    def test_missing_required_table_fails(self):
+        with tempfile.TemporaryDirectory() as temp:
+            toc = Path(temp) / 'toc.xml'
+            toc.write_text('<trace-toc><run><data/></run></trace-toc>')
+            with self.assertRaises(RuntimeError):
+                selections(toc)
+
+    def test_contents_not_zip_packaging_define_identity(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            digests = []
+            for number, compression in enumerate((zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED)):
+                archive = root / f'{number}.zip'
+                with zipfile.ZipFile(archive, 'w', compression=compression) as output:
+                    output.writestr(PREFIX + 'system.trace/data', b'original recording')
+                    output.writestr('unrelated-run/data', b'not selected')
+                digests.append(content_hash(archive))
+            self.assertEqual(digests[0], digests[1])
+            destination = root / 'out'
+            destination.mkdir()
+            extract(archive, destination)
+            self.assertEqual((destination / 'system.trace/data').read_bytes(), b'original recording')
+            self.assertFalse((destination / 'unrelated-run').exists())
+
+    def test_parent_escape_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive = root / 'bad.zip'
+            with zipfile.ZipFile(archive, 'w') as output:
+                output.writestr(PREFIX + '../escape', b'bad')
+            with self.assertRaises(ValueError):
+                extract(archive, root)

--- a/system_test/test_qwp_ws_watchdog_unit.py
+++ b/system_test/test_qwp_ws_watchdog_unit.py
@@ -22,6 +22,39 @@ def wait_for(predicate):
 
 
 class WatchdogTest(unittest.TestCase):
+    def test_query_observer_fallback_waits_for_first_data_and_tracks_progress(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            progress = watchdog.QueryObserverProgress(directory)
+            self.assertIsNone(progress.check(0))
+            self.assertIsNone(progress.check(100))
+            path = directory / 'show-columns.tsv'
+            path.write_text('heartbeat\n')
+            self.assertIsNone(progress.check(101))
+            self.assertIsNone(progress.check(105.9))
+            self.assertIn('5.000s', progress.check(106))
+            path.write_text('heartbeat\nheartbeat\n')
+            self.assertIsNone(progress.check(107))
+            self.assertIsNone(progress.check(111.9))
+            self.assertIn('cause unknown', progress.check(112))
+            path.unlink()
+            self.assertIn('cause unknown', progress.check(113))
+
+    def test_query_arm_captures_observer_loss_even_when_ping_is_healthy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            for name in ('start-test', 'show-columns-enabled'):
+                (directory / name).touch()
+            stop = threading.Event()
+            opener = mock.MagicMock()
+            opener.open.return_value.__enter__.return_value.status = 204
+            reason = 'Java query observer telemetry stopped advancing for 5.000s; cause unknown'
+            with mock.patch.object(watchdog.urllib.request, 'build_opener', return_value=opener), \
+                    mock.patch.object(watchdog.QueryObserverProgress, 'check', return_value=reason), \
+                    mock.patch.object(watchdog, 'capture', side_effect=lambda *_: stop.set()) as capture:
+                watchdog.watch(directory, 123, 9000, stop)
+            capture.assert_called_once_with(directory, 123, reason)
+
     def test_traced_capture_requests_stop_without_dumping_or_sampling(self):
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp)

--- a/system_test/test_qwp_ws_watchdog_unit.py
+++ b/system_test/test_qwp_ws_watchdog_unit.py
@@ -81,7 +81,7 @@ class WatchdogTest(unittest.TestCase):
             def record(*args, **kwargs):
                 argv = args[0]
                 self.assertEqual(argv[:3], ['sudo', '-n', 'env'])
-                self.assertEqual(argv[-3:], ['--record', '--limit', '25'])
+                self.assertEqual(argv[-3:], ['--record-raw', '--limit', '25'])
                 (directory / 'kernel-stacks/recorder-validation.json').write_text('{}')
                 events.append('kernel-recorded')
 

--- a/system_test/test_qwp_ws_watchdog_unit.py
+++ b/system_test/test_qwp_ws_watchdog_unit.py
@@ -22,6 +22,55 @@ def wait_for(predicate):
 
 
 class WatchdogTest(unittest.TestCase):
+    def test_kernel_ping_followup_is_opt_in_and_keeps_query_observer(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            for name in ('start-test', 'show-columns-enabled', 'kernel-stacks-enabled',
+                         'kernel-ping-capture-enabled'):
+                (directory / name).touch()
+            stop = threading.Event()
+            opener = mock.Mock()
+            opener.open.side_effect = TimeoutError('injected ping')
+            with mock.patch.object(watchdog.urllib.request, 'build_opener', return_value=opener), \
+                    mock.patch.object(watchdog, 'capture', side_effect=lambda *_: stop.set()) as collect:
+                watchdog.watch(directory, 123, 9000, stop)
+            self.assertIn('kernel resource follow-up: ping:', collect.call_args.args[2])
+
+    def test_kernel_capture_finishes_before_jvm_dump_without_second_sampler(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / 'kernel-stacks-enabled').touch()
+            events = []
+
+            def record(*args, **kwargs):
+                argv = args[0]
+                self.assertEqual(argv[:3], ['sudo', '-n', 'env'])
+                self.assertEqual(argv[-3:], ['--record', '--limit', '25'])
+                (directory / 'kernel-stacks/recorder-validation.json').write_text('{}')
+                events.append('kernel-recorded')
+
+            with mock.patch.object(watchdog.sys, 'platform', 'darwin'), \
+                    mock.patch.object(watchdog.subprocess, 'run', side_effect=record), \
+                    mock.patch.object(watchdog.subprocess, 'Popen') as native, \
+                    mock.patch.object(watchdog.os, 'kill', side_effect=lambda *_: events.append('sigquit')), \
+                    mock.patch.object(watchdog.time, 'sleep'):
+                watchdog.capture(directory, 123, 'slow query')
+            native.assert_not_called()
+            self.assertEqual(events, ['kernel-recorded', 'sigquit', 'sigquit', 'sigquit'])
+            self.assertFalse((directory / 'capture-error').exists())
+
+    def test_kernel_capture_error_does_not_suppress_jvm_dump(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / 'kernel-stacks-enabled').touch()
+            with mock.patch.object(watchdog.sys, 'platform', 'darwin'), \
+                    mock.patch.object(watchdog.subprocess, 'run', side_effect=RuntimeError('denied')), \
+                    mock.patch.object(watchdog.os, 'kill') as send, \
+                    mock.patch.object(watchdog.time, 'sleep'):
+                watchdog.capture(directory, 123, 'slow query')
+            self.assertEqual(send.call_count, 3)
+            self.assertIn('denied', (directory / 'capture-error').read_text())
+
     def test_query_observer_fallback_waits_for_first_data_and_tracks_progress(self):
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp)

--- a/system_test/test_qwp_ws_watchdog_unit.py
+++ b/system_test/test_qwp_ws_watchdog_unit.py
@@ -35,6 +35,42 @@ class WatchdogTest(unittest.TestCase):
                     mock.patch.object(watchdog, 'capture', side_effect=lambda *_: stop.set()) as collect:
                 watchdog.watch(directory, 123, 9000, stop)
             self.assertIn('kernel resource follow-up: ping:', collect.call_args.args[2])
+            self.assertGreaterEqual(opener.open.call_count, 2)
+
+    def test_successful_ping_resets_kernel_failure_streak(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            for name in ('start-test', 'show-columns-enabled', 'kernel-stacks-enabled',
+                         'kernel-ping-capture-enabled'):
+                (directory / name).touch()
+            stop = threading.Event()
+            response = mock.MagicMock()
+            response.__enter__.return_value.status = 204
+            opener = mock.Mock()
+            opener.open.side_effect = [TimeoutError(), response, TimeoutError(), TimeoutError()]
+            with mock.patch.object(watchdog.urllib.request, 'build_opener', return_value=opener), \
+                    mock.patch.object(watchdog, 'capture', side_effect=lambda *_: stop.set()) as collect:
+                watchdog.watch(directory, 123, 9000, stop)
+            collect.assert_called_once()
+            self.assertEqual(opener.open.call_count, 4)
+
+    def test_memory_heartbeat_does_not_write_until_stop(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / 'memory-heartbeat-enabled').touch()
+            stop = mock.Mock()
+            observed = []
+
+            def wait(_):
+                self.assertFalse((directory / 'heartbeat.jsonl').exists())
+                observed.append(1)
+                return len(observed) == 4
+
+            stop.wait.side_effect = wait
+            watchdog.heartbeat(directory, stop, threading.Event())
+            rows = [json.loads(line) for line in (directory / 'heartbeat.jsonl').read_text().splitlines()]
+            self.assertEqual(len(rows), 3)
+            self.assertTrue(all(row['buffered'] and row['previous_write_ms'] == 0 for row in rows))
 
     def test_kernel_capture_finishes_before_jvm_dump_without_second_sampler(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/system_test/test_qwp_ws_watchdog_unit.py
+++ b/system_test/test_qwp_ws_watchdog_unit.py
@@ -76,14 +76,20 @@ class WatchdogTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp)
             (directory / 'kernel-stacks-enabled').touch()
+            (directory / 'kernel-stacks/tmp').mkdir(parents=True)
             events = []
 
             def record(*args, **kwargs):
                 argv = args[0]
                 self.assertEqual(argv[:3], ['sudo', '-n', 'env'])
                 self.assertEqual(argv[-3:], ['--record-raw', '--limit', '25'])
-                (directory / 'kernel-stacks/recorder-validation.json').write_text('{}')
+                self.assertEqual(kwargs['stdout'], watchdog.subprocess.PIPE)
+                self.assertEqual(kwargs['stderr'], watchdog.subprocess.PIPE)
+                for filename in ('capture-started', 'capture.jsonl', 'sample-command.log',
+                                 'kernel-stacks/spindump.raw'):
+                    self.assertFalse((directory / filename).exists())
                 events.append('kernel-recorded')
+                return watchdog.subprocess.CompletedProcess(argv, 0, stdout=b'raw fixture', stderr=b'')
 
             with mock.patch.object(watchdog.sys, 'platform', 'darwin'), \
                     mock.patch.object(watchdog.subprocess, 'run', side_effect=record), \
@@ -94,6 +100,30 @@ class WatchdogTest(unittest.TestCase):
             native.assert_not_called()
             self.assertEqual(events, ['kernel-recorded', 'sigquit', 'sigquit', 'sigquit'])
             self.assertFalse((directory / 'capture-error').exists())
+            self.assertEqual((directory / 'kernel-stacks/spindump.raw').read_bytes(), b'raw fixture')
+
+    def test_buffered_ping_loop_starts_capture_without_publishing_files(self):
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            for name in ('start-test', 'show-columns-enabled', 'kernel-stacks-enabled',
+                         'kernel-ping-capture-enabled', 'memory-heartbeat-enabled'):
+                (directory / name).touch()
+            stop = threading.Event()
+            opener = mock.Mock()
+            def ping(*args, **kwargs):
+                self.assertFalse((directory / 'watchdog.jsonl').exists())
+                raise TimeoutError('injected')
+            def collect(*args):
+                self.assertFalse((directory / 'capture-started').exists())
+                self.assertTrue((directory / 'kernel-stacks/tmp').is_dir())
+                stop.set()
+            opener.open.side_effect = ping
+            with mock.patch.object(watchdog.urllib.request, 'build_opener', return_value=opener), \
+                    mock.patch.object(watchdog, 'capture', side_effect=collect) as capture:
+                watchdog.watch(directory, 123, 9000, stop)
+            capture.assert_called_once()
+            self.assertEqual(opener.open.call_count, 2)
+            self.assertTrue((directory / 'watchdog.jsonl').is_file())
 
     def test_kernel_capture_error_does_not_suppress_jvm_dump(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/system_test/test_qwp_ws_watchdog_unit.py
+++ b/system_test/test_qwp_ws_watchdog_unit.py
@@ -1,0 +1,150 @@
+"""Exercise onset capture without a Mac, JVM, or CI allocation."""
+
+import io
+import json
+from pathlib import Path
+import signal
+import tempfile
+import threading
+import time
+import unittest
+from unittest import mock
+
+import qwp_ws_watchdog as watchdog
+
+
+def wait_for(predicate):
+    deadline = time.monotonic() + 5
+    while not predicate():
+        if time.monotonic() > deadline:
+            raise AssertionError('watchdog did not reach expected state')
+        time.sleep(0.01)
+
+
+class WatchdogTest(unittest.TestCase):
+    def test_event_has_wall_and_monotonic_clocks(self):
+        log = io.StringIO()
+        watchdog.write_event(log, 'example', elapsed_ms=7)
+        event = json.loads(log.getvalue())
+        self.assertEqual(event['event'], 'example')
+        self.assertEqual(event['elapsed_ms'], 7)
+        self.assertGreater(event['wall_ns'], 0)
+        self.assertGreater(event['monotonic_ns'], 0)
+
+    def test_heartbeat_continues_while_http_is_blocked(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / 'start-test').touch()
+            release = threading.Event()
+            stop = threading.Event()
+            opener = mock.Mock()
+
+            def blocked_ping(*_args, **_kwargs):
+                release.wait(5)
+                raise TimeoutError('injected stall')
+
+            opener.open.side_effect = blocked_ping
+            with mock.patch.object(watchdog.urllib.request, 'build_opener', return_value=opener), \
+                    mock.patch.object(watchdog, 'capture') as capture:
+                thread = threading.Thread(target=watchdog.watch,
+                                          args=(directory, 123, 9000, stop))
+                thread.start()
+                try:
+                    heartbeat = directory / 'heartbeat.jsonl'
+                    wait_for(lambda: heartbeat.exists() and
+                             len(heartbeat.read_text().splitlines()) >= 3)
+                    capture.assert_not_called()
+                    release.set()
+                    wait_for(lambda: capture.call_count == 1)
+                    self.assertIn('injected stall', capture.call_args.args[2])
+                finally:
+                    stop.set()
+                    release.set()
+                    thread.join(5)
+                self.assertFalse(thread.is_alive())
+
+    def test_callback_requests_one_capture_even_when_ping_is_healthy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / 'start-test').touch()
+            (directory / 'capture-request').write_text('SHOW COLUMNS timeout')
+            stop = threading.Event()
+            opener = mock.MagicMock()
+            opener.open.return_value.__enter__.return_value.status = 204
+            with mock.patch.object(watchdog.urllib.request, 'build_opener', return_value=opener), \
+                    mock.patch.object(watchdog, 'capture') as capture:
+                thread = threading.Thread(target=watchdog.watch,
+                                          args=(directory, 123, 9000, stop))
+                thread.start()
+                try:
+                    wait_for(lambda: opener.open.call_count >= 2)
+                finally:
+                    stop.set()
+                    thread.join(5)
+                capture.assert_called_once_with(directory, 123, 'SHOW COLUMNS timeout')
+
+    def test_does_not_capture_a_ping_that_finishes_during_teardown(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / 'start-test').touch()
+            opener = mock.Mock()
+
+            def teardown_during_ping(*_args, **_kwargs):
+                (directory / 'workload-finished').touch()
+                raise TimeoutError('cleanup, not onset')
+
+            opener.open.side_effect = teardown_during_ping
+            with mock.patch.object(watchdog.urllib.request, 'build_opener', return_value=opener), \
+                    mock.patch.object(watchdog, 'capture') as capture:
+                watchdog.watch(directory, 123, 9000, threading.Event())
+            capture.assert_not_called()
+
+    def test_native_capture_uses_explicit_output_and_three_dump_requests(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / 'native-sample.txt').write_text('sample stacks')
+            child = mock.Mock()
+            child.wait.return_value = 0
+            child.poll.return_value = 0
+            with mock.patch.object(watchdog.sys, 'platform', 'darwin'), \
+                    mock.patch.object(watchdog.subprocess, 'Popen', return_value=child) as launch, \
+                    mock.patch.object(watchdog.os, 'kill') as send, \
+                    mock.patch.object(watchdog.time, 'sleep'):
+                watchdog.capture(directory, 123, 'timeout')
+            self.assertEqual(launch.call_args.args[0], [
+                '/usr/bin/sample', '123', '3', '10', '-file',
+                str(directory / 'native-sample.txt')])
+            self.assertEqual(send.call_args_list, [mock.call(123, signal.SIGQUIT)] * 3)
+            self.assertTrue((directory / 'capture-complete').exists())
+            self.assertFalse((directory / 'capture-error').exists())
+
+    def test_final_workload_error_is_captured_before_teardown_ack(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            for marker in ('start-test', 'workload-finished'):
+                (directory / marker).touch()
+            (directory / 'capture-request').write_text('producer failed')
+
+            def collect(*_args):
+                self.assertFalse((directory / 'watchdog-stopped').exists())
+
+            with mock.patch.object(watchdog, 'capture', side_effect=collect) as capture:
+                watchdog.watch(directory, 123, 9000, threading.Event())
+            capture.assert_called_once_with(directory, 123, 'producer failed')
+            self.assertTrue((directory / 'watchdog-stopped').exists())
+
+    def test_native_capture_failure_is_explicit_and_releases_teardown(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            with mock.patch.object(watchdog.sys, 'platform', 'darwin'), \
+                    mock.patch.object(watchdog.subprocess, 'Popen', side_effect=OSError('denied')), \
+                    mock.patch.object(watchdog.os, 'kill') as send, \
+                    mock.patch.object(watchdog.time, 'sleep'):
+                watchdog.capture(directory, 123, 'timeout')
+            self.assertEqual(send.call_count, 3)
+            self.assertIn('denied', (directory / 'capture-error').read_text())
+            self.assertTrue((directory / 'capture-complete').exists())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/system_test/test_qwp_ws_watchdog_unit.py
+++ b/system_test/test_qwp_ws_watchdog_unit.py
@@ -230,8 +230,26 @@ class WatchdogTest(unittest.TestCase):
                 '/usr/bin/sample', '123', '3', '10', '-file',
                 str(directory / 'native-sample.txt')])
             self.assertEqual(send.call_args_list, [mock.call(123, signal.SIGQUIT)] * 3)
+            events = [json.loads(line)['event'] for line in (directory / 'capture.jsonl').read_text().splitlines()]
+            self.assertLess(events.index('native_sample_exit'), events.index('sigquit_requested'))
             self.assertTrue((directory / 'capture-complete').exists())
             self.assertFalse((directory / 'capture-error').exists())
+
+    def test_native_sample_timeout_still_requests_jvm_dumps(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            child = mock.Mock()
+            child.wait.side_effect = [watchdog.subprocess.TimeoutExpired('sample', 10), 0]
+            child.poll.side_effect = [None, 0]
+            with mock.patch.object(watchdog.sys, 'platform', 'darwin'), \
+                    mock.patch.object(watchdog.subprocess, 'Popen', return_value=child), \
+                    mock.patch.object(watchdog.os, 'kill') as send, \
+                    mock.patch.object(watchdog.time, 'sleep'):
+                watchdog.capture(directory, 123, 'timeout')
+            child.kill.assert_called_once()
+            self.assertEqual(send.call_count, 3)
+            self.assertTrue((directory / 'capture-error').exists())
+            self.assertTrue((directory / 'capture-complete').exists())
 
     def test_final_workload_error_is_captured_before_teardown_ack(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/system_test/test_qwp_ws_watchdog_unit.py
+++ b/system_test/test_qwp_ws_watchdog_unit.py
@@ -22,6 +22,55 @@ def wait_for(predicate):
 
 
 class WatchdogTest(unittest.TestCase):
+    def test_query_reader_stops_on_first_timeout_and_buffers_events(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / 'show-columns.tsv').write_text('1\t2\t3\t4\tnetwork\tWEATHER2\tcursor-enter\t0\n')
+            opener = mock.Mock()
+
+            def fail(*args, **kwargs):
+                self.assertFalse((directory / 'query-reader.jsonl').exists())
+                self.assertIn('SHOW+COLUMNS+FROM+WEATHER2', args[0])
+                self.assertEqual(kwargs['timeout'], 5)
+                raise TimeoutError('injected')
+
+            opener.open.side_effect = fail
+            with mock.patch.object(watchdog.urllib.request, 'build_opener', return_value=opener):
+                watchdog.query_reader(directory, 9000, threading.Event())
+            self.assertEqual(opener.open.call_count, 1)
+            rows = [json.loads(line) for line in (directory / 'query-reader.jsonl').read_text().splitlines()]
+            self.assertEqual([row['event'] for row in rows], ['ready', 'query_start', 'query_error', 'stopped'])
+
+    def test_query_reader_request_budget_and_no_teardown_queries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / 'show-columns.tsv').write_text('1\t2\t3\t4\tnetwork\tweather0\tcursor-enter\t0\n')
+            opener = mock.Mock()
+            response = mock.MagicMock()
+            response.__enter__.return_value.status = 200
+            response.__enter__.return_value.read.return_value = b'{"dataset": []}'
+            opener.open.return_value = response
+            stop = mock.Mock()
+            stop.is_set.return_value = False
+            stop.wait.return_value = False
+            with mock.patch.object(watchdog.urllib.request, 'build_opener', return_value=opener):
+                watchdog.query_reader(directory, 9000, stop, max_requests=2)
+                self.assertEqual(opener.open.call_count, 2)
+                self.assertEqual(stop.wait.call_args_list, [mock.call(.2), mock.call(.2)])
+                (directory / 'workload-finished').touch()
+                watchdog.query_reader(directory, 9000, stop)
+                self.assertEqual(opener.open.call_count, 2)
+
+    def test_query_reader_waits_for_real_cursor_not_observer_heartbeat(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / 'show-columns.tsv').write_text('1\t2\t0\t0\tobserver\t\theartbeat dropped=0\t0\n')
+            stop = threading.Event()
+            with mock.patch.object(watchdog.urllib.request, 'build_opener') as opener, \
+                    mock.patch.object(stop, 'wait', side_effect=lambda _: stop.set()):
+                watchdog.query_reader(directory, 9000, stop)
+            opener.return_value.open.assert_not_called()
+
     def test_kernel_ping_followup_is_opt_in_and_keeps_query_observer(self):
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp)

--- a/system_test/test_qwp_ws_watchdog_unit.py
+++ b/system_test/test_qwp_ws_watchdog_unit.py
@@ -22,6 +22,66 @@ def wait_for(predicate):
 
 
 class WatchdogTest(unittest.TestCase):
+    def test_traced_capture_requests_stop_without_dumping_or_sampling(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / 'system-trace-enabled').touch()
+            (directory / 'system-trace-stop-sent.json').write_text('{}')
+            with mock.patch.object(watchdog.os, 'kill') as send, \
+                    mock.patch.object(watchdog.subprocess, 'Popen') as launch:
+                watchdog.capture(directory, 123, 'ping timeout')
+            send.assert_not_called()
+            launch.assert_not_called()
+            request = json.loads((directory / 'system-trace-stop-request.json').read_text())
+            self.assertEqual(request['reason'], 'ping timeout')
+            self.assertTrue((directory / 'capture-complete').exists())
+            self.assertFalse((directory / 'capture-error').exists())
+
+    def test_trace_failure_releases_teardown_with_explicit_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / 'system-trace-enabled').touch()
+            (directory / 'system-trace-error.json').write_text('{}')
+            with mock.patch.object(watchdog.os, 'kill') as send:
+                watchdog.capture(directory, 123, 'ping timeout')
+            send.assert_not_called()
+            self.assertTrue((directory / 'capture-complete').exists())
+            self.assertIn('did not acknowledge', (directory / 'capture-error').read_text())
+
+    def test_normal_completion_requests_trace_stop_before_teardown_ack(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            for name in ('start-test', 'workload-finished', 'system-trace-enabled'):
+                (directory / name).touch()
+            (directory / 'system-trace-stop-sent.json').write_text('{}')
+            watchdog.watch(directory, 123, 9000, threading.Event())
+            request = json.loads((directory / 'system-trace-stop-request.json').read_text())
+            self.assertEqual(request['reason'], 'workload-finished')
+            self.assertTrue((directory / 'watchdog-stopped').exists())
+            self.assertFalse((directory / 'capture-error').exists())
+
+    def test_trace_stop_is_requested_before_capture_thread_starts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            for name in ('start-test', 'system-trace-enabled'):
+                (directory / name).touch()
+            stop = threading.Event()
+            opener = mock.Mock()
+            opener.open.side_effect = TimeoutError('injected stall')
+
+            def capture(*_args):
+                self.assertTrue((directory / 'system-trace-stop-request.json').exists())
+                (directory / 'system-trace-stop-sent.json').write_text('{}')
+                stop.set()
+
+            with mock.patch.object(watchdog.urllib.request, 'build_opener', return_value=opener), \
+                    mock.patch.object(watchdog, 'capture', side_effect=capture) as collect:
+                watchdog.watch(directory, 123, 9000, stop)
+            collect.assert_called_once()
+            events = [json.loads(line) for line in (directory / 'watchdog.jsonl').read_text().splitlines()]
+            ping = next(event for event in events if event['event'] == 'ping')
+            self.assertLessEqual(ping['started_wall_ns'], ping['wall_ns'])
+
     def test_event_has_wall_and_monotonic_clocks(self):
         log = io.StringIO()
         watchdog.write_event(log, 'example', elapsed_ms=7)

--- a/system_test/test_qwp_ws_watchdog_unit.py
+++ b/system_test/test_qwp_ws_watchdog_unit.py
@@ -143,6 +143,28 @@ class WatchdogTest(unittest.TestCase):
                     thread.join(5)
                 capture.assert_called_once_with(directory, 123, 'SHOW COLUMNS timeout')
 
+    def test_query_arm_ignores_ping_timeout_then_captures_slow_query(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / 'start-test').touch()
+            (directory / 'show-columns-enabled').touch()
+            stop = threading.Event()
+            opener = mock.Mock()
+            calls = []
+
+            def ping(*args, **kwargs):
+                calls.append(1)
+                if len(calls) == 2:
+                    (directory / 'show-columns-slow').write_text('metadata-read-lock-wait')
+                raise TimeoutError('ping only')
+
+            opener.open.side_effect = ping
+            with mock.patch.object(watchdog.urllib.request, 'build_opener', return_value=opener), \
+                    mock.patch.object(watchdog, 'capture', side_effect=lambda *_: stop.set()) as capture:
+                watchdog.watch(directory, 123, 9000, stop)
+                capture.assert_called_once_with(directory, 123, 'slow SHOW COLUMNS: metadata-read-lock-wait')
+                self.assertEqual(len(calls), 2)
+
     def test_does_not_capture_a_ping_that_finishes_during_teardown(self):
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Diagnostics**
  * Added optional macOS System Trace collection and validation for QWP/WebSocket diagnostic runs.
  * Improved watchdog diagnostics with progress reporting, transient network-error capture, timeout handling, and coordinated teardown.
  * Added per-run telemetry summaries and preserved successful diagnostic artifacts.
  * Added a controlled file-close diagnostic for investigating ingestion stalls.

* **CI Improvements**
  * Added repeated macOS arm64 diagnostic runs with preflight checks and natural memory pressure.
  * Improved diagnostic artifact collection, process tracking, and test gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->