### PR TITLE
Compare QWP/UDP column names case insensitively

### DIFF
--- a/questdb-rs/src/ingress/buffer/qwp.rs
+++ b/questdb-rs/src/ingress/buffer/qwp.rs
@@ -1312,7 +1312,7 @@ impl QwpBuffer {
         let name_bytes = name.as_bytes();
         for entry in &self.entries[start..] {
             let entry_name = &self.name_bytes[entry.name.0.as_range()];
-            if entry_name == name_bytes {
+            if names_eq_ignore_case(entry_name, name_bytes) {
                 return Err(error::fmt!(
                     InvalidApiCall,
                     "column '{}' already set for current row",
@@ -5236,6 +5236,26 @@ impl QwpWsColumnValues {
     }
 }
 
+/// Compare two column names the way the server does, case insensitively.
+///
+/// QWP/WebSocket already folds case, through `lowercase_name_bytes`, but QWP/UDP
+/// compared byte for byte, so `Side` and `side` were treated as two columns and a
+/// single row could set the same server column twice, with conflicting values or
+/// even conflicting types (issue #204). Folding is done in place rather than by
+/// building the lowercase key, since these comparisons sit in the per-row scan and
+/// the ASCII case is the common one. The non-ASCII fallback mirrors
+/// `lowercase_name_bytes`: full Unicode lowercasing, dropping back to ASCII folding
+/// when the bytes are not valid UTF-8.
+fn names_eq_ignore_case(a: &[u8], b: &[u8]) -> bool {
+    if a.is_ascii() && b.is_ascii() {
+        return a.eq_ignore_ascii_case(b);
+    }
+    match (std::str::from_utf8(a), std::str::from_utf8(b)) {
+        (Ok(a), Ok(b)) => a.to_lowercase() == b.to_lowercase(),
+        _ => a.eq_ignore_ascii_case(b),
+    }
+}
+
 #[cfg(feature = "_sender-qwp-ws")]
 fn lowercase_name_bytes(name: &[u8], is_ascii: bool) -> Vec<u8> {
     if is_ascii {
@@ -7313,7 +7333,7 @@ impl RowGroupPlanner {
     fn find_column(&self, name: &[u8], name_bytes: &[u8]) -> Option<usize> {
         self.columns
             .iter()
-            .position(|c| &name_bytes[c.name.0.as_range()] == name)
+            .position(|c| names_eq_ignore_case(&name_bytes[c.name.0.as_range()], name))
     }
 }
 

--- a/questdb-rs/src/tests/qwp.rs
+++ b/questdb-rs/src/tests/qwp.rs
@@ -738,6 +738,71 @@ fn qwp_udp_rejects_duplicate_entry_names_within_row() -> TestResult {
 }
 
 #[test]
+fn qwp_udp_rejects_case_variant_duplicate_within_row() -> TestResult {
+    // QuestDB column names are case insensitive, so `Side` and `side` are one
+    // column. QWP/UDP compared them byte for byte and emitted both (issue #204).
+    let mock = QwpUdpMock::new()?;
+    let sender = mock.sender_builder().build()?;
+    let mut buffer = sender.new_buffer();
+
+    buffer.table("trades")?.symbol("Side", "buy")?;
+    assert_err_contains(
+        buffer.symbol("side", "sell"),
+        ErrorCode::InvalidApiCall,
+        "column 'side' already set for current row",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn qwp_udp_rejects_case_variant_type_change_within_row() -> TestResult {
+    // The same clash with two different types, which is the worse shape: the row
+    // would otherwise carry one server column as both a LONG and a SYMBOL.
+    let mock = QwpUdpMock::new()?;
+    let sender = mock.sender_builder().build()?;
+    let mut buffer = sender.new_buffer();
+
+    buffer.table("trades")?.column_i64("Qty", 1)?;
+    assert_err_contains(
+        buffer.symbol("qty", "x"),
+        ErrorCode::InvalidApiCall,
+        "column 'qty' already set for current row",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn qwp_udp_treats_case_variants_as_one_column_across_rows() -> TestResult {
+    // Cross-row identity is resolved by RowGroupPlanner::find_column, which was also
+    // byte exact, so two rows spelling one column differently planned two columns and
+    // the datagram carried the same server column twice.
+    let mock = QwpUdpMock::new()?;
+    let mut sender = mock.sender_builder().build()?;
+    let mut buffer = sender.new_buffer();
+
+    buffer.table("trades")?.symbol("Side", "buy")?.at_now()?;
+    buffer.table("trades")?.symbol("side", "sell")?.at_now()?;
+    // A genuinely different name must still plan as its own column.
+    buffer.table("trades")?.symbol("venue", "XNAS")?.at_now()?;
+
+    sender.flush(&mut buffer)?;
+    let decoded = decode_datagram(&mock.recv_datagram()?).expect("datagram should decode");
+    assert_eq!(
+        decoded
+            .table
+            .columns
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Side", "venue"]
+    );
+
+    Ok(())
+}
+
+#[test]
 fn qwp_udp_rejects_ilp_buffer_with_qwp_sender() -> TestResult {
     let mock = QwpUdpMock::new()?;
     let mut sender = mock.sender_builder().build()?;


### PR DESCRIPTION
Closes #204.

Both byte-exact comparisons named in the report now fold case: `QwpBuffer::mark_pending_entry_name` for the within-row duplicate check, and `RowGroupPlanner::find_column` for cross-row column identity.

They share a new `names_eq_ignore_case` rather than reusing `lowercase_name_bytes`, for two reasons. That helper is behind `#[cfg(feature = "_sender-qwp-ws")]`, so it is not compiled in a UDP-only build, and it allocates a lowercase `Vec` per call, which these two sites do inside the per-row and per-column scans. The new one compares in place, taking `eq_ignore_ascii_case` on the common path and falling back to full Unicode lowercasing only when a name is not ASCII, matching what `lowercase_name_bytes` does including its non-UTF-8 fallback.

Three tests. Two case variants in one row are rejected, the same with two different types is rejected, and across rows they plan as one column. The third is the one that shows the wire effect, and on the current code it fails with

    left: ["Side", "side", "venue"]
    right: ["Side", "venue"]

so the datagram really did carry the same server column twice. `venue` is in there so the change cannot pass by collapsing every column into one. The two within-row cases fail on current code as well, by returning `Ok` where an error is expected.

`cargo test` with `sync-sender,sync-sender-qwp-udp,sync-reader,tls-webpki-certs,ring-crypto` is 1804 passed, 23 ignored, and `cargo fmt --check` and `cargo clippy` are clean. Worth noting for anyone reproducing: `--all-features` does not build, since it turns on both `aws-lc-crypto` and `ring-crypto` and the build script rejects that.

This is on `main`, so it does not depend on #203. As the issue says, #203 opens one more route into the same defect rather than causing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - QWP/UDP ingestion now treats column names case-insensitively, including ASCII and Unicode variants.
  - Prevents duplicate columns and conflicting type assignments when name capitalization differs.
  - Consistently combines case variants of the same column across rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->