### PR TITLE
docs(ingress): state which UUID half column_uuid takes as hi

### DIFF
--- a/include/questdb/ingress/line_sender.h
+++ b/include/questdb/ingress/line_sender.h
@@ -1114,7 +1114,15 @@ bool line_sender_buffer_column_dec128(
 /**
  * Record a UUID column value. QWP-only.
  *
+ * `hi` is the most significant 64 bits of the UUID and `lo` the least
+ * significant, the same split as Java's `UUID.getMostSignificantBits()` and
+ * `UUID.getLeastSignificantBits()`. Both halves are big-endian reads of the
+ * canonical 16-byte form, so for `123e4567-e89b-12d3-a456-426614174000`,
+ * `hi` is `0x123e4567e89b12d3` and `lo` is `0xa456426614174000`.
+ *
  * The wire encoding writes `lo` (8 bytes LE) followed by `hi` (8 bytes LE).
+ * Do not derive the arguments from that layout: decoding either half
+ * little-endian silently writes a byte-reversed UUID.
  * For canonical RFC-4122 bytes, use `qwp_chunk_column_uuid` instead of
  * splitting the bytes into `lo` and `hi`.
  */

--- a/include/questdb/ingress/line_sender.hpp
+++ b/include/questdb/ingress/line_sender.hpp
@@ -831,6 +831,18 @@ public:
 
     /**
      * Record a UUID column value. QWP-only.
+     *
+     * `hi` is the most significant 64 bits of the UUID and `lo` the least
+     * significant, the same split as Java's
+     * `UUID.getMostSignificantBits()` and
+     * `UUID.getLeastSignificantBits()`. Both halves are big-endian reads of
+     * the canonical 16-byte form, so for
+     * `123e4567-e89b-12d3-a456-426614174000`, `hi` is
+     * `0x123e4567e89b12d3` and `lo` is `0xa456426614174000`.
+     *
+     * The wire encoding writes `lo` (8 bytes LE) followed by `hi` (8 bytes
+     * LE). Do not derive the arguments from that layout: decoding either
+     * half little-endian silently writes a byte-reversed UUID.
      * For canonical RFC-4122 bytes, use `column_chunk::column_uuid` instead of
      * splitting the bytes into `lo` and `hi`.
      */

--- a/questdb-rs-ffi/src/lib.rs
+++ b/questdb-rs-ffi/src/lib.rs
@@ -2016,7 +2016,15 @@ pub unsafe extern "C" fn line_sender_buffer_column_dec128(
 
 /// Record a UUID column value. QWP-only.
 ///
+/// `hi` is the most significant 64 bits of the UUID and `lo` the least
+/// significant, the same split as `java.util.UUID`. Both halves are
+/// big-endian reads of the canonical 16-byte form, so for
+/// `123e4567-e89b-12d3-a456-426614174000`, `hi` is `0x123e4567e89b12d3` and
+/// `lo` is `0xa456426614174000`.
+///
 /// The wire encoding writes `lo` (8 bytes LE) followed by `hi` (8 bytes LE).
+/// Do not derive the arguments from that layout: decoding either half
+/// little-endian silently writes a byte-reversed UUID.
 /// For canonical RFC-4122 bytes, use `qwp_chunk_column_uuid` instead of
 /// splitting the bytes into `lo` and `hi`.
 #[unsafe(no_mangle)]

--- a/questdb-rs/src/ingress/buffer.rs
+++ b/questdb-rs/src/ingress/buffer.rs
@@ -1267,8 +1267,16 @@ impl Buffer {
 
     /// Adds a UUID column to the current row. QWP-only.
     ///
+    /// `hi` is the most significant 64 bits of the UUID and `lo` the least
+    /// significant, the same split as `java.util.UUID` and as the
+    /// `(high, low)` pair returned by `uuid::Uuid::as_u64_pair()`. Both
+    /// halves are big-endian reads of the canonical 16-byte form, so for
+    /// `123e4567-e89b-12d3-a456-426614174000`, `hi` is `0x123e4567e89b12d3`
+    /// and `lo` is `0xa456426614174000`.
+    ///
     /// Per spec, the wire encoding writes `lo` (8 bytes LE) followed by `hi`
-    /// (8 bytes LE).
+    /// (8 bytes LE). Do not derive the arguments from that layout: decoding
+    /// either half little-endian silently writes a byte-reversed UUID.
     /// For canonical RFC-4122 bytes, use `column_sender::Chunk::column_uuid`
     /// instead of splitting the bytes into `lo` and `hi`.
     pub fn column_uuid<'a, N>(&mut self, name: N, lo: u64, hi: u64) -> crate::Result<&mut Self>
@@ -1297,6 +1305,9 @@ impl Buffer {
     }
 
     /// Adds a UUID column if `value` is `Some`. QWP-only.
+    ///
+    /// The tuple is `(lo, hi)`, split as described on
+    /// [`column_uuid`](Self::column_uuid).
     pub fn column_uuid_opt<'a, N>(
         &mut self,
         name: N,


### PR DESCRIPTION
## Summary

`Buffer::column_uuid(name, lo, hi)` documented only the wire layout, "the wire encoding writes `lo` (8 bytes LE) followed by `hi` (8 bytes LE)", and never said which half of the UUID is `hi`. Read as the caller-facing split, that sentence produces a byte-reversed UUID and no error: passing `123e4567-e89b-12d3-a456-426614174000` stores `00401714-6642-56a4-d312-9be867453e12`.

The comments now state the split first: `hi` is the most significant 64 bits and `lo` the least, the same convention as `java.util.UUID` and `Uuid::as_u64_pair()`, with the worked hex values, and a warning not to derive the arguments from the wire layout. `column_uuid_opt` now says its tuple is `(lo, hi)`.

Comment text only, on the four row-API surfaces: `questdb-rs`, `questdb-rs-ffi`, `line_sender.h` and `line_sender.hpp`. No behaviour change.

The chunk and bind surfaces are already covered by #186 and are untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified UUID column parameter ordering and byte representation across client APIs.
  * Added examples and compatibility references for interpreting the most- and least-significant UUID halves.
  * Documented the distinction between canonical UUID bytes and wire encoding to help prevent byte-reversed UUID values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->